### PR TITLE
Added lang specifier to script tag, i.e., lang='typescript'

### DIFF
--- a/create-snowpack-app/app-template-svelte-typescript/src/App.svelte
+++ b/create-snowpack-app/app-template-svelte-typescript/src/App.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang='typescript'>
 	import {onMount} from 'svelte';
 	let count: number = 0;
 	onMount(() => {

--- a/create-snowpack-app/app-template-svelte-typescript/svelte.config.js
+++ b/create-snowpack-app/app-template-svelte-typescript/svelte.config.js
@@ -1,9 +1,9 @@
 const autoPreprocess = require('svelte-preprocess');
 
 module.exports = {
-    preprocess: autoPreprocess({
-        defaults: {
-            script: 'typescript'
-        }
-    })
-}
+  preprocess: autoPreprocess({
+    defaults: {
+      script: 'typescript',
+    },
+  }),
+};


### PR DESCRIPTION
## Changes

Targets app-template-svelte-typescript. 
Adds language specifier to script block. This signals the svelte language server to process the enclosed based on the specified attribute, typescript, in this case. 
See [svelte language server docs](https://github.com/sveltejs/language-tools/tree/master/docs#using-with-preprocessors) for more info.

## Testing

Tested in started project with vscode and svelte for vscode plugin. Warnings related to types disappeared. 

## Docs

No docs added. Template enhancement/bug fix.
