### PR TITLE
Adding "@babel/preset-env" to Webpack plugin dependencies

### DIFF
--- a/plugins/plugin-webpack/package.json
+++ b/plugins/plugin-webpack/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.0.0",
+    "@babel/preset-env": "^7.12.1",
     "babel-loader": "^8.1.0",
     "core-js": "^3.5.0",
     "css-loader": "^4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1053,7 +1053,7 @@
     levenary "^1.1.1"
     semver "^5.5.0"
 
-"@babel/preset-env@^7.10.4":
+"@babel/preset-env@^7.10.4", "@babel/preset-env@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.12.1.tgz#9c7e5ca82a19efc865384bb4989148d2ee5d7ac2"
   integrity sha512-H8kxXmtPaAGT7TyBvSSkoSTUK6RHh61So05SyEbpmr0MCZrsNYn7mGMzzeYoOUCdHzww61k8XBft2TaES+xPLg==


### PR DESCRIPTION
## Changes

When using the Webpack plugin, I got this error when trying to build
```
Module build failed (from ../node_modules/babel-loader/lib/index.js):
Error: Cannot find module '@babel/preset-env' from '/Users/melissamcewen/Sites/my-first-snowpack/build'
```

## Testing

TBA
## Docs

Bug fix only
