### PR TITLE
Fix: use the response handler

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -1196,10 +1196,10 @@ export async function startDevServer(commandOptions: CommandOptions): Promise<Sn
         responseHandler as Http2RequestListener,
       );
     } else if (credentials) {
-      return https.createServer(credentials, handleRequest);
+      return https.createServer(credentials, responseHandler as http.RequestListener);
     }
 
-    return http.createServer(handleRequest);
+    return http.createServer(responseHandler as http.RequestListener);
   };
 
   const server = createServer(async (req, res) => {


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
Utilizes the `responseHandler` variable which will properly check if `config.expirements.app` is set before calling the `requestHandler`.

Fixes the bug found in https://github.com/snowpackjs/snowpack/discussions/1514

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->
Manually tested

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
Bug fix only
