### PR TITLE
Don't let deepmerge merge instantiated objects

### DIFF
--- a/snowpack/package.json
+++ b/snowpack/package.json
@@ -68,6 +68,7 @@
     "glob": "^7.1.4",
     "http-proxy": "^1.18.1",
     "httpie": "^1.1.2",
+    "is-plain-object": "^5.0.0",
     "isbinaryfile": "^4.0.6",
     "jsonschema": "~1.2.5",
     "kleur": "^4.1.1",

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -4,6 +4,7 @@ import {cosmiconfigSync} from 'cosmiconfig';
 import {all as merge} from 'deepmerge';
 import * as esbuild from 'esbuild';
 import http from 'http';
+import {isPlainObject} from 'is-plain-object';
 import {validate, ValidatorResult} from 'jsonschema';
 import os from 'os';
 import path from 'path';
@@ -855,7 +856,9 @@ export function createConfiguration(
   if (validationErrors.length > 0) {
     return [validationErrors, undefined];
   }
-  const mergedConfig = merge<SnowpackConfig>([DEFAULT_CONFIG, config]);
+  const mergedConfig = merge<SnowpackConfig>([DEFAULT_CONFIG, config], {
+    isMergeableObject: isPlainObject,
+  });
   return [null, normalizeConfig(mergedConfig)];
 }
 
@@ -959,7 +962,9 @@ export function loadAndValidateConfig(flags: CLIFlags, pkgManifest: any): Snowpa
     {webDependencies: pkgManifest.webDependencies},
     config,
     cliConfig as any,
-  ]);
+  ], {
+    isMergeableObject: isPlainObject,
+  });
   for (const webDependencyName of Object.keys(mergedConfig.webDependencies || {})) {
     if (pkgManifest.dependencies && pkgManifest.dependencies[webDependencyName]) {
       handleConfigError(

--- a/test/build/config-instantiated-object/__snapshots__
+++ b/test/build/config-instantiated-object/__snapshots__
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snowpack build config-instantiated-object: allFiles 1`] = `
+Array [
+  "__snowpack__/env.js",
+  "_dist_/index.js",
+]
+`;
+
+exports[`snowpack build config-instantiated-object: build/__snowpack__/env.js 1`] = `"export default {\\"MODE\\":\\"production\\",\\"NODE_ENV\\":\\"production\\",\\"SSR\\":false};"`;
+
+exports[`snowpack build config-instantiated-object: build/_dist_/index.js 1`] = `"console.log('fooey');"`;

--- a/test/build/config-instantiated-object/dummy-plugin.js
+++ b/test/build/config-instantiated-object/dummy-plugin.js
@@ -1,0 +1,11 @@
+module.exports = (snowpackConfig, { instance }) => {
+    if(!instance.prop) {
+        throw new Error("simple prop value didn't make it");
+    }
+    
+    if(!instance.method) {
+        throw new Error("method value didn't make it");
+    }
+
+    return { name : "dummy-plugin" };
+};

--- a/test/build/config-instantiated-object/package.json
+++ b/test/build/config-instantiated-object/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "version": "1.0.1",
+  "name": "@snowpack/test-config-instantiated-object",
+  "description": "Test for plugin options using instantiated objects",
+  "scripts": {
+    "testbuild": "snowpack build"
+  },
+  "devDependencies": {
+    "cross-env": "^7.0.2",
+    "snowpack": "^2.14.3"
+  }
+}

--- a/test/build/config-instantiated-object/snowpack.config.js
+++ b/test/build/config-instantiated-object/snowpack.config.js
@@ -1,0 +1,18 @@
+class Instantiable {
+	constructor() {
+		this.prop = true;
+	}
+
+	method() {}
+}
+
+const instance = new Instantiable();
+
+module.exports = {
+  mount: {
+    './src': '/_dist_',
+  },
+  plugins: [
+    [ "./dummy-plugin.js", { instance } ]
+  ]
+};

--- a/test/build/config-instantiated-object/src/index.js
+++ b/test/build/config-instantiated-object/src/index.js
@@ -1,0 +1,1 @@
+console.log('fooey');

--- a/test/build/config-js-file/__snapshots__
+++ b/test/build/config-js-file/__snapshots__
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snowpack build config-js-file: allFiles 1`] = `
+Array [
+  "__snowpack__/env.js",
+  "_dist_/index.js",
+]
+`;
+
+exports[`snowpack build config-js-file: build/__snowpack__/env.js 1`] = `"export default {\\"MODE\\":\\"production\\",\\"NODE_ENV\\":\\"production\\",\\"SSR\\":false};"`;
+
+exports[`snowpack build config-js-file: build/_dist_/index.js 1`] = `"console.log('fooey');"`;

--- a/test/build/config-js-file/package.json
+++ b/test/build/config-js-file/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "version": "1.0.1",
+  "name": "@snowpack/test-config-js-file",
+  "description": "Test for a js config file",
+  "scripts": {
+    "testbuild": "snowpack build"
+  },
+  "devDependencies": {
+    "cross-env": "^7.0.2",
+    "snowpack": "^2.14.3"
+  }
+}

--- a/test/build/config-js-file/snowpack.config.js
+++ b/test/build/config-js-file/snowpack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  mount: {
+    './src': '/_dist_',
+  },
+};

--- a/test/build/config-js-file/src/index.js
+++ b/test/build/config-js-file/src/index.js
@@ -1,0 +1,1 @@
+console.log('fooey');


### PR DESCRIPTION
## Changes

Fixes #1416

Uses `is-plain-object` package and the `isMergeableObject` option in `deepmerge` to prevent it from copying properties around from non plain objects, which strips method off of `class` instances at the very least.

## Testing

- Added a test for a plain `snowpack.config.js` file because it didn't exist yet
- Copied that test and used it as a basis for testing the specific change to fix #1416 

## Docs

TODO: Should docs be updated for this? I'm not sure, but am happy to do that if it makes sense.
