### PR TITLE
test: add test for plugin-optimize target option

### DIFF
--- a/plugins/plugin-optimize/test/__snapshots__/plugin.test.js.snap
+++ b/plugins/plugin-optimize/test/__snapshots__/plugin.test.js.snap
@@ -37,13 +37,67 @@ FILE: stubs/minimal/index.html
 --------------------------------------------------------------------------------
 
 FILE: stubs/minimal/index.js
-import"./esm_example.js";import("./do-not-preload-3.js"),(()=>{function o(e){console.log(e)}o("test")})();
+import"./esm_example.js";import t from"./target-es2018.js";import("./do-not-preload-3.js"),(()=>{function o(e){console.log(e)}o("test",t())})();
 
 
 --------------------------------------------------------------------------------
 
 FILE: stubs/minimal/style.css
-body{border:1px solid red}
+body{border:1px solid #fff;margin:1px}
+
+--------------------------------------------------------------------------------
+
+FILE: stubs/minimal/target-es2018.js
+export default function n(){const o={bar:"bar"},t=null;return console.log(o?.bar,t??100),!0}
+
+`;
+
+exports[`@snowpack/plugin-optimize minimal - target: console.log 1`] = ``;
+
+exports[`@snowpack/plugin-optimize minimal - target: fs.writeFileSync 1`] = `
+FILE: stubs/minimal/do-not-preload-1.js
+console.error("Error: this file in a comment shouldn\\u2019t be preloaded");
+
+
+--------------------------------------------------------------------------------
+
+FILE: stubs/minimal/do-not-preload-2.js
+console.error("Error: this entry file shouldn\\u2019t be preloaded, either (it\\u2019s already in the entry)");
+
+
+--------------------------------------------------------------------------------
+
+FILE: stubs/minimal/do-not-preload-3.js
+console.error("Error: this lazy-loaded file should not be preloaded (then it\\u2019s not lazy-loaded)");
+
+
+--------------------------------------------------------------------------------
+
+FILE: stubs/minimal/esm_example.js
+export default function e(){return console.log("example"),1}
+
+
+--------------------------------------------------------------------------------
+
+FILE: stubs/minimal/index.html
+<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>Minimal test</title><link rel="stylesheet" href="style.css"></head><body><script type="module" src="index.js"></script><script type="module" src="./do-not-preload-2.js"></script></body></html>
+
+--------------------------------------------------------------------------------
+
+FILE: stubs/minimal/index.js
+import"./esm_example.js";import t from"./target-es2018.js";import("./do-not-preload-3.js"),(()=>{function o(e){console.log(e)}o("test",t())})();
+
+
+--------------------------------------------------------------------------------
+
+FILE: stubs/minimal/style.css
+body{border:1px solid #fff;margin:1px}
+
+--------------------------------------------------------------------------------
+
+FILE: stubs/minimal/target-es2018.js
+export default function n(){const o={bar:"bar"},t=null;return console.log(o==null?void 0:o.bar,t!=null?t:100),!0}
+
 `;
 
 exports[`@snowpack/plugin-optimize no HTML minification, with preloadModules: console.log 1`] = ``;
@@ -82,13 +136,14 @@ FILE: stubs/minimal/index.html
     <link rel="stylesheet" href="style.css" />
     <!-- [@snowpack/plugin-optimize] Add modulepreload to improve unbundled load performance (More info: https://developers.google.com/web/updates/2017/12/modulepreload) -->
     <link rel="modulepreload" href="/esm_example.js" />
+    <link rel="modulepreload" href="/target-es2018.js" />
   </head>
   <body>
     <script type="module" src="index.js"></script>
     <!-- <script type="module" src="./do-not-preload-1.js"></script> -->
     <script type="module" src="./do-not-preload-2.js"></script>
     <!-- [@snowpack/plugin-optimize] modulepreload fallback for browsers that do not support it yet -->
-    <script type="module" src="/esm_example.js"></script>
+    <script type="module" src="/esm_example.js"></script><script type="module" src="/target-es2018.js"></script>
   </body>
 </html>
 
@@ -96,11 +151,17 @@ FILE: stubs/minimal/index.html
 --------------------------------------------------------------------------------
 
 FILE: stubs/minimal/index.js
-import"./esm_example.js";import("./do-not-preload-3.js"),(()=>{function o(e){console.log(e)}o("test")})();
+import"./esm_example.js";import t from"./target-es2018.js";import("./do-not-preload-3.js"),(()=>{function o(e){console.log(e)}o("test",t())})();
 
 
 --------------------------------------------------------------------------------
 
 FILE: stubs/minimal/style.css
-body{border:1px solid red}
+body{border:1px solid #fff;margin:1px}
+
+--------------------------------------------------------------------------------
+
+FILE: stubs/minimal/target-es2018.js
+export default function n(){const o={bar:"bar"},t=null;return console.log(o?.bar,t??100),!0}
+
 `;

--- a/plugins/plugin-optimize/test/plugin.test.js
+++ b/plugins/plugin-optimize/test/plugin.test.js
@@ -73,4 +73,22 @@ describe('@snowpack/plugin-optimize', () => {
     expect(fs.writeFileSync).toMatchSnapshot('fs.writeFileSync');
     expect(console.log).toMatchSnapshot('console.log');
   });
+
+  it('minimal - target', async () => {
+    const pluginInstance = plugin(
+      {
+        buildOptions: {},
+      },
+      {
+        target: ['es2018']
+      },
+    );
+
+    await pluginInstance.optimize({
+      buildDirectory: path.resolve(__dirname, 'stubs/minimal'),
+    });
+
+    expect(fs.writeFileSync).toMatchSnapshot('fs.writeFileSync');
+    expect(console.log).toMatchSnapshot('console.log');
+  });
 });

--- a/plugins/plugin-optimize/test/stubs/minimal/index.js
+++ b/plugins/plugin-optimize/test/stubs/minimal/index.js
@@ -1,9 +1,10 @@
 import esm_example from './esm_example.js';
+import supportTarget from './target-es2018.js';
 import('./do-not-preload-3.js');
 
 (() => {
   function n(o) {
     console.log(o);
   }
-  n('test');
+  n('test', supportTarget());
 })();

--- a/plugins/plugin-optimize/test/stubs/minimal/style.css
+++ b/plugins/plugin-optimize/test/stubs/minimal/style.css
@@ -1,1 +1,4 @@
-body{border:1px solid red}
+body {
+  border: 1px solid #ffffff;
+  margin: 1px 1px 1px 1px;
+}

--- a/plugins/plugin-optimize/test/stubs/minimal/target-es2018.js
+++ b/plugins/plugin-optimize/test/stubs/minimal/target-es2018.js
@@ -1,0 +1,9 @@
+export default function testTarget() {
+  // es2020 - Optional Chaining & Nullish coalescing Operator
+  const foo = {
+    bar: 'bar'
+  };
+  const bar = null;
+  console.log(foo?.bar, bar ?? 100);
+  return true;
+}


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

There is no test for `@snowpack/plugin-optimize` target option.
Add test for `@snowpack/plugin-optimize` target option, which transform `es2020` to `es2018`.

No target option:
<img width="633" alt="Screen Shot 2020-10-31 at 15 32 11" src="https://user-images.githubusercontent.com/23313266/97773862-5167df80-1b8e-11eb-951f-8e39c52d8624.png">

`target: ["es2018"]`:
<img width="627" alt="Screen Shot 2020-10-31 at 15 31 47" src="https://user-images.githubusercontent.com/23313266/97773869-66447300-1b8e-11eb-8369-445971cf5600.png">


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->
Add test for `@snowpack/plugin-optimize` target option.


## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
No docs added.