### PR TITLE
Update docs for troubleshooting TypeScript named interface imports

### DIFF
--- a/docs/09-troubleshooting.md
+++ b/docs/09-troubleshooting.md
@@ -18,6 +18,8 @@ If you see this error message, that means that you've imported a file path not a
 
 ### Uncaught SyntaxError: The requested module '/web_modules/XXXXXX.js' does not provide an export named 'YYYYYY'
 
+#### Legacy Common.js Packages
+
 This is usually seen when importing a named export from a package written in the older Common.js format. Snowpack will automatically scan legacy Common.js packages to detect its named exports, but sometimes these exports can't be detected statically.
 
 **To solve this issue:** Add a ["namedExports"](#config.installoptions) entry in your Snowpack config file. This tells Snowpack to use a more-powerful runtime scanner on this legacy Common.js package to detect it's exports at runtime.
@@ -29,6 +31,12 @@ This is usually seen when importing a named export from a package written in the
   "namedExports": ["xterm"]
 }
 ```
+
+#### TypeScript imports
+
+This could occur if you're attempting to import a named interface or other type from another compiled TypeScript file.
+
+**To solve this issue:** Make sure to use `import type { MyInterfaceName }` instead.
 
 ### Installing Non-JS Packages
 


### PR DESCRIPTION
## Changes
When importing a named interface from TypeScript, a normal `import` causes this error. I didn't see any documentation about this, but was able to find a previously-accepted solution from other discussions:

https://www.pika.dev/npm/snowpack/discuss/131
https://github.com/snowpackjs/snowpack/pull/234#issuecomment-594276513

I wanted to add this to the docs to avoid other users from running into this same problem.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing
* No testing applicable 

## Docs
* Added docs to help TypeScript users troubleshoot a class of `The requested module ‘/web_modules/XXXXXX.js’ does not provide an export named ‘YYYYYY’` issues
