### PR TITLE
Fix sourcemap plugin

### DIFF
--- a/esinstall/src/rollup-plugins/rollup-plugin-strip-source-mapping.ts
+++ b/esinstall/src/rollup-plugins/rollup-plugin-strip-source-mapping.ts
@@ -9,7 +9,9 @@ export function rollupPluginStripSourceMapping(): Plugin {
   return {
     name: 'snowpack:rollup-plugin-strip-source-mapping',
     transform: (code) => ({
-      code: code.replace(/[^'"`]\/\/+#\s*sourceMappingURL=.+$/gm, ''),
+      code: code
+        // [a-zA-Z0-9-_\*?\.\/\&=+%]: valid URL characters (for sourcemaps)
+        .replace(/\/\/#\s*sourceMappingURL=[a-zA-Z0-9-_\*\?\.\/\&=+%\s]+$/gm, ''),
       map: null,
     }),
   };

--- a/test/rollup-plugins.test.js
+++ b/test/rollup-plugins.test.js
@@ -1,0 +1,49 @@
+const {
+  rollupPluginStripSourceMapping,
+} = require('../esinstall/lib/rollup-plugins/rollup-plugin-strip-source-mapping.js');
+
+describe('snowpack:rollup-plugin-strip-source-mapping', () => {
+  const tests = [
+    {
+      name: 'inline',
+      given: `console.log('foo');//# sourceMappingURL=js.map.js`,
+      expected: `console.log('foo');`,
+    },
+    {
+      name: 'end of file',
+      given: `console.log('foo');
+//# sourceMappingURL=js.map.js`,
+      expected: `console.log('foo');
+`,
+    },
+    {
+      name: 'middle of file',
+      given: `console.log('foo');
+//# sourceMappingURL=js.map.js
+console.log('bar');
+  //# sourceMappingURL=js.map.js`,
+      expected: `console.log('foo');
+
+console.log('bar');
+  `,
+    },
+    {
+      name: 'inside string', // leave alone
+      given: `const myString ='//# sourceMappingURL=js.map.js';`,
+      expected: `const myString ='//# sourceMappingURL=js.map.js';`,
+    },
+    {
+      name: 'es-module-shim', // leave alone
+      given: `    sourceMappingResolved = \`\n//# sourceMappingURL=\` + resolveUrl(sourceMapping.slice(21), load.r);`,
+      expected: `    sourceMappingResolved = \`\n//# sourceMappingURL=\` + resolveUrl(sourceMapping.slice(21), load.r);`,
+    },
+  ];
+
+  const {transform} = rollupPluginStripSourceMapping();
+
+  tests.forEach(({name, given, expected}) => {
+    it(name, () => {
+      expect(transform(given).code).toBe(expected);
+    });
+  });
+});


### PR DESCRIPTION
## Changes

Was investigating CDN issues and came across https://github.com/snowpackjs/skypack-cdn/issues/22. Guy Bedford’s `es-module-shims` package won’t load because our builtin Rollup plugin catches the following line:

```js
      sourceMappingResolved = `\n//# sourceMappingURL=` + resolveUrl(sourceMapping.slice(21), load.r);
```

As a result this package couldn’t be installed.

This changes the RegEx to handle end-of-file (single line) differently than middle-of-file
- **end of file**: if this comment occurs at the end of the file and nothing follows it, remove
- **middle of file**: this **MUST** occur on its own line (otherwise it‘s not a comment)

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

New snapshot was added for this 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
