### PR TITLE
plugin-webpack: clean intermediary files from output directory

### DIFF
--- a/plugins/plugin-webpack/README.md
+++ b/plugins/plugin-webpack/README.md
@@ -111,3 +111,23 @@ The default options are:
   removeStyleLinkTypeAttributes: true,
 }
 ```
+
+#### Including static assets
+
+This plugin will remove any files from the output directory that aren't
+`import`ed anywhere in the source files, unless they are mounted via a
+static mount. If you need to include files in your output without `import`ing
+them (eg. for reference via manually-built URLs), then they must be mounted
+in Snowpack under a static mount:
+
+```js
+// snowpack.config.js
+module.exports = {
+  mount: {
+    myStaticAssets: {
+      url: '/my-static-assets',
+      static: true,
+    },
+  },
+};
+```

--- a/plugins/plugin-webpack/package.json
+++ b/plugins/plugin-webpack/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@babel/core": "^7.0.0",
     "babel-loader": "^8.1.0",
+    "clean-webpack-plugin": "^3.0.0",
     "core-js": "^3.5.0",
     "css-loader": "^4.3.0",
     "file-loader": "^6.0.0",


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Fixes #1439. When using `@snowpack/plugin-webpack`, removes all files/directories from the output directory unless they are either:

1. Part of Webpack's output, or
2. Mounted under a static mount (`static: true` in `config.mount`).

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

No tests were added/changed, as I wasn't clear on how to extend `plugin.test.js` to cover the uses cases in this PR. I did, however, test it by verifying that it worked properly when used as part of the application I'm working on.

**This does break the existing tests**, however, since the `CleanWebpackPlugin` seems to delete the stub files in `test/stubs/minimal/**`. I don't know what can be done to solve this.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

I've added a section to the plugin's documentation that explains that the output directory will be cleaned, and that to include static assets they must be mounted under a static mount.