### PR TITLE
add init command, remove no command behavior

### DIFF
--- a/snowpack/assets/snowpack-init-file.js
+++ b/snowpack/assets/snowpack-init-file.js
@@ -1,0 +1,11 @@
+// Snowpack Configuration File
+// See all supported options: https://www.snowpack.dev/#configuration
+
+/** @type {import("snowpack").SnowpackUserConfig } */
+module.exports = {
+  // mount: {},
+  // plugins: [],
+  // installOptions: {},
+  // devOptions: {},
+  // buildOptions: {},
+};

--- a/snowpack/src/commands/init.ts
+++ b/snowpack/src/commands/init.ts
@@ -5,7 +5,7 @@ import {logger} from '../logger';
 import {CommandOptions} from '../types/snowpack';
 
 export async function command(commandOptions: CommandOptions) {
-  const {cwd, config, pkgManifest} = commandOptions;
+  const {cwd} = commandOptions;
   logger.info(`Creating new project configuration file... ${dim('(snowpack.config.js)')}`);
   const templateLoc = path.join(__dirname, '../../assets/snowpack-init-file.js');
   const destLoc = path.join(cwd, 'snowpack.config.js');

--- a/snowpack/src/commands/init.ts
+++ b/snowpack/src/commands/init.ts
@@ -1,0 +1,18 @@
+import {promises as fs, existsSync, constants as fsConstants} from 'fs';
+import {bold, dim} from 'kleur/colors';
+import path from 'path';
+import {logger} from '../logger';
+import {CommandOptions} from '../types/snowpack';
+
+export async function command(commandOptions: CommandOptions) {
+  const {cwd, config, pkgManifest} = commandOptions;
+  logger.info(`Creating new project configuration file... ${dim('(snowpack.config.js)')}`);
+  const templateLoc = path.join(__dirname, '../../assets/snowpack-init-file.js');
+  const destLoc = path.join(cwd, 'snowpack.config.js');
+  if (existsSync(destLoc)) {
+    logger.error(`Error: File already exists, cannot overwrite ${destLoc}`);
+    process.exit(1);
+  }
+  await fs.copyFile(templateLoc, destLoc, fsConstants.COPYFILE_EXCL);
+  logger.info(`File created! Open ${bold('snowpack.config.js')} to customize your project.`);
+}

--- a/snowpack/src/index.ts
+++ b/snowpack/src/index.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import util from 'util';
 import yargs from 'yargs-parser';
 import {addCommand, rmCommand} from './commands/add-rm';
+import {command as initCommand} from './commands/init';
 import {command as buildCommand} from './commands/build';
 import {command as devCommand} from './commands/dev';
 import {command as installCommand} from './commands/install';
@@ -44,6 +45,7 @@ ${colors.bold(`snowpack`)} - A faster build system for the modern web.
   📖 ${colors.dim('https://www.snowpack.dev/#configuration')}
 
 ${colors.bold('Commands:')}
+  snowpack init         Create a new project config file.
   snowpack dev          Develop your app locally.
   snowpack build        Build your app for production.
   snowpack install      (Advanced) Install web-ready dependencies.
@@ -92,8 +94,12 @@ export async function cli(args: string[]) {
     process.exit(1);
   }
 
-  const cmd = cliFlags['_'][2] || 'install';
+  const cmd = cliFlags['_'][2];
   logger.debug(`run command: ${cmd}`);
+  if (!cmd) {
+    printHelp();
+    process.exit(1);
+  }
 
   // Set this early -- before config loading -- so that plugins see it.
   if (cmd === 'build') {
@@ -129,6 +135,10 @@ export async function cli(args: string[]) {
     process.exit(1);
   }
 
+  if (cmd === 'init') {
+    await initCommand(commandOptions);
+    return process.exit(0);
+  }
   if (cmd === 'build') {
     await buildCommand(commandOptions);
     return process.exit(0);

--- a/test/esinstall/auto-named-exports/package.json
+++ b/test/esinstall/auto-named-exports/package.json
@@ -4,7 +4,7 @@
   "name": "@snowpack/test-auto-named-exports",
   "description": "Handle automatic named export detection for cjs packages",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "install": [

--- a/test/esinstall/config-alias/package.json
+++ b/test/esinstall/config-alias/package.json
@@ -4,7 +4,7 @@
   "name": "@snowpack/test-config-alias",
   "description": "Handle deep imports to package entrypoints",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "alias": {

--- a/test/esinstall/config-custom-path/package.json
+++ b/test/esinstall/config-custom-path/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-config-custom-path",
   "scripts": {
-    "testinstall": "snowpack --config snowpack.dev.json"
+    "testinstall": "snowpack install --config snowpack.dev.json"
   },
   "dependencies": {
     "array-flatten": "^3.0.0",

--- a/test/esinstall/config-extends/package.json
+++ b/test/esinstall/config-extends/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-config-extends",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "dependencies": {
     "array-flatten": "^3.0.0"

--- a/test/esinstall/config-external/package.json
+++ b/test/esinstall/config-external/package.json
@@ -4,7 +4,7 @@
   "name": "@snowpack/test-config-external",
   "description": "Handle external packages",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "installOptions": {

--- a/test/esinstall/config-named-exports/package.json
+++ b/test/esinstall/config-named-exports/package.json
@@ -4,7 +4,7 @@
   "name": "@snowpack/test-config-named-exports",
   "description": "Handle installOptions.namedExports",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "install": [

--- a/test/esinstall/config-package-lookup-fields/package.json
+++ b/test/esinstall/config-package-lookup-fields/package.json
@@ -4,7 +4,7 @@
   "name": "@snowpack/test-config-package-lookup-fields",
   "description": "Handle custom packageLookupFields",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "installOptions": {

--- a/test/esinstall/config-polyfill-node/package.json
+++ b/test/esinstall/config-polyfill-node/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-config-polyfill-node",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "exclude": [

--- a/test/esinstall/config-rollup/package.json
+++ b/test/esinstall/config-rollup/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-config-rollup",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "dependencies": {
     "rollup-plugin-svelte": "^6.0.0",

--- a/test/esinstall/config-with-cli-flags/package.json
+++ b/test/esinstall/config-with-cli-flags/package.json
@@ -4,7 +4,7 @@
   "name": "@snowpack/test-config-with-cli-flags",
   "description": "Test that the --optimize flag overrides the config",
   "scripts": {
-    "testinstall": "snowpack --no-source-map"
+    "testinstall": "snowpack install --no-source-map"
   },
   "snowpack": {
     "install": [

--- a/test/esinstall/dep-browser-entrypoint-object/package.json
+++ b/test/esinstall/dep-browser-entrypoint-object/package.json
@@ -4,7 +4,7 @@
   "name": "@snowpack/test-dep-browser-entrypoint-object",
   "description": "Test that we properly handle a package.json 'browser' object.",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "install": [

--- a/test/esinstall/dep-exports/package.json
+++ b/test/esinstall/dep-exports/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-dep-exports",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "install": [

--- a/test/esinstall/dep-list-complex/package.json
+++ b/test/esinstall/dep-list-complex/package.json
@@ -4,7 +4,7 @@
   "name": "@snowpack/test-dep-list-complex",
   "description": "Test packages with tricky names",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "install": [

--- a/test/esinstall/dep-list-css/package.json
+++ b/test/esinstall/dep-list-css/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-dep-list-css",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "dependencies": {
     "css-mock-pkg-a": "file:./packages/css-mock-pkg-a",

--- a/test/esinstall/dep-list-simple/package.json
+++ b/test/esinstall/dep-list-simple/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-dep-list-simple",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "install": [

--- a/test/esinstall/dep-node-fetch/package.json
+++ b/test/esinstall/dep-node-fetch/package.json
@@ -4,7 +4,7 @@
   "name": "@snowpack/test-dep-node-fetch",
   "description": "Handle specific node.js fetch polyfill packages",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "install": [

--- a/test/esinstall/dep-remote-url/package.json
+++ b/test/esinstall/dep-remote-url/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-dep-remote-url",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "install": [

--- a/test/esinstall/dep-types-only/package.json
+++ b/test/esinstall/dep-types-only/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-dep-types-only",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "install": [

--- a/test/esinstall/error-config-invalid/package.json
+++ b/test/esinstall/error-config-invalid/package.json
@@ -4,7 +4,7 @@
   "name": "@snowpack/test-config-invalid",
   "description": "Test invalid configuration (install should be array)",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "install": "shallow-equal"

--- a/test/esinstall/error-empty-dep-list/package.json
+++ b/test/esinstall/error-empty-dep-list/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-error-empty-dep-list",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "install": []

--- a/test/esinstall/error-file-ext/package.json
+++ b/test/esinstall/error-file-ext/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-error-file-ext",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "install": [

--- a/test/esinstall/error-illegal-env-var/package.json
+++ b/test/esinstall/error-illegal-env-var/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-error-illegal-env-var",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "installOptions": {

--- a/test/esinstall/error-include-ignore-unsupported-files/package.json
+++ b/test/esinstall/error-include-ignore-unsupported-files/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-include-ignore-unsupported-files",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "devDependencies": {
     "snowpack": "^2.14.3"

--- a/test/esinstall/error-missing-dep/package.json
+++ b/test/esinstall/error-missing-dep/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-error-missing-dep",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "install": [

--- a/test/esinstall/error-missing-exports/package.json
+++ b/test/esinstall/error-missing-exports/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-error-missing-exports",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "install": [

--- a/test/esinstall/error-no-dep-list/package.json
+++ b/test/esinstall/error-no-dep-list/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-error-no-dep-list",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {},
   "devDependencies": {

--- a/test/esinstall/error-node-builtin-unresolved/package.json
+++ b/test/esinstall/error-node-builtin-unresolved/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-error-node-builtin-unresolved",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "exclude": [

--- a/test/esinstall/error-react-source-pika/package.json
+++ b/test/esinstall/error-react-source-pika/package.json
@@ -4,7 +4,7 @@
   "name": "@snowpack/test-error-react-source-pika",
   "description": "Test that error is reported when React workaround package is used.",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "webDependencies": {
     "async": "~3.0.0",

--- a/test/esinstall/error-react-workaround/package.json
+++ b/test/esinstall/error-react-workaround/package.json
@@ -4,7 +4,7 @@
   "name": "@snowpack/test-error-react-workaround",
   "description": "Test that error is reported when React workaround package is used.",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "install": [

--- a/test/esinstall/exclude-external-packages/package.json
+++ b/test/esinstall/exclude-external-packages/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-exclude-external-packages",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "install": [

--- a/test/esinstall/exclude/package.json
+++ b/test/esinstall/exclude/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-exclude",
   "scripts": {
-    "testinstall": "snowpack  --exclude 'src/exclude.js'"
+    "testinstall": "snowpack install --exclude 'src/exclude.js'"
   },
   "snowpack": {
     "buildOptions": {

--- a/test/esinstall/export-maps/package.json
+++ b/test/esinstall/export-maps/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-export-maps",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "install": [

--- a/test/esinstall/include-missing-in-package-json/package.json
+++ b/test/esinstall/include-missing-in-package-json/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-include-missing-in-package-json",
   "scripts": {
-    "testinstall": "node copyPackages && snowpack"
+    "testinstall": "node copyPackages && snowpack install"
   },
   "snowpack": {
     "mount": {

--- a/test/esinstall/include-ts/package.json
+++ b/test/esinstall/include-ts/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-include-ts",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "buildOptions": {

--- a/test/esinstall/include-with-alias/package.json
+++ b/test/esinstall/include-with-alias/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-include-with-alias",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "buildOptions": {

--- a/test/esinstall/include-with-package-name/package.json
+++ b/test/esinstall/include-with-package-name/package.json
@@ -4,7 +4,7 @@
   "name": "@snowpack/test-include-with-package-name",
   "description": "Test that 'include' import scanner supports package name imports",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "buildOptions": {

--- a/test/esinstall/include/package.json
+++ b/test/esinstall/include/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-include",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "buildOptions": {

--- a/test/esinstall/legacy-mount-alias/package.json
+++ b/test/esinstall/legacy-mount-alias/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "snowpack-install-test-top-level-imports",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "dependencies": {
     "array-flatten": "^3.0.0"

--- a/test/esinstall/node-env/package.json
+++ b/test/esinstall/node-env/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-node-env",
   "scripts": {
-    "testinstall": "cross-env CLI_A=cli CONF_A=alpha ./node_modules/.bin/snowpack --env NODE_ENV=FOOBAR --env CLI_A"
+    "testinstall": "cross-env CLI_A=cli CONF_A=alpha ./node_modules/.bin/snowpack install --env NODE_ENV=FOOBAR --env CLI_A"
   },
   "snowpack": {
     "install": [

--- a/test/esinstall/package-react/package.json
+++ b/test/esinstall/package-react/package.json
@@ -4,7 +4,7 @@
   "name": "@snowpack/test-package-react",
   "description": "Ensures React still works",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "install": [

--- a/test/esinstall/source-map-strip/package.json
+++ b/test/esinstall/source-map-strip/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-source-map-strip",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "install": [

--- a/test/esinstall/sub-package-json/package.json
+++ b/test/esinstall/sub-package-json/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "name": "@snowpack/test-sub-package-json",
   "scripts": {
-    "testinstall": "snowpack"
+    "testinstall": "snowpack install"
   },
   "snowpack": {
     "install": [


### PR DESCRIPTION
## Changes

- Remove "no command' behavior (previously would run install.) This was legacy v1 behavior that was never documented as supported, so we now show the help command with an error exit code. You could definitely consider this a breaking change, but given that it was not documented and is now an error with obvious help output, I feel okay making this change.

## Testing

- No tests added

## Docs

- Added to docs output, @melissamcewen would love if you could incorporate this into the new Getting Started guide.
