### PR TITLE
Fix case problem of openChrome on Mac

### DIFF
--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -203,7 +203,7 @@ export async function openInBrowser(
       });
       // use open Chrome tab if exists; create new Chrome tab if not
       const openChrome = execa(
-        'osascript ../assets/openChrome.applescript "' + encodeURI(url) + '"',
+        'osascript ../assets/openChrome.appleScript "' + encodeURI(url) + '"',
         {
           cwd: __dirname,
           stdio: 'ignore',


### PR DESCRIPTION
## Changes

fix case problem of openChrome within `snowpack/src/util.ts`.
for Mac users who turn their disk APFS(Case Sensitive).  

before:
![image](https://user-images.githubusercontent.com/15810641/96998493-1e0dcb00-1566-11eb-992a-5fb580fa8899.png)
after:
![image](https://user-images.githubusercontent.com/15810641/96998569-3da4f380-1566-11eb-9eaf-dfa91167efc2.png)

The red line out of air is realy annoying.

## Testing

extremely minor change

## Docs

bugfix only
