### PR TITLE
move one more warning behind verbose flag (this keyword is equivalent…

### DIFF
--- a/docs/10-reference.md
+++ b/docs/10-reference.md
@@ -155,7 +155,7 @@ Options:
   - Snowpack uses Rollup internally to install your packages. This `rollup` config option gives you deeper control over the internal rollup configuration that we use.
   - **`installOptions.rollup.plugins`** - Specify [Custom Rollup plugins](#installing-non-js-packages) if you are dealing with non-standard files.
   - **`installOptions.rollup.dedupe`** - If needed, deduplicate multiple versions/copies of a packages to a single one. This helps prevent issues with some packages when multiple versions are installed from your node_modules tree. See [rollup-plugin-node-resolve](https://github.com/rollup/plugins/tree/master/packages/node-resolve#usage) for more documentation.
-  - **`installOptions.rollup.context`** - Specify top-level `this` value. Useful to silence install errors caused by legacy common.js packages that reference a top-level this variable, which does not exist in a pure ESM environment.
+  - **`installOptions.rollup.context`** - Specify top-level `this` value. Useful to silence install errors caused by legacy common.js packages that reference a top-level this variable, which does not exist in a pure ESM environment. Note that the `'THIS_IS_UNDEFINED'` warning (`The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten`) is silenced by default, unless `--verbose` is used.
 
 #### `config.devOptions`
 

--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -411,8 +411,10 @@ ${colors.dim(
       }
       const {loc, message} = warning;
       const logMessage = loc ? `${loc.file}:${loc.line}:${loc.column} ${message}` : message;
-      // These two warnings are usually harmless in packages, so don't show them by default.
-      if (warning.code === 'CIRCULAR_DEPENDENCY' || warning.code === 'NAMESPACE_CONFLICT') {
+      // These warnings are usually harmless in packages, so don't show them by default.
+      if (warning.code === 'CIRCULAR_DEPENDENCY' ||
+          warning.code === 'NAMESPACE_CONFLICT' ||
+          warning.code === 'THIS_IS_UNDEFINED') {
         logger.debug(logMessage);
       } else {
         logger.warn(logMessage);


### PR DESCRIPTION
## Changes

Per discussion in #718 with @FredKSchott, this change silences the rollup `The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten` warning, and move it behind the `--verbose` flag.

## Testing

I ran this local fork against my repo before and after the change, and noticed the warning being silenced.
I also ran `yarn test` and `yarn test:dev`

## Docs

The `10-reference.md` file now mentions that this warning is silenced by default.
