### PR TITLE
add isHMR flag to loadUrl, and default off on isSSR

### DIFF
--- a/snowpack/src/commands/build.ts
+++ b/snowpack/src/commands/build.ts
@@ -322,6 +322,7 @@ export async function command(commandOptions: CommandOptions) {
       const runJob = runPlugin
         .run({
           isDev: isDev,
+          // @ts-ignore: deprecated
           isHmrEnabled: getIsHmrEnabled(config),
           // @ts-ignore: internal API only
           log: (msg, data: {msg: string} = {}) => {

--- a/snowpack/src/types/snowpack.ts
+++ b/snowpack/src/types/snowpack.ts
@@ -99,6 +99,7 @@ export interface PluginTransformOptions {
 
 export interface PluginRunOptions {
   isDev: boolean;
+  /* @deprecated */
   isHmrEnabled: boolean;
 }
 


### PR DESCRIPTION
## Changes

- Added explicit `isHMR` option to `loadUrl()` JS API
- Default to `isHMR` mode off when `isSSR` is true, since HMR isn't meant to run on the server
- Deprecated an outdated `run()` plugin hook option. Now that SSR mode is on/off per file, this flag no longer tracks. We had already added `isHmrEnabled` to the build & transform functions.

## Testing

- Tests passing.

## Docs

- No docs changes needed (not even sure if this option had been documented).