### PR TITLE
Add input option to plugin-svelte

### DIFF
--- a/plugins/plugin-svelte/README.md
+++ b/plugins/plugin-svelte/README.md
@@ -22,6 +22,7 @@ By default, this plugin will look for a `svelte.config.js` file in your project 
 | Name              |                                  Type                                  | Description                                                                                                         |
 | :---------------- | :--------------------------------------------------------------------: | :------------------------------------------------------------------------------------------------------------------ |
 | `configFilePath`  |                                `string`                                | Relative path to a Svelte config file. Defaults to load `svelte.config.js` from the current project root directory. |
+| `input`            | `string[]` | Array of file extensions to process. Defaults to `['.svelte']`. |
 | `preprocess`      | [svelte.preprocess options](https://svelte.dev/docs#svelte_preprocess) | Configure the Svelte pre-processor. If this option is given, the config file `preprocess` option will be ignored.   |
 | `compilerOptions` |    [svelte.compile options](https://svelte.dev/docs#svelte_compile)    | Configure the Svelte compiler.If this option is given, the config file `preprocess` option will be ignored.         |
 | `hmrOptions`      |        [svelte-hmr options](https://github.com/rixo/svelte-hmr)        | Configure HMR & "fast refresh" behavior for Svelte.                                                                 |

--- a/plugins/plugin-svelte/plugin.js
+++ b/plugins/plugin-svelte/plugin.js
@@ -38,10 +38,19 @@ module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
       `[plugin-svelte] Could not recognize "compileOptions". Did you mean "compilerOptions"?`,
     );
   }
+  if (pluginOptions.input && !Array.isArray(pluginOptions.input)) {
+    throw new Error(
+      `[plugin-svelte] Option "input" must be an array (e.g. ['.svelte', '.svx'])`,
+    );
+  }
+  if (pluginOptions.input && pluginOptions.input.length === 0) {
+    throw new Error(`[plugin-svelte] Option "input" must specify at least one filetype`);
+  }
 
   let configFilePath = path.resolve(cwd, pluginOptions.configFilePath || 'svelte.config.js');
   let compilerOptions = pluginOptions.compilerOptions;
   let preprocessOptions = pluginOptions.preprocess;
+  let resolveInputOption = pluginOptions.input || ['.svelte'];
   const hmrOptions = pluginOptions.hmrOptions;
 
   if (fs.existsSync(configFilePath)) {
@@ -58,7 +67,7 @@ module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
   return {
     name: '@snowpack/plugin-svelte',
     resolve: {
-      input: ['.svelte'],
+      input: resolveInputOption,
       output: ['.js', '.css'],
     },
     knownEntrypoints: [

--- a/plugins/plugin-svelte/test/plugin.test.js
+++ b/plugins/plugin-svelte/test/plugin.test.js
@@ -47,6 +47,23 @@ describe('@snowpack/plugin-svelte (mocked)', () => {
     ).toThrow(badOptionCheck);
   });
 
+  it('logs error if resolve input is invalid', async () => {
+    expect(() => {
+      plugin(mockConfig, {
+        input: '.svelte'
+      });
+    }).toThrow(
+      `[plugin-svelte] Option "input" must be an array (e.g. ['.svelte', '.svx'])`
+    );
+    expect(() => {
+      plugin(mockConfig, {
+        input: []
+      });
+    }).toThrow(
+      `[plugin-svelte] Option "input" must specify at least one filetype`
+    );
+  });
+
   it('passes compilerOptions to compiler', async () => {
     const compilerOptions = {
       __test: 'compilerOptions',
@@ -92,5 +109,27 @@ describe('@snowpack/plugin-svelte (mocked)', () => {
       outputFilename: mockComponent,
     });
     expect(mockPreprocessor.mock.calls[0][1]).toEqual({__test: 'custom-config.js::preprocess'});
+  });
+
+  it('resolves custom file extensions', async () => {
+    expect(
+      plugin(mockConfig, {
+          input: ['.svelte','.svx'],
+      }).resolve.input,
+    ).toMatchInlineSnapshot(`
+      Array [
+        ".svelte",
+        ".svx",
+      ]
+    `);
+    expect(
+      plugin(mockConfig, {
+          input: ['.svx'],
+      }).resolve.input,
+    ).toMatchInlineSnapshot(`
+      Array [
+        ".svx",
+      ]
+    `);
   });
 });


### PR DESCRIPTION
## Changes

Adds an `input` option to plugin-svelte that modifies `resolve.input`. Enables non-standard file extensions such as `.svx` to be used
## Testing

Roughly copied the related tests from plugin-babel. Had issues getting test to run properly locally, so opening the PR a bit early to see the results.

## Docs

Roughly copied related docs from plugin-babel.
