### PR TITLE
docs: native asset module reference style

### DIFF
--- a/docs/04-features.md
+++ b/docs/04-features.md
@@ -73,12 +73,27 @@ Snowpack supports CSS Modules using the `[name].module.css` naming convention. C
 ### Import Images & Other Assets
 
 ```jsx
+const img = new URL('./image.png', import.meta.url); // img === '/src/image.png'
+const svg = new URL('./image.svg', import.meta.url); // svg === '/src/image.svg'
+
+/**
+* This example uses JSX, but you can create url objects with any framework 
+* and provide these as your asset reference to your img tag
+*/
+<img src={img.href} />
+```
+
+Snowpack supports the usage of URL class for asset references which doesn't overload the import keyword. This is the recommended way since it is the native asset module reference style.
+
+```jsx
 import img from './image.png'; // img === '/src/image.png'
 import svg from './image.svg'; // svg === '/src/image.svg'
 
 // This example uses JSX, but you can use these references with any framework.
 <img src={img} />;
 ```
+
+Alternatively, you can import images and reference your assets in the more traditional way. 
 
 All other assets not explicitly mentioned above can be imported and will return a URL reference to the final built asset. This can be useful for referencing non-JS assets by URL, like creating an image element with a `src` attribute pointing to that image.
 


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
Adds documentation for the native way of referencing asset modules which snowpack supports

<!-- Before/after screenshots may be helpful.  -->
Docs preview:
![2020-10-19 02_58_25-Snowpack - The faster frontend build tool and 2 more pages - Personal - Microsof](https://user-images.githubusercontent.com/32328857/96386259-11c8ed00-11b7-11eb-946a-f26afdacf5f6.png)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->
No tests are added because these are only documentation changes

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
Yes
