### PR TITLE
Add new optional param name of plugin-run-script

### DIFF
--- a/plugins/plugin-run-script/README.md
+++ b/plugins/plugin-run-script/README.md
@@ -33,5 +33,6 @@ Supply any CLI command in `cmd`. Note that this is the same as running the comma
 | Name     |   Type    | Description                                                                 |
 | :------- | :-------: | :-------------------------------------------------------------------------- |
 | `cmd`    | `string`  | The CLI command to run. Note that this will run **before** Snowpack builds. |
+| `name`   | `string`  | (optional) Set name of console output, default is program name.             |
 | `watch`  | `string`  | (optional) A watch command to run during the dev server.                    |
 | `output` | `"stream" | "dashboard"`                                                                | (optional) Set how the output should be recorded during dev. |

--- a/plugins/plugin-run-script/plugin.js
+++ b/plugins/plugin-run-script/plugin.js
@@ -2,12 +2,12 @@ const execa = require('execa');
 const npmRunPath = require('npm-run-path');
 const cwd = process.cwd();
 
-function runScriptPlugin(_, {cmd, watch, output}) {
+function runScriptPlugin(_, {name, cmd, watch, output}) {
   const [cmdProgram] = cmd.split(' ');
   const watchCmd = watch && watch.replace('$1', cmd);
 
   return {
-    name: cmdProgram,
+    name: name || cmdProgram,
     async run({isDev, log}) {
       const workerPromise = execa.command(isDev ? watchCmd || cmd : cmd, {
         env: npmRunPath.env(),

--- a/plugins/plugin-run-script/test/plugin.test.js
+++ b/plugins/plugin-run-script/test/plugin.test.js
@@ -4,9 +4,7 @@ const {EventEmitter} = require('events');
 jest.mock('execa');
 const execa = require('execa');
 
-// NOTE(fks): This is skipped due to refactoring happening in https://github.com/snowpackjs/snowpack/pull/1203
-// Once that PR is merged, this should be safe to unskip
-describe.skip('plugin-run-script', () => {
+describe('plugin-run-script', () => {
   const DEFAULT_OPTIONS = {
     cmd: 'CMD',
     watch: '$1 --additional-test-watch-options',
@@ -33,7 +31,7 @@ describe.skip('plugin-run-script', () => {
   test('calls the given "watch" command when isDev=true', async () => {
     const p = plugin(null, {cmd: 'CMD', watch: '$1 --additional-test-watch-options'});
     await p.run({isDev: true, log: jest.fn});
-    expect(execaFn.mock.calls[0][0]).toMatch('cmd --additional-test-watch-options');
+    expect(execaFn.mock.calls[0][0]).toMatch('CMD --additional-test-watch-options');
   });
   test('handles command output in "stream" mode', async () => {
     const logFn = jest.fn();
@@ -70,4 +68,8 @@ describe.skip('plugin-run-script', () => {
       ['WORKER_MSG', {level: 'log', msg: 'TEST_CLEAR_MESSAGE'}],
     ]);
   });
+  test('modify plugin name when specify name', async() => {
+    const p = plugin(null, {...DEFAULT_OPTIONS, output: 'dashboard', name: 'test'});
+    expect(p.name).toBe('test')
+  })
 });


### PR DESCRIPTION
Its useful run two same cli.

In old case, i cannot make a distinction between those

## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

`plugin-run-script` add new param which can modify display name of cmd by user

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

Add a testcase of specify name

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

Yep. update README.md of plugin-run-script
