### PR TITLE
Fix import sources needing trailing slash for file aliases

### DIFF
--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -594,7 +594,7 @@ function normalizeAlias(config: SnowpackConfig, cwd: string, createMountAlias: b
       replacement.startsWith('/')
     ) {
       delete cleanAlias[target];
-      cleanAlias[addTrailingSlash(target)] = addTrailingSlash(path.resolve(cwd, replacement));
+      cleanAlias[target] = addTrailingSlash(path.resolve(cwd, replacement));
     }
   }
   return cleanAlias;

--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -292,7 +292,7 @@ export function findMatchingAliasEntry(
 
   for (const [from, to] of Object.entries(config.alias)) {
     let foundType: 'package' | 'path' = isPackageAliasEntry(to) ? 'package' : 'path';
-    const isExactMatch = spec === removeTrailingSlash(from);
+    const isExactMatch = spec === from;
     const isDeepMatch = spec.startsWith(addTrailingSlash(from));
     if (isExactMatch || isDeepMatch) {
       return {

--- a/test/build/resolve-imports/__snapshots__
+++ b/test/build/resolve-imports/__snapshots__
@@ -122,7 +122,8 @@ import sort_ from './sort.js'; // absolute import
 import sort__ from './sort.js'; // bare import using alias
 import sort___ from './sort.js'; // bare import using alias + extension
 import sort____ from './sort.js'; // bare import using alias with trailing slash
-console.log(sort, sort_, sort__, sort___, sort___, sort____);
+import sort_____ from './sort.js'; // bare import using file alias
+console.log(sort, sort_, sort__, sort___, sort___, sort____, sort_____);
 // Note: file does not need to exist for these checks:
 import svelteFile from './foo.js'; // plugin-provided file extension
 import svelteFile_ from './foo.js'; // plugin-provided, missing file extension

--- a/test/build/resolve-imports/snowpack.config.js
+++ b/test/build/resolve-imports/snowpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
     '@app': './src',
     '@/': './src/',
     '%': '.',
+    "@sort": "./src/sort.js",
   },
   mount: {
     './src': '/_dist_',

--- a/test/build/resolve-imports/src/index.js
+++ b/test/build/resolve-imports/src/index.js
@@ -9,7 +9,8 @@ import sort_ from '/_dist_/sort.js'; // absolute import
 import sort__ from '@app/sort'; // bare import using alias
 import sort___ from '@app/sort.js'; // bare import using alias + extension
 import sort____ from '@/sort'; // bare import using alias with trailing slash
-console.log(sort, sort_, sort__, sort___, sort___, sort____);
+import sort_____ from '@sort'; // bare import using file alias
+console.log(sort, sort_, sort__, sort___, sort___, sort____, sort_____);
 
 // Note: file does not need to exist for these checks:
 import svelteFile from './foo.svelte'; // plugin-provided file extension


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Previously it wasn't possible to have an import alias that pointed to a specific file, instead of a directory. The only way to make it work was to include a trailing slash in the import specifier, which is undesirable.

```js
// snowpack.config.js
module.exports = {
  alias: {
    "@foo": "./src/foo.js",
  },
};

// src/bar.js
import foo from "@foo"; // doesn't work, but should
import foo from "@foo/"; // does work, but import shouldn't have a trailing slash
```

This change makes it so that aliases to specific files don't require a trailing slash (ie. `import "@foo"` now works).

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

I have added a test case to the `resolve-imports` test file and updated the snapshot to match the new behavior.

Note: `jest -u` wanted to remove a bunch of obsolete snapshots, but I chose not to commit those deletions since that's beyond the scope of this PR. Also I only tested the `resolve-imports` tests, since the rest of the tests failed on a fresh install on my machine and I couldn't figure out why.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

Public documentation was not updated, as this bug fix restores the behavior to what a user would presumably expect based on the existing docs.