### PR TITLE
[plugin-svelte] upgrade svelte-hmr to 0.11.2

### DIFF
--- a/plugins/plugin-svelte/README.md
+++ b/plugins/plugin-svelte/README.md
@@ -25,4 +25,4 @@ By default, this plugin will look for a `svelte.config.js` file in your project 
 | `input`           |                               `string[]`                               | Array of file extensions to process. Uses `svelte.config.js` `extensions` if available. Defaults to `['.svelte']`.  |
 | `preprocess`      | [svelte.preprocess options](https://svelte.dev/docs#svelte_preprocess) | Configure the Svelte pre-processor. If this option is given, the config file `preprocess` option will be ignored.   |
 | `compilerOptions` |    [svelte.compile options](https://svelte.dev/docs#svelte_compile)    | Configure the Svelte compiler.If this option is given, the config file `preprocess` option will be ignored.         |
-| `hmrOptions`      |        [svelte-hmr options](https://github.com/rixo/svelte-hmr)        | Configure HMR & "fast refresh" behavior for Svelte.                                                                 |
+| `hmrOptions`      |    [svelte-hmr options](https://github.com/rixo/svelte-hmr#options)    | Configure HMR & "fast refresh" behavior for Svelte.                                                                 |

--- a/plugins/plugin-svelte/package.json
+++ b/plugins/plugin-svelte/package.json
@@ -18,7 +18,7 @@
   "gitHead": "a01616bb0787d56cd782f94cecf2daa12c7594e4",
   "dependencies": {
     "rollup-plugin-svelte": "^6.0.0",
-    "svelte-hmr": "^0.11.2-1"
+    "svelte-hmr": "^0.11.2"
   },
   "devDependencies": {
     "node-sass": "^4.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13963,10 +13963,10 @@ svelte-check@^1.0.0:
     vscode-languageserver-types "3.15.1"
     vscode-uri "2.1.2"
 
-svelte-hmr@^0.11.2-1:
-  version "0.11.2-1"
-  resolved "https://registry.yarnpkg.com/svelte-hmr/-/svelte-hmr-0.11.2-1.tgz#ce1b481a2489697ccf7aa405bccae1421ce80011"
-  integrity sha512-VanuFg1OiMvLjs44jo8+qnZnKfQGfflNRf8hETUhOs28J5V4xsCgU2NJHy+3iTVgEX1+a41zIEIBgquh02o9bQ==
+svelte-hmr@^0.11.2:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/svelte-hmr/-/svelte-hmr-0.11.2.tgz#741426f26d1b799670f16e36d1b59d04c5d6ca8b"
+  integrity sha512-KbzQESDdREGwKbu39xFrHonuUWitE61gKSNYJRjibS2djTxsRYFNCNf/nkKsJBcueU8k+9czrjfiYx22KgXZQw==
 
 svelte-language-server@*:
   version "0.10.134"


### PR DESCRIPTION
## Changes

Using the latest version of svelte-hmr, that contains the minor modifications that were needed for Snowpack support (and, apart from that, a bug fix), in Svelte plugin.

## Testing

Test strategy for this is not totally defined yet, is it?

## Docs

I've started to document svelte-hmr options (the most stable & public of them for now), so I've updated the link in Svelte plugin's doc to point to this section instead of just generally the README.

## Further discussion

I've been tinkering again with svelte-hmr with a fresh look, since I hadn't done that for some time. I've found there was room for improvement on some levels, especially options. I'm expecting a breaking change version pretty soon, changing defaults or renaming / removing existing options... There are other aspects I'm not satisfied with currently (around named imports mainly), that I intend to address and would probably also mean more breaking changes coming. I suppose each of them would also mean a major bump for this plugin. I'm mentioning this mainly to give you some visibility about this, but I'm also curious if you have any special feelings or suggestion about this.