### PR TITLE
chore: expose `package.json` in `exports` map

### DIFF
--- a/snowpack/package.json
+++ b/snowpack/package.json
@@ -31,8 +31,11 @@
   "types": "lib/index.d.ts",
   "main": "lib/index.js",
   "exports": {
-    "import": "./index.esm.mjs",
-    "require": "./lib/index.js"
+    ".": {
+      "import": "./index.esm.mjs",
+      "require": "./lib/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "bin": {
     "sp": "index.bin.js",


### PR DESCRIPTION
## Changes

This is necessary so that consumers can read/parse the package's config. 
While it may not be very often that a CLI/bin gets parsed, it will still happen.

For example, Svelte kit is doing this to execute `snowpack` manually in the background:

```js
require.resolve('snowpack/package.json');
```

Without this change, all Node 12.x and 14.x users get this error immediately:

<img width="1356" alt="Screen Shot 2020-10-22 at 5 21 04 PM" src="https://user-images.githubusercontent.com/5855893/96942827-10cfde00-148b-11eb-95fe-aa9957f30334.png">

## Testing

No tests, just removes Node error.

## Docs

Bug fix only.
