### PR TITLE
reset etag with pathname only

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -1167,7 +1167,11 @@ export async function startDevServer(commandOptions: CommandOptions): Promise<Sn
         await result.checkStale();
       }
       if (result.contents) {
-        knownETags.set(reqPath, etag(result.contents, {weak: true}));
+        const tag = etag(result.contents, {weak: true});
+        knownETags.set(reqPath, tag);
+        if (reqPath.indexOf('?') >= 0) {
+          knownETags.set(reqPath.split('?', 2)[0], tag);
+        }
       }
       return;
     } catch (err) {

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -1145,15 +1145,15 @@ export async function startDevServer(commandOptions: CommandOptions): Promise<Sn
     res: http.ServerResponse,
     {handleError}: {handleError?: boolean} = {},
   ) {
-    const fullRequestUrl = req.url!;
+    const reqUrl = req.url!;
     // Check if a configured proxy matches the request.
-    const requestProxy = getRequestProxy(fullRequestUrl);
+    const requestProxy = getRequestProxy(reqUrl);
     if (requestProxy) {
       return requestProxy(req, res);
     }
     // Check if we can send back an optimized 304 response
     const quickETagCheck = req.headers['if-none-match'];
-    if (quickETagCheck && quickETagCheck === knownETags.get(fullRequestUrl)) {
+    if (quickETagCheck && quickETagCheck === knownETags.get(reqUrl)) {
       logger.debug(`optimized etag! sending 304...`);
       res.writeHead(304, {'Access-Control-Allow-Origin': '*'});
       res.end();
@@ -1161,7 +1161,7 @@ export async function startDevServer(commandOptions: CommandOptions): Promise<Sn
     }
     // Otherwise, load the file and respond if successful.
     try {
-      const result = await loadUrl(fullRequestUrl, {allowStale: true, encoding: null});
+      const result = await loadUrl(reqUrl, {allowStale: true, encoding: null});
       sendResponseFile(req, res, result);
       if (result.checkStale) {
         await result.checkStale();


### PR DESCRIPTION
try to fix https://github.com/snowpackjs/snowpack/issues/1409

## Changes

When running dev, if requesting url contains search part, then set etag to both origin url and pathname.

## Testing

Don't know how to simply test response code for dev mode.

## Docs

bug fix only
