### PR TITLE
Update _base.scss

### DIFF
--- a/www/css/_base.scss
+++ b/www/css/_base.scss
@@ -268,7 +268,7 @@ img.company-logo {
   position: fixed;
   top: 0;
   z-index: 100;
-  width: 100vw;
+  width: 100%;
 
   @media (min-width: $breakpoint-m) {
     position: sticky;


### PR DESCRIPTION
Tweak main nav css styles to fix horizontal scrolling (wiggle) issue.

## Changes

The main nav in the docs was overflowing horizontally (slightly) and causing horizontal scroll bars to appear. This minor change from a width of 100vw to 100% resolves that issue.

![before](https://user-images.githubusercontent.com/514273/96323409-d3260d80-0fd1-11eb-9b92-869af81ab886.png)
![after](https://user-images.githubusercontent.com/514273/96323404-d02b1d00-0fd1-11eb-8bd1-715f161cf0a3.png)

## Testing

Tested manually by viewing the docs at a medium+ viewport and noting whether horizontal scroll bars were shown.

## Docs
bug fix (styles) only