### PR TITLE
Update repository URL

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,11 +5,11 @@
 ---- Issues are handled a little bit differently than you might be used to.
 ----
 ---- ❗️ Don't start by creating a new issue. Instead, create a discussion:
-----   🔎 Search Existing:   https://github.com/pikapkg/snowpack/discussions
-----   📝 Create New:        https://github.com/pikapkg/snowpack/discussions/category_choices
+----   🔎 Search Existing:   https://github.com/snowpackjs/snowpack/discussions
+----   📝 Create New:        https://github.com/snowpackjs/snowpack/discussions/category_choices
 ----
 ---- More information on how our team manages issues & discussions:
-----   https://github.com/pikapkg/snowpack/discussions/613#discussioncomment-41103
+----   https://github.com/snowpackjs/snowpack/discussions/613#discussioncomment-41103
 --->
 
 **Original Discussion:** <!-- URL to discussion -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,11 @@
 
 Interested in contributing? We'd love your help!
 
-If you run into problems or find something confusing, please share it with us in [this discussion](https://github.com/pikapkg/snowpack/discussions/958). A great experience for new contributors is very important to us!
+If you run into problems or find something confusing, please share it with us in [this discussion](https://github.com/snowpackjs/snowpack/discussions/958). A great experience for new contributors is very important to us!
 
-Please note that all activity on the [`pikapkg/snowpack` repository](https://github.com/pikapkg/snowpack) and our [Discord](https://discord.gg/rS8SnRk) is moderated and will be strictly enforced under Snowpack's [Contributor Code of Conduct](CODE_OF_CONDUCT.md).
+Please note that all activity on the [`snowpackjs/snowpack` repository](https://github.com/snowpackjs/snowpack) and our [Discord](https://discord.gg/rS8SnRk) is moderated and will be strictly enforced under Snowpack's [Contributor Code of Conduct](CODE_OF_CONDUCT.md).
 
-Our [issue tracker](https://github.com/pikapkg/snowpack/issues) is always organized with a selection of high-priority bugs, feature requests, and ["help wanted!"](https://github.com/pikapkg/snowpack/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)/["good first issue"](https://github.com/pikapkg/snowpack/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) items. For general package troubleshooting and discussions, check out our [Package Community](https://www.pika.dev/npm/snowpack/discuss) discussion board.
+Our [issue tracker](https://github.com/snowpackjs/snowpack/issues) is always organized with a selection of high-priority bugs, feature requests, and ["help wanted!"](https://github.com/snowpackjs/snowpack/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)/["good first issue"](https://github.com/snowpackjs/snowpack/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) items. For general package troubleshooting and discussions, check out our [Package Community](https://www.pika.dev/npm/snowpack/discuss) discussion board.
 
 ## Requirements
 
@@ -15,7 +15,7 @@ Snowpack uses [yarn workspaces](https://classic.yarnpkg.com/) to manage multiple
 ## Initial setup
 
 ```bash
-git clone https://github.com/pikapkg/snowpack.git
+git clone https://github.com/snowpackjs/snowpack.git
 cd snowpack
 yarn
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-<a href="https://github.com/pikapkg/snowpack/actions" align="right">
-  <img src="https://github.com/pikapkg/snowpack/workflows/CI/badge.svg?event=push" alt="CI" />
+<a href="https://github.com/snowpackjs/snowpack/actions" align="right">
+  <img src="https://github.com/snowpackjs/snowpack/workflows/CI/badge.svg?event=push" alt="CI" />
 </a>    
   
 <h1>Snowpack</h1>

--- a/create-snowpack-app/app-scripts-lit-element/package.json
+++ b/create-snowpack-app/app-scripts-lit-element/package.json
@@ -6,10 +6,10 @@
     "access": "public"
   },
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-scripts-lit-element#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-scripts-lit-element#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "create-snowpack-app/app-scripts-lit-element"
   },
   "dependencies": {

--- a/create-snowpack-app/app-scripts-preact/package.json
+++ b/create-snowpack-app/app-scripts-preact/package.json
@@ -6,10 +6,10 @@
     "access": "public"
   },
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-scripts-preact#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-scripts-preact#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "create-snowpack-app/app-scripts-preact"
   },
   "dependencies": {

--- a/create-snowpack-app/app-scripts-react/package.json
+++ b/create-snowpack-app/app-scripts-react/package.json
@@ -6,10 +6,10 @@
     "access": "public"
   },
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-scripts-react#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-scripts-react#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "create-snowpack-app/app-scripts-react"
   },
   "dependencies": {

--- a/create-snowpack-app/app-scripts-svelte/package.json
+++ b/create-snowpack-app/app-scripts-svelte/package.json
@@ -6,10 +6,10 @@
     "access": "public"
   },
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-scripts-svelte#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-scripts-svelte#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "create-snowpack-app/app-scripts-svelte"
   },
   "peerDependencies": {

--- a/create-snowpack-app/app-scripts-vue/package.json
+++ b/create-snowpack-app/app-scripts-vue/package.json
@@ -3,10 +3,10 @@
   "version": "1.8.8",
   "main": "snowpack.config.js",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-scripts-vue#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-scripts-vue#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "create-snowpack-app/app-scripts-vue"
   },
   "publishConfig": {

--- a/create-snowpack-app/app-template-11ty/README.md
+++ b/create-snowpack-app/app-template-11ty/README.md
@@ -17,7 +17,7 @@ You will also see any lint errors in the console.
 Builds a static copy of your site to the `build/` folder.
 Your app is ready to be deployed!
 
-**For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.
+**For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.
 
 ### Q: What about Eject?
 

--- a/create-snowpack-app/app-template-11ty/package.json
+++ b/create-snowpack-app/app-template-11ty/package.json
@@ -3,10 +3,10 @@
   "description": "A preconfigured template for Snowpack with Eleventy",
   "version": "1.9.3",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-11ty#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-11ty#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "create-snowpack-app/app-template-11ty"
   },
   "keywords": [

--- a/create-snowpack-app/app-template-blank-typescript/README.md
+++ b/create-snowpack-app/app-template-blank-typescript/README.md
@@ -17,7 +17,7 @@ You will also see any lint errors in the console.
 Builds a static copy of your site to the `build/` folder.
 Your app is ready to be deployed!
 
-**For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.
+**For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.
 
 ### Q: What about Eject?
 

--- a/create-snowpack-app/app-template-blank-typescript/package.json
+++ b/create-snowpack-app/app-template-blank-typescript/package.json
@@ -3,10 +3,10 @@
   "description": "A preconfigured template for Snowpack with Typescript",
   "version": "1.9.7",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-blank-typescript#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-blank-typescript#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "create-snowpack-app/app-template-blank-typescript"
   },
   "keywords": [

--- a/create-snowpack-app/app-template-blank/README.md
+++ b/create-snowpack-app/app-template-blank/README.md
@@ -17,7 +17,7 @@ You will also see any lint errors in the console.
 Builds a static copy of your site to the `build/` folder.
 Your app is ready to be deployed!
 
-**For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.
+**For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.
 
 ### Q: What about Eject?
 

--- a/create-snowpack-app/app-template-blank/package.json
+++ b/create-snowpack-app/app-template-blank/package.json
@@ -3,10 +3,10 @@
   "description": "A preconfigured template for Snowpack with Prettier",
   "version": "1.6.19",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-blank#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-blank#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "create-snowpack-app/app-template-blank"
   },
   "keywords": [

--- a/create-snowpack-app/app-template-lit-element-typescript/package.json
+++ b/create-snowpack-app/app-template-lit-element-typescript/package.json
@@ -3,10 +3,10 @@
   "description": "A preconfigured template for Snowpack with TypeScript and LitElement",
   "version": "1.10.6",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-lit-element-typescript#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-lit-element-typescript#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "create-snowpack-app/app-template-lit-element-typescript"
   },
   "keywords": [

--- a/create-snowpack-app/app-template-lit-element/package.json
+++ b/create-snowpack-app/app-template-lit-element/package.json
@@ -3,10 +3,10 @@
   "description": "A preconfigured template for Snowpack with LitElement",
   "version": "1.9.6",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-lit-element#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-lit-element#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "create-snowpack-app/app-template-lit-element"
   },
   "keywords": [

--- a/create-snowpack-app/app-template-preact-typescript/package.json
+++ b/create-snowpack-app/app-template-preact-typescript/package.json
@@ -3,10 +3,10 @@
   "description": "A preconfigured template for Snowpack with Preact and Typescript",
   "version": "1.1.3",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-preact-typescript#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-preact-typescript#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "create-snowpack-app/app-template-preact-typescript"
   },
   "keywords": [

--- a/create-snowpack-app/app-template-preact/package.json
+++ b/create-snowpack-app/app-template-preact/package.json
@@ -3,10 +3,10 @@
   "description": "A preconfigured template for Snowpack with Preact",
   "version": "1.11.3",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-preact#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-preact#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "create-snowpack-app/app-template-preact"
   },
   "keywords": [

--- a/create-snowpack-app/app-template-react-typescript/package.json
+++ b/create-snowpack-app/app-template-react-typescript/package.json
@@ -3,10 +3,10 @@
   "description": "A preconfigured template for Snowpack with React and TypeScript",
   "version": "1.14.2",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-react-typescript#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-react-typescript#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "create-snowpack-app/app-template-react-typescript"
   },
   "keywords": [

--- a/create-snowpack-app/app-template-react/package.json
+++ b/create-snowpack-app/app-template-react/package.json
@@ -3,10 +3,10 @@
   "description": "A preconfigured template for Snowpack with React",
   "version": "1.12.2",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-react#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-react#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "create-snowpack-app/app-template-react"
   },
   "keywords": [

--- a/create-snowpack-app/app-template-svelte-typescript/README.md
+++ b/create-snowpack-app/app-template-svelte-typescript/README.md
@@ -22,7 +22,7 @@ See the section about running tests for more information.
 Builds a static copy of your site to the `build/` folder.
 Your app is ready to be deployed!
 
-**For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.
+**For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.
 
 ### Q: What about Eject?
 

--- a/create-snowpack-app/app-template-svelte-typescript/package.json
+++ b/create-snowpack-app/app-template-svelte-typescript/package.json
@@ -3,10 +3,10 @@
   "description": "A preconfigured template for Snowpack with Svelte and TypeScript",
   "version": "1.11.3",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-svelte-typescript#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-svelte-typescript#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "create-snowpack-app/app-template-svelte-typescript"
   },
   "keywords": [

--- a/create-snowpack-app/app-template-svelte/README.md
+++ b/create-snowpack-app/app-template-svelte/README.md
@@ -22,7 +22,7 @@ See the section about running tests for more information.
 Builds a static copy of your site to the `build/` folder.
 Your app is ready to be deployed!
 
-**For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.
+**For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.
 
 ### Q: What about Eject?
 

--- a/create-snowpack-app/app-template-svelte/package.json
+++ b/create-snowpack-app/app-template-svelte/package.json
@@ -3,10 +3,10 @@
   "description": "A preconfigured template for Snowpack with Svelte",
   "version": "1.10.3",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-svelte#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-svelte#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "create-snowpack-app/app-template-svelte"
   },
   "keywords": [

--- a/create-snowpack-app/app-template-vue-typescript/package.json
+++ b/create-snowpack-app/app-template-vue-typescript/package.json
@@ -3,10 +3,10 @@
   "description": "A preconfigured template for Snowpack with Vue and TypeScript",
   "version": "1.10.6",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-vue-typescript#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-vue-typescript#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "create-snowpack-app/app-template-vue-typescript"
   },
   "keywords": [

--- a/create-snowpack-app/app-template-vue/package.json
+++ b/create-snowpack-app/app-template-vue/package.json
@@ -3,10 +3,10 @@
   "description": "A preconfigured template for Snowpack with Vue",
   "version": "1.10.6",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-vue#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-vue#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "create-snowpack-app/app-template-vue"
   },
   "keywords": [

--- a/create-snowpack-app/cli/README.md
+++ b/create-snowpack-app/cli/README.md
@@ -29,6 +29,6 @@ npx create-snowpack-app new-dir --template @snowpack/app-template-NAME [--use-ya
 - [svelte-tailwind](https://github.com/agneym/svelte-tailwind-snowpack) (Adds PostCSS and TailwindCSS using [svelte-preprocess](https://github.com/sveltejs/svelte-preprocess))
 - [snowpack-react-tailwind](https://github.com/mrkldshv/snowpack-react-tailwind) (React + Snowpack + Tailwindcss)
 - [hyperapp-snowpack](https://github.com/bmartel/hyperapp-snowpack) (Hyperapp + Snowpack + TailwindCSS)
-- [snowpack-vue-capacitor-2-demo](https://github.com/brodybits/snowpack-vue-capacitor-2-demo) Demo of Snowpack with Vue and [Capacitor mobile app framework](https://capacitorjs.com/) version 2, originally generated from `@snowpack/vue-template` template, see [discussion #905](https://github.com/pikapkg/snowpack/discussions/905)
+- [snowpack-vue-capacitor-2-demo](https://github.com/brodybits/snowpack-vue-capacitor-2-demo) Demo of Snowpack with Vue and [Capacitor mobile app framework](https://capacitorjs.com/) version 2, originally generated from `@snowpack/vue-template` template, see [discussion #905](https://github.com/snowpackjs/snowpack/discussions/905)
 - [snowpack-react-ssr](https://github.com/matthoffner/snowpack-react-ssr) (React + Server Side Rendering)
 - PRs that add a link to this list are welcome!

--- a/create-snowpack-app/cli/createSnowpackApp.js
+++ b/create-snowpack-app/cli/createSnowpackApp.js
@@ -6,7 +6,7 @@ const {copy, removeSync} = require('fs-extra');
 const colors = require('kleur');
 
 const errorAlert = `${colors.red('[ERROR]')}`;
-const errorLink = `${colors.dim(colors.underline('https://github.com/pikapkg/snowpack'))}`;
+const errorLink = `${colors.dim(colors.underline('https://github.com/snowpackjs/snowpack'))}`;
 
 function logError(msg) {
   console.error(`${errorAlert} ${msg} ${errorLink}`);

--- a/create-snowpack-app/cli/package.json
+++ b/create-snowpack-app/cli/package.json
@@ -2,10 +2,10 @@
   "name": "create-snowpack-app",
   "version": "1.8.3",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/cli#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/cli#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "create-snowpack-app/cli"
   },
   "publishConfig": {

--- a/docs/01-introduction.md
+++ b/docs/01-introduction.md
@@ -24,7 +24,7 @@ Snowpack leverages JavaScript's native module system (<a href="https://developer
     {% endif %}
   </a>
 {% endfor %}
-<a href="https://github.com/pikapkg/snowpack/edit/master/docs/docs/00.md" target="_blank" title="Add Your Project/Company!" class="add-company-button" >
+<a href="https://github.com/snowpackjs/snowpack/edit/master/docs/docs/00.md" target="_blank" title="Add Your Project/Company!" class="add-company-button" >
   <svg style="height: 22px; margin-right: 8px;" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="plus" class="company-logo" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"></path></svg>
   Add your logo
 </a>

--- a/docs/02-quickstart.md
+++ b/docs/02-quickstart.md
@@ -33,7 +33,7 @@ snowpack --help
 
 ### Create Snowpack App (CSA)
 
-The easiest way to get started with Snowpack is via [Create Snowpack App (CSA)](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app). CSA automatically initializes a starter application for you with a pre-configured, Snowpack-powered dev environment.
+The easiest way to get started with Snowpack is via [Create Snowpack App (CSA)](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app). CSA automatically initializes a starter application for you with a pre-configured, Snowpack-powered dev environment.
 
 If you've ever used Create React App, this is a lot like that!
 
@@ -43,19 +43,19 @@ npx create-snowpack-app new-dir --template [SELECT FROM BELOW] [--use-yarn]
 
 ### Official App Templates
 
-- [@snowpack/app-template-blank](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-blank)
-- [@snowpack/app-template-blank-typescript](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-blank-typescript)
-- [@snowpack/app-template-minimal](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-minimal)
-- [@snowpack/app-template-react](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-react)
-- [@snowpack/app-template-react-typescript](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-react-typescript)
-- [@snowpack/app-template-preact](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-preact)
-- [@snowpack/app-template-svelte](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-svelte)
-- [@snowpack/app-template-vue](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-vue)
-- [@snowpack/app-template-lit-element](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-lit-element)
-- [@snowpack/app-template-lit-element-typescript](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-lit-element-typescript)
-- [@snowpack/app-template-11ty](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-11ty)
+- [@snowpack/app-template-blank](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-blank)
+- [@snowpack/app-template-blank-typescript](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-blank-typescript)
+- [@snowpack/app-template-minimal](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-minimal)
+- [@snowpack/app-template-react](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-react)
+- [@snowpack/app-template-react-typescript](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-react-typescript)
+- [@snowpack/app-template-preact](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-preact)
+- [@snowpack/app-template-svelte](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-svelte)
+- [@snowpack/app-template-vue](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-vue)
+- [@snowpack/app-template-lit-element](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-lit-element)
+- [@snowpack/app-template-lit-element-typescript](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-lit-element-typescript)
+- [@snowpack/app-template-11ty](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-11ty)
 
-- **[See all community templates](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/cli#featured-community-templates)**
+- **[See all community templates](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/cli#featured-community-templates)**
 
 <!--
 ### Tutorial: Starting from Scratch

--- a/docs/04-features.md
+++ b/docs/04-features.md
@@ -172,7 +172,7 @@ You can use environment variables in HTML files. All occurrences of `%SNOWPACK_P
 }
 ```
 
-Add the `@snowpack/plugin-dotenv` plugin to your dev environment to automatically load environment variables from your project `.env` files. Visit the [plugin README](https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-dotenv) to learn more.
+Add the `@snowpack/plugin-dotenv` plugin to your dev environment to automatically load environment variables from your project `.env` files. Visit the [plugin README](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-dotenv) to learn more.
 
 ### Hot Module Replacement
 
@@ -184,14 +184,14 @@ Snowpack supports full HMR out-of-the-box for the following served files:
 - CSS Modules
 - JSON
 
-Popular frameworks can also be set up for HMR. **[Create Snowpack App (CSA)](https://github.com/pikapkg/snowpack/blob/master/create-snowpack-app) ships with HMR enabled by default for all of the following frameworks.** If you're not using CSA, you can setup HMR in your application with a simple plugin or a few lines of code:
+Popular frameworks can also be set up for HMR. **[Create Snowpack App (CSA)](https://github.com/snowpackjs/snowpack/blob/master/create-snowpack-app) ships with HMR enabled by default for all of the following frameworks.** If you're not using CSA, you can setup HMR in your application with a simple plugin or a few lines of code:
 
 - Preact: [@prefresh/snowpack](https://www.npmjs.com/package/@prefresh/snowpack)
 - React: [@snowpack/plugin-react-refresh](https://www.npmjs.com/package/@snowpack/plugin-react-refresh)
-- Svelte: [A few lines of code](https://github.com/pikapkg/snowpack/blob/master/create-snowpack-app/app-template-svelte/src/index.js#L9-L16)
-- Vue: [A few lines of code](https://github.com/pikapkg/snowpack/blob/master/create-snowpack-app/app-template-vue/src/index.js#L7-L14)
+- Svelte: [A few lines of code](https://github.com/snowpackjs/snowpack/blob/master/create-snowpack-app/app-template-svelte/src/index.js#L9-L16)
+- Vue: [A few lines of code](https://github.com/snowpackjs/snowpack/blob/master/create-snowpack-app/app-template-vue/src/index.js#L7-L14)
 
-For more advanced, bare-metal HMR integrations, Snowpack created [ESM-HMR](https://github.com/pikapkg/esm-hot-module-replacement-spec), a standard HMR API for any ESM-based dev environment. Any HMR integration built for ESM-HMR will run on Snowpack and any other ESM-HMR-enabled dev server. To use the HMR API directly (via `import.meta.hot`) check out [the ESM-HMR spec](https://github.com/pikapkg/esm-hot-module-replacement-spec) to learn more.
+For more advanced, bare-metal HMR integrations, Snowpack created [ESM-HMR](https://github.com/snowpackjs/esm-hot-module-replacement-spec), a standard HMR API for any ESM-based dev environment. Any HMR integration built for ESM-HMR will run on Snowpack and any other ESM-HMR-enabled dev server. To use the HMR API directly (via `import.meta.hot`) check out [the ESM-HMR spec](https://github.com/snowpackjs/esm-hot-module-replacement-spec) to learn more.
 
 ```js
 if (import.meta.hot) {
@@ -204,7 +204,7 @@ if (import.meta.hot) {
 }
 ```
 
-- 👉 **[Check out the full ESM-HMR spec.](https://github.com/pikapkg/esm-hot-module-replacement-spec)**
+- 👉 **[Check out the full ESM-HMR spec.](https://github.com/snowpackjs/esm-hot-module-replacement-spec)**
 
 ### Dev Request Proxy
 
@@ -340,4 +340,4 @@ module.exports = {
 };
 ```
 
-[See an example setup](https://github.com/pikapkg/snowpack/blob/master/create-snowpack-app/app-template-react) in on of our Create Snowpack App starter templates.
+[See an example setup](https://github.com/snowpackjs/snowpack/blob/master/create-snowpack-app/app-template-react) in on of our Create Snowpack App starter templates.

--- a/docs/07-plugins.md
+++ b/docs/07-plugins.md
@@ -80,13 +80,13 @@ This plugin allows you to run any CLI command as a part of your dev and build wo
 
 ### Official Plugins
 
-- [@snowpack/plugin-babel](https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-babel)
-- [@snowpack/plugin-dotenv](https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-dotenv)
-- [@snowpack/plugin-postcss](https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-postcss)
-- [@snowpack/plugin-react-refresh](https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-react-refresh)
-- [@snowpack/plugin-svelte](https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-svelte)
-- [@snowpack/plugin-vue](https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-vue)
-- [@snowpack/plugin-webpack](https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-webpack)
+- [@snowpack/plugin-babel](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-babel)
+- [@snowpack/plugin-dotenv](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-dotenv)
+- [@snowpack/plugin-postcss](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-postcss)
+- [@snowpack/plugin-react-refresh](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-react-refresh)
+- [@snowpack/plugin-svelte](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-svelte)
+- [@snowpack/plugin-vue](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-vue)
+- [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-webpack)
 
 👉 **[Check out our full list](/plugins) of official plugins.**
 

--- a/esinstall/package.json
+++ b/esinstall/package.json
@@ -3,10 +3,10 @@
   "version": "0.3.3",
   "description": "Convert packages to ESM.",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/esinstall#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/esinstall#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "esinstall"
   },
   "publishConfig": {

--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -98,7 +98,7 @@ function resolveWebDependency(dep: string, {cwd}: {cwd: string}): DependencyLoc 
     return {
       type: isJSFile ? 'JS' : 'ASSET',
       // For details on why we need to call fs.realpathSync.native here and other places, see
-      // https://github.com/pikapkg/snowpack/pull/999.
+      // https://github.com/snowpackjs/snowpack/pull/999.
       loc: fs.realpathSync.native(require.resolve(dep, {paths: [cwd]})),
     };
   }

--- a/plugins/babel-plugin-package-import/package.json
+++ b/plugins/babel-plugin-package-import/package.json
@@ -3,10 +3,10 @@
   "version": "1.1.4",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/plugins/babel-plugin-package-import#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/babel-plugin-package-import#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "plugins/babel-plugin-package-import"
   },
   "publishConfig": {

--- a/plugins/plugin-babel/package.json
+++ b/plugins/plugin-babel/package.json
@@ -3,10 +3,10 @@
   "version": "2.1.3",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-babel#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-babel#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "plugins/plugin-babel"
   },
   "publishConfig": {

--- a/plugins/plugin-build-script/package.json
+++ b/plugins/plugin-build-script/package.json
@@ -3,10 +3,10 @@
   "name": "@snowpack/plugin-build-script",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-build-script#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-build-script#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "plugins/plugin-build-script"
   },
   "publishConfig": {

--- a/plugins/plugin-dotenv/package.json
+++ b/plugins/plugin-dotenv/package.json
@@ -3,10 +3,10 @@
   "version": "2.0.3",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-dotenv#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-dotenv#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "plugins/plugin-dotenv"
   },
   "publishConfig": {

--- a/plugins/plugin-optimize/package.json
+++ b/plugins/plugin-optimize/package.json
@@ -3,10 +3,10 @@
   "version": "0.2.5",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-optimize#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-optimize#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "plugins/plugin-optimize"
   },
   "publishConfig": {

--- a/plugins/plugin-postcss/package.json
+++ b/plugins/plugin-postcss/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.5",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-postcss#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-postcss#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "plugins/plugin-postcss"
   },
   "publishConfig": {

--- a/plugins/plugin-react-refresh/package.json
+++ b/plugins/plugin-react-refresh/package.json
@@ -3,10 +3,10 @@
   "version": "2.3.2",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-react-refresh#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-react-refresh#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "plugins/plugin-react-refresh"
   },
   "publishConfig": {

--- a/plugins/plugin-run-script/package.json
+++ b/plugins/plugin-run-script/package.json
@@ -3,10 +3,10 @@
   "name": "@snowpack/plugin-run-script",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-run-script#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-run-script#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "plugins/plugin-run-script"
   },
   "publishConfig": {

--- a/plugins/plugin-run-script/test/plugin.test.js
+++ b/plugins/plugin-run-script/test/plugin.test.js
@@ -4,7 +4,7 @@ const {EventEmitter} = require('events');
 jest.mock('execa');
 const execa = require('execa');
 
-// NOTE(fks): This is skipped due to refactoring happening in https://github.com/pikapkg/snowpack/pull/1203
+// NOTE(fks): This is skipped due to refactoring happening in https://github.com/snowpackjs/snowpack/pull/1203
 // Once that PR is merged, this should be safe to unskip
 describe.skip('plugin-run-script', () => {
   const DEFAULT_OPTIONS = {

--- a/plugins/plugin-sass/package.json
+++ b/plugins/plugin-sass/package.json
@@ -3,10 +3,10 @@
   "name": "@snowpack/plugin-sass",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-sass#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-sass#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "plugins/plugin-sass"
   },
   "publishConfig": {

--- a/plugins/plugin-svelte/package.json
+++ b/plugins/plugin-svelte/package.json
@@ -3,10 +3,10 @@
   "version": "3.0.0",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-svelte#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-svelte#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "plugins/plugin-svelte"
   },
   "publishConfig": {

--- a/plugins/plugin-typescript/package.json
+++ b/plugins/plugin-typescript/package.json
@@ -3,10 +3,10 @@
   "name": "@snowpack/plugin-typescript",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-typescript#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-typescript#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "plugins/plugin-typescript"
   },
   "publishConfig": {

--- a/plugins/plugin-vue/package.json
+++ b/plugins/plugin-vue/package.json
@@ -3,10 +3,10 @@
   "version": "2.2.3",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-vue#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-vue#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "plugins/plugin-vue"
   },
   "publishConfig": {

--- a/plugins/plugin-webpack/package.json
+++ b/plugins/plugin-webpack/package.json
@@ -3,10 +3,10 @@
   "version": "2.0.16",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-webpack#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-webpack#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
     "directory": "plugins/plugin-webpack"
   },
   "publishConfig": {

--- a/plugins/web-test-runner-plugin/plugin.js
+++ b/plugins/web-test-runner-plugin/plugin.js
@@ -44,7 +44,7 @@ To Resolve:
       if (!isTestFilePath(source) || source.startsWith('/__web-dev-server')) {
         return;
       }
-      // PERF(fks): https://github.com/pikapkg/snowpack/pull/1259/files#r502963818
+      // PERF(fks): https://github.com/snowpackjs/snowpack/pull/1259/files#r502963818
       const reqPath = source.substring(
         0,
         source.indexOf('?') === -1 ? undefined : source.indexOf('?'),

--- a/snowpack/README.md
+++ b/snowpack/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/pikapkg/snowpack/workflows/CI/badge.svg?event=push)](https://github.com/pikapkg/snowpack/actions)
+[![CI](https://github.com/snowpackjs/snowpack/workflows/CI/badge.svg?event=push)](https://github.com/snowpackjs/snowpack/actions)
 
 ### What is Snowpack?
 

--- a/snowpack/assets/babel-plugin.js
+++ b/snowpack/assets/babel-plugin.js
@@ -3,5 +3,5 @@ console.error('');
 console.error('  npm install --save-dev @snowpack/babel-plugin-package-import');
 console.error('');
 console.error(
-  'Learn more: https://github.com/pikapkg/snowpack/tree/master/plugins/babel-plugin-package-import',
+  'Learn more: https://github.com/snowpackjs/snowpack/tree/master/plugins/babel-plugin-package-import',
 );

--- a/snowpack/package.json
+++ b/snowpack/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pikapkg/snowpack.git"
+    "url": "https://github.com/snowpackjs/snowpack.git"
   },
   "publishConfig": {
     "access": "public"

--- a/test-dev/README.md
+++ b/test-dev/README.md
@@ -2,4 +2,4 @@
 
 We moved the tests out of the common `test/` folder because of problems with Windows. This way, we can run the dev tests using a separate command, which we can run on CI on Ubuntu only.
 
-We would love to figure out the problem. If you develop on a Windows machine, we would appreciate your help. See [#1171](https://github.com/pikapkg/snowpack/pull/1171) for more information.
+We would love to figure out the problem. If you develop on a Windows machine, we would appreciate your help. See [#1171](https://github.com/snowpackjs/snowpack/pull/1171) for more information.

--- a/test/build/bugfix-named-import/package.json
+++ b/test/build/bugfix-named-import/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "version": "1.0.1",
   "name": "@snowpack/test-bugfix-named-import",
-  "description": "Tests for the _$v4 named import bug (https://github.com/pikapkg/snowpack/issues/560)",
+  "description": "Tests for the _$v4 named import bug (https://github.com/snowpackjs/snowpack/issues/560)",
   "snowpack": {
     "mount": {
       "./src": "/_dist_"

--- a/www/_eleventy/layouts/base.njk
+++ b/www/_eleventy/layouts/base.njk
@@ -65,10 +65,10 @@
           <a href="/guides/plugins" class="grid-nav-link plugin-nav-link">Plugin Guide</a>
           <!-- <input type="text" name="search" placeholder="Search documentation..." class="search-form-input"></div> -->
         </form>
-        <a href="https://github.com/pikapkg/snowpack/discussions/1183" target="_blank" class="grid-nav-link">
+        <a href="https://github.com/snowpackjs/snowpack/discussions/1183" target="_blank" class="grid-nav-link">
               v2.14.3
             </a>
-        <a href="https://github.com/pikapkg/snowpack" target="_blank" class="icon-link hidden-mobile">
+        <a href="https://github.com/snowpackjs/snowpack" target="_blank" class="icon-link hidden-mobile">
           <svg aria-hidden="true" focusable="false" data-prefix="fab" data-icon="github" class="svg-inline--fa fa-github fa-w-16" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512">
             <path fill="currentColor" d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"></path>
           </svg>

--- a/www/_eleventy/layouts/main.njk
+++ b/www/_eleventy/layouts/main.njk
@@ -34,7 +34,7 @@ description: "Snowpack is the fast, bundle-free build tool for all kinds of fron
       <a href="#get-started" class="button">Get Started</a>
       <!-- Place this tag where you want the button to render. -->
       <div class="hidden-mobile" style="text-align: center;">
-        <a class="github-button" href="https://github.com/pikapkg/snowpack" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star pikapkg/snowpack on GitHub">Star</a>
+        <a class="github-button" href="https://github.com/snowpackjs/snowpack" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star snowpackjs/snowpack on GitHub">Star</a>
       </div>
     </div>
   </div>

--- a/www/_eleventy/layouts/post.njk
+++ b/www/_eleventy/layouts/post.njk
@@ -120,7 +120,7 @@
         </svg>
       Snowpack
       </a>
-      <a href="https://github.com/pikapkg/snowpack" target="_blank">
+      <a href="https://github.com/snowpackjs/snowpack" target="_blank">
         <svg aria-hidden="true" focusable="false" data-prefix="fab" data-icon="github" class="svg-inline--fa fa-github fa-w-16" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512"><path fill="currentColor" d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"></path></svg>
       </a>
       <a href="https://twitter.com/pikapkg" target="_blank">
@@ -153,7 +153,7 @@
         <p>{{tagline}}<br /> Published <a href='#published-at'>{{page.date | readableDate }}</a> by <a href="https://twitter.com/FredKSchott">Fred K. Schott<a></p>
         <!-- Place this tag where you want the button to render. -->
         <div class="hidden-mobile" style="text-align: center; margin-top: 0.5rem; filter: scale(2);">
-            <a class="github-button" href="https://github.com/pikapkg/snowpack" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star pikapkg/snowpack on GitHub">Star</a>
+            <a class="github-button" href="https://github.com/snowpackjs/snowpack" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star snowpackjs/snowpack on GitHub">Star</a>
         </div>
         <!-- Place this tag in your head or just before your close body tag. -->
         <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/www/guides/plugins.md
+++ b/www/guides/plugins.md
@@ -39,7 +39,7 @@ Snowpack plugins support a `run()` method which lets you run any CLI tool and co
 
 Snowpack builds you a runnable, unbundled website by default, but you can optimize this final build with your favorite bundler (webpack, Rollup, Parcel, etc.) through the plugin `optimize()` method. When a bundler plugin is used, Snowpack will run the bundler on your build automatically to optimize it.
 
-See our official [@snowpack/plugin-webpack](https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-webpack) bundler plugin for an example of using the current interface.
+See our official [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-webpack) bundler plugin for an example of using the current interface.
 
 ## How to Write a Plugin
 
@@ -245,7 +245,7 @@ This is an (obviously) simplified version of the `@snowpack/plugin-webpack` plug
 
 ## Plugin API
 
-Check out our ["SnowpackPlugin" TypeScript definition](https://github.com/pikapkg/snowpack/tree/master/snowpack/src/types/snowpack.ts) for a fully documented and up-to-date summary of the Plugin API and all supported options.
+Check out our ["SnowpackPlugin" TypeScript definition](https://github.com/snowpackjs/snowpack/tree/master/snowpack/src/types/snowpack.ts) for a fully documented and up-to-date summary of the Plugin API and all supported options.
 
 ### knownEntrypoints
 
@@ -266,7 +266,7 @@ config(snowpackConfig) {
 
 Use this hook to read or make changes to the completed Snowpack configuration object. This is currently the recommended way to access the Snowpack configuration, since the one passed to the top-level plugin function is not yet finalized and may be incomplete.
 
-- [Full TypeScript definition](https://github.com/pikapkg/snowpack/tree/master/snowpack/src/types/snowpack.ts).
+- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/master/snowpack/src/types/snowpack.ts).
 
 ### resolve
 
@@ -282,43 +282,43 @@ If your plugin defines a `load()` method, Snowpack will need to know what files 
 
 - `input`: An array of file extensions that this plugin will load.
 - `output`: The set of all file extensions that this plugin's `load()` method will output.
-- [Full TypeScript definition](https://github.com/pikapkg/snowpack/tree/master/snowpack/src/types/snowpack.ts).
+- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/master/snowpack/src/types/snowpack.ts).
 
 ### load()
 
 Load a file from disk and build it for your application. This is most useful for taking a file type that can't run in the browser (TypeScript, Sass, Vue, Svelte) and returning JS and/or CSS. It can even be used to load JS/CSS files directly from disk with a build step like Babel or PostCSS.
 
 - See above for an example of how to use this method.
-- [Full TypeScript definition](https://github.com/pikapkg/snowpack/tree/master/snowpack/src/types/snowpack.ts).
+- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/master/snowpack/src/types/snowpack.ts).
 
 ### transform()
 
 Transform a file's contents. Useful for making changes to all types of output (JS, CSS, etc.) regardless of how they were loaded from disk.
 
 - See above for an example of how to use this method.
-- Example: [@snowpack/plugin-postcss](https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-postcss)
-- [Full TypeScript definition](https://github.com/pikapkg/snowpack/tree/master/snowpack/src/types/snowpack.ts).
+- Example: [@snowpack/plugin-postcss](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-postcss)
+- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/master/snowpack/src/types/snowpack.ts).
 
 ### run()
 
 Run a CLI command, and connect it's output into the Snowpack console. Useful for connecting tools like TypeScript.
 
-- [Full TypeScript definition](https://github.com/pikapkg/snowpack/tree/master/snowpack/src/types/snowpack.ts).
+- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/master/snowpack/src/types/snowpack.ts).
 
 ### optimize()
 
 Snowpack’s bundler plugin API is still experimental and may change in a future release. See our official bundler plugins for an example of using the current interface:
 
-- Example: [@snowpack/plugin-webpack](https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-webpack)
+- Example: [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-webpack)
 - Example: [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle)
-- [Full TypeScript definition](https://github.com/pikapkg/snowpack/tree/master/snowpack/src/types/snowpack.ts).
+- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/master/snowpack/src/types/snowpack.ts).
 
 ### onChange()
 
 Get notified any time a watched file changes. This can be useful when paired with the `markChanged()` plugin method, to mark multiple files changed at once.
 
-- See [@snowpack/plugin-sass](https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-sass/plugin.js) for an example of how to use this method.
-- [Full TypeScript definition](https://github.com/pikapkg/snowpack/tree/master/snowpack/src/types/snowpack.ts).
+- See [@snowpack/plugin-sass](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-sass/plugin.js) for an example of how to use this method.
+- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/master/snowpack/src/types/snowpack.ts).
 
 ## Plugin API Methods
 
@@ -331,12 +331,12 @@ this.markChanged('/some/file/path.scss');
 
 Manually mark a file as changed, regardless of whether the file changed on disk or not. This can be useful when paired with the `markChanged()` plugin hook, to mark multiple files changed at once.
 
-- See [@snowpack/plugin-sass](https://github.com/pikapkg/snowpack/tree/master/plugins/plugin-sass/plugin.js) for an example of how to use this method.
-- [Full TypeScript definition](https://github.com/pikapkg/snowpack/tree/master/snowpack/src/types/snowpack.ts).
+- See [@snowpack/plugin-sass](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-sass/plugin.js) for an example of how to use this method.
+- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/master/snowpack/src/types/snowpack.ts).
 
 ## Publishing a Plugin
 
-To share a plugin with the world, you can publish it to npm. For example, take a look at [snowpack-plugin-starter-template](https://github.com/pikapkg/snowpack-plugin-starter-template) which can get you up-and-running quickly. You can either copy this outright or simply take what you need.
+To share a plugin with the world, you can publish it to npm. For example, take a look at [snowpack-plugin-starter-template](https://github.com/snowpackjs/snowpack-plugin-starter-template) which can get you up-and-running quickly. You can either copy this outright or simply take what you need.
 
 In general, make sure to mind the following checklist:
 

--- a/www/posts/2020-05-26-snowpack-2-0-release.md
+++ b/www/posts/2020-05-26-snowpack-2-0-release.md
@@ -123,25 +123,25 @@ If you already have an existing Snowpack application, Snowpack 2.0 will walk you
 
 #### Create Snowpack App
 
-The easiest way to get started with Snowpack is with [Create Snowpack App (CSA)](https://github.com/pikapkg/snowpack). CSA automatically initializes a starter application for you with a pre-configured, Snowpack-powered dev environment.
+The easiest way to get started with Snowpack is with [Create Snowpack App (CSA)](https://github.com/snowpackjs/snowpack). CSA automatically initializes a starter application for you with a pre-configured, Snowpack-powered dev environment.
 
 ```bash
 npx create-snowpack-app new-dir --template [SELECT FROM BELOW] [--use-yarn]
 ```
 
-- [@snowpack/app-template-blank](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-blank)
-- [@snowpack/app-template-react](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-react)
-- [@snowpack/app-template-react-typescript](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-react-typescript)
-- [@snowpack/app-template-preact](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-preact)
-- [@snowpack/app-template-svelte](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-svelte)
-- [@snowpack/app-template-vue](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-vue)
-- [@snowpack/app-template-lit-element](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-lit-element)
-- [@snowpack/app-template-11ty](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-11ty)
-- **[See all community templates](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app)**
+- [@snowpack/app-template-blank](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-blank)
+- [@snowpack/app-template-react](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-react)
+- [@snowpack/app-template-react-typescript](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-react-typescript)
+- [@snowpack/app-template-preact](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-preact)
+- [@snowpack/app-template-svelte](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-svelte)
+- [@snowpack/app-template-vue](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-vue)
+- [@snowpack/app-template-lit-element](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-lit-element)
+- [@snowpack/app-template-11ty](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-11ty)
+- **[See all community templates](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app)**
 
 🐹 Happy hacking!
 
 ---
 
-_Thank you to all of our [80+ contributors](https://github.com/pikapkg/snowpack/graphs/contributors) for making this release possible._
+_Thank you to all of our [80+ contributors](https://github.com/snowpackjs/snowpack/graphs/contributors) for making this release possible._
 _Thanks to [Melissa McEwen](https://twitter.com/melissamcewen) & [@TheoOnTwitch](https://twitter.com/TheoOnTwitch) for helping to edit this post._

--- a/www/posts/2020-07-30-snowpack-2-7-release.md
+++ b/www/posts/2020-07-30-snowpack-2-7-release.md
@@ -20,7 +20,7 @@ Happy release day! We are excited to announce Snowpack v2.7 with a handful of ne
 
 Plus, we hit some VERY exciting project milestones last month:
 
-- ❤️ **150** [open source contributors](https://github.com/pikapkg/snowpack/graphs/contributors) (and growing!)
+- ❤️ **150** [open source contributors](https://github.com/snowpackjs/snowpack/graphs/contributors) (and growing!)
 - 🏆 **1000+** discussions, issues, and pull requests
 - ⭐️ **10,000+** stars on GitHub
 - 👋 **New companies using Snowpack:** [Alibaba](https://www.1688.com/) & [Airhacks](https://airhacks.com/)
@@ -80,11 +80,11 @@ If you don't use a bundler in production, you'll still see a smaller build. That
 
 Last week, [Svelte announced official support for TypeScript](https://svelte.dev/blog/svelte-and-typescript). We're huge fans of both projects and couldn't pass up the chance to test the new support out in a brand new Svelte + TypeScript app template for Snowpack.
 
-Visit [Create Snowpack App](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app) for a list of all of our new app templates.
+Visit [Create Snowpack App](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app) for a list of all of our new app templates.
 
 ## Thank You, Contributors!
 
-Finally, Snowpack wouldn't be possible without the [150+ contributors](https://github.com/pikapkg/snowpack/graphs/contributors) who contributed features, fixes, and documentation improvements. Thanks again for all of your help.
+Finally, Snowpack wouldn't be possible without the [150+ contributors](https://github.com/snowpackjs/snowpack/graphs/contributors) who contributed features, fixes, and documentation improvements. Thanks again for all of your help.
 
 -- Snowpack Maintainers
 


### PR DESCRIPTION
Since https://github.com/pikapkg is no longer reachable.

## Changes

Update repository URL from https://github.com/pikapkg to https://github.com/snowpackjs

## Testing

No need to add tests as not code change.

## Docs

Updates repository URL.
