### PR TITLE
Allow aliasing npm packages to custom files

### DIFF
--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -31,12 +31,12 @@ import {
   createInstallTarget,
   findMatchingAliasEntry,
   getWebDependencyName,
-  isPackageAliasEntry,
   MISSING_PLUGIN_SUGGESTIONS,
   parsePackageImportSpecifier,
   resolveDependencyManifest,
   sanitizePackageName,
   writeLockfile,
+  removeTrailingSlash,
 } from './util';
 
 export * from './types';
@@ -363,12 +363,10 @@ ${colors.dim(
     treeshake: {moduleSideEffects: 'no-external'},
     plugins: [
       rollupPluginAlias({
-        entries: Object.entries(installAlias)
-          .filter(([, val]) => isPackageAliasEntry(val))
-          .map(([key, val]) => ({
-            find: key,
-            replacement: val,
-          })),
+        entries: Object.entries(installAlias).map(([key, val]) => ({
+          find: key,
+          replacement: removeTrailingSlash(val),
+        })),
       }),
       rollupPluginCatchFetch(),
       rollupPluginNodeResolve({


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

The docs state that aliases "[apply] to imports inside of your dependencies as well, essentially replacing all references to the aliased package." However, this is only true for aliases that point to packages. Aliases that point to a local file/directory do take effect in project files, but aren't applied to imports in npm dependencies.

This fixes aliases such that all aliases are applied to all files, regardless of whether the alias is to a package or not, and regardless of if the file is a project file or npm dependency.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

No tests were written for this change, as I have no idea how to test it :disappointed: 

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

No docs changed - "bug fix only".

## Motivation

As an example, we have some old jQuery plugins that expect to be able to mutate the jQuery global object. Mutations to ES6 imports don't change what other modules receive from their imports, though. In order to apply the jQuery plugins to jQuery, we've had to write a file that imports jQuery, applies the plugins, and then exports the modified jQuery object - but we need all modules (including third-party dependencies) to be given the export from this custom jQuery module instead of the default jQuery. Hence we need aliases to our custom jQuery file to be applied to dependencies as well as project files.