### PR TITLE
use regex for detecting import.meta

### DIFF
--- a/snowpack/src/build/build-import-proxy.ts
+++ b/snowpack/src/build/build-import-proxy.ts
@@ -14,6 +14,8 @@ const SRI_ERROR_HMR_SNOWPACK = generateSRI(
   readFileSync(path.join(__dirname, '../../assets/hmr-error-overlay.js')),
 );
 
+const importMetaRegex = /import\s*\.\s*meta/;
+
 export function getMetaUrlPath(urlPath: string, config: SnowpackConfig): string {
   let {metaDir} = config.buildOptions || {};
   return path.posix.normalize(path.posix.join('/', metaDir, urlPath));
@@ -30,7 +32,7 @@ export function wrapImportMeta({
   env: boolean;
   config: SnowpackConfig;
 }) {
-  if (!/import\s*\.\s*meta/.test(code)) {
+  if (!importMetaRegex.test(code)) {
     return code;
   }
   return (

--- a/snowpack/src/build/build-import-proxy.ts
+++ b/snowpack/src/build/build-import-proxy.ts
@@ -30,7 +30,7 @@ export function wrapImportMeta({
   env: boolean;
   config: SnowpackConfig;
 }) {
-  if (!code.includes('import.meta')) {
+  if (!/import\s*\.\s*meta/.test(code)) {
     return code;
   }
   return (

--- a/test/build/base-url/__snapshots__
+++ b/test/build/base-url/__snapshots__
@@ -77,7 +77,9 @@ export default function doNothing() {
   // I do nothing 🎉
 }
 // Triggers a snowpack meta import URL
-console.log(import.meta.env)"
+console.log(import
+  .meta
+  .env)"
 `;
 
 exports[`snowpack build base-url: build/web_modules/array-flatten.js 1`] = `

--- a/test/build/base-url/public/index.js
+++ b/test/build/base-url/public/index.js
@@ -7,4 +7,6 @@ export default function doNothing() {
 }
 
 // Triggers a snowpack meta import URL
-console.log(import.meta.env)
+console.log(import
+  .meta
+  .env)


### PR DESCRIPTION
## Changes

The code that detects `import.meta`, in order to inject the HMR client etc, is using a naive `code.includes('import.meta')` check. This updates it to use a more robust regular expression, that can catch things like

```js
import
  .meta
  .blah
```

which could be injected by tools like Prettier.

## Testing

I changed one of the tests that uses `import.meta.hot`, but wasn't sure how to update the snapshot, so it's currently failing.

## Docs

No docs, bug fix only
