### PR TITLE
add onFileChanged hook to JS API

### DIFF
--- a/snowpack/src/types/snowpack.ts
+++ b/snowpack/src/types/snowpack.ts
@@ -18,6 +18,7 @@ export interface LoadResult<T = Buffer | string> {
   checkStale?: () => Promise<void>;
 }
 
+export type OnFileChangeCallback = ({filePath: string}) => any;
 export interface SnowpackDevServer {
   port: number;
   loadUrl: {
@@ -59,6 +60,7 @@ export interface SnowpackDevServer {
     {contents, originalFileLoc, responseFileName}: LoadResult,
   ) => void;
   sendResponseError: (req: http.IncomingMessage, res: http.ServerResponse, status: number) => void;
+  onFileChange: (callback: OnFileChangeCallback) => void;
   shutdown(): Promise<void>;
 }
 


### PR DESCRIPTION
## Changes

- Svelte team right now runs their own file watcher in @sveltejs/kit
- The result is that their SSR implementation doesn't get the same "on change" updates as dev
- By providing this hook, we make sure that all impl. on top of snowpack are consistent

## Testing

- No JS API tests yet.

## Docs

- No JS API docs yet.