### PR TITLE
fix hmr dispose of styleEl

### DIFF
--- a/snowpack/src/build/build-import-proxy.ts
+++ b/snowpack/src/build/build-import-proxy.ts
@@ -179,12 +179,15 @@ ${
     hmr
       ? `
 import * as __SNOWPACK_HMR_API__ from '${getMetaUrlPath('hmr-client.js', config)}';
-import.meta.hot = __SNOWPACK_HMR_API__.createHotContext(import.meta.url);
-import.meta.hot.dispose(() => {
-  document && document.head.removeChild(styleEl);
-});\n` : ``}
+import.meta.hot = __SNOWPACK_HMR_API__.createHotContext(import.meta.url);\n` : ``}
 // [snowpack] add styles to the page (skip if no document exists)
-if (typeof document !== 'undefined') {
+if (typeof document !== 'undefined') {${
+    hmr
+      ? `
+  import.meta.hot.dispose(() => {
+    document && document.head.removeChild(styleEl);
+  });\n`
+      : ``}
   const styleEl = document.createElement("style");
   const codeEl = document.createTextNode(code);
   styleEl.type = 'text/css';


### PR DESCRIPTION
try to fix #1412 

## Changes

Moves the `removeChild(styleEl)` call into the same scope that `styleEl` was created in. 

## Testing

Ran through the reproduction steps in the issue and then tried changing the color to see it update and no longer error.

## Docs

bug fix only