### PR TITLE
Add svelte to packageLookupFields

### DIFF
--- a/plugins/plugin-svelte/plugin.js
+++ b/plugins/plugin-svelte/plugin.js
@@ -18,6 +18,8 @@ module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
   snowpackConfig.installOptions.rollup.plugins.push(
     svelteRollupPlugin({include: '**/node_modules/**', dev: isDev}),
   );
+  // Support importing sharable Svelte components.
+  snowpackConfig.installOptions.packageLookupFields.push('svelte');
 
   if (
     pluginOptions.generate !== undefined ||

--- a/plugins/plugin-svelte/test/plugin.test.js
+++ b/plugins/plugin-svelte/test/plugin.test.js
@@ -6,10 +6,19 @@ jest.mock('svelte/compiler', () => ({compile: mockCompiler, preprocess: mockPrep
 
 const plugin = require('../plugin');
 
-const mockConfig = {buildOptions: {sourceMaps: false}, installOptions: {rollup: {plugins: []}}};
+let mockConfig;
 const mockComponent = path.join(__dirname, 'Button.svelte');
 
 describe('@snowpack/plugin-svelte (mocked)', () => {
+  beforeEach(()=>{
+    mockConfig = {
+      buildOptions: {sourceMaps: false},
+      installOptions: {
+        rollup: {plugins: []},
+        packageLookupFields: [],
+      },
+    };
+  })
   afterEach(() => {
     mockCompiler.mockClear();
     mockPreprocessor.mockClear();
@@ -127,5 +136,12 @@ describe('@snowpack/plugin-svelte (mocked)', () => {
         ".svx",
       ]
     `);
+  });
+  it('supports importing svelte components', async () => {
+    plugin(mockConfig,{});
+    expect(mockConfig.installOptions.packageLookupFields).toEqual(['svelte']);
+    mockConfig.installOptions.packageLookupFields = ['module'];
+    plugin(mockConfig,{});
+    expect(mockConfig.installOptions.packageLookupFields).toEqual(['module', 'svelte']);
   });
 });


### PR DESCRIPTION
## Changes
Makes plugin-svelte append 'svelte' to snowpack's `packageLookupFields`.
Used for importing svelte sharable components into svelte apps.

## Testing

Add test to ensure `packageLookupFields` field changed as expected.

## Docs

No docs added. I believe it would belong in lower level docs than any existing documentation.
