### PR TITLE
plugin-react-refresh: fix global variable 'exports' leak

### DIFF
--- a/plugins/plugin-react-refresh/plugin.js
+++ b/plugins/plugin-react-refresh/plugin.js
@@ -18,13 +18,15 @@ function transformHtml(contents) {
     `$&
 <script>
   function debounce(e,t){let u;return()=>{clearTimeout(u),u=setTimeout(e,t)}}
-  const exports = {};
-  ${reactRefreshCode}
-  exports.performReactRefresh = debounce(exports.performReactRefresh, 30);
-  window.$RefreshRuntime$ = exports;
-  window.$RefreshRuntime$.injectIntoGlobalHook(window);
-  window.$RefreshReg$ = () => {};
-  window.$RefreshSig$ = () => (type) => type;
+  {
+    const exports = {};
+    ${reactRefreshCode}
+    exports.performReactRefresh = debounce(exports.performReactRefresh, 30);
+    window.$RefreshRuntime$ = exports;
+    window.$RefreshRuntime$.injectIntoGlobalHook(window);
+    window.$RefreshReg$ = () => {};
+    window.$RefreshSig$ = () => (type) => type;
+  }
 </script>`,
   );
 }

--- a/plugins/plugin-react-refresh/test/__snapshots__/plugin.test.js.snap
+++ b/plugins/plugin-react-refresh/test/__snapshots__/plugin.test.js.snap
@@ -12,8 +12,9 @@ exports[`@snowpack/plugin-react-refresh transform js and html when babel is disa
   <body>
 <script>
   function debounce(e,t){let u;return()=>{clearTimeout(u),u=setTimeout(e,t)}}
-  const exports = {};
-  /** @license React v0.9.0
+  {
+    const exports = {};
+    /** @license React v0.9.0
  * react-refresh-runtime.development.js
  *
  * Copyright (c) Facebook, Inc. and its affiliates.
@@ -685,11 +686,12 @@ exports.setSignature = setSignature;
   })();
 }
 
-  exports.performReactRefresh = debounce(exports.performReactRefresh, 30);
-  window.$RefreshRuntime$ = exports;
-  window.$RefreshRuntime$.injectIntoGlobalHook(window);
-  window.$RefreshReg$ = () => {};
-  window.$RefreshSig$ = () => (type) => type;
+    exports.performReactRefresh = debounce(exports.performReactRefresh, 30);
+    window.$RefreshRuntime$ = exports;
+    window.$RefreshRuntime$.injectIntoGlobalHook(window);
+    window.$RefreshReg$ = () => {};
+    window.$RefreshSig$ = () => (type) => type;
+  }
 </script>
     <div id=\\"root\\"></div>
     <noscript>You need to enable JavaScript to run this app.</noscript>
@@ -731,8 +733,9 @@ exports[`@snowpack/plugin-react-refresh transform js and html: html 1`] = `
   <body>
 <script>
   function debounce(e,t){let u;return()=>{clearTimeout(u),u=setTimeout(e,t)}}
-  const exports = {};
-  /** @license React v0.9.0
+  {
+    const exports = {};
+    /** @license React v0.9.0
  * react-refresh-runtime.development.js
  *
  * Copyright (c) Facebook, Inc. and its affiliates.
@@ -1404,11 +1407,12 @@ exports.setSignature = setSignature;
   })();
 }
 
-  exports.performReactRefresh = debounce(exports.performReactRefresh, 30);
-  window.$RefreshRuntime$ = exports;
-  window.$RefreshRuntime$.injectIntoGlobalHook(window);
-  window.$RefreshReg$ = () => {};
-  window.$RefreshSig$ = () => (type) => type;
+    exports.performReactRefresh = debounce(exports.performReactRefresh, 30);
+    window.$RefreshRuntime$ = exports;
+    window.$RefreshRuntime$.injectIntoGlobalHook(window);
+    window.$RefreshReg$ = () => {};
+    window.$RefreshSig$ = () => (type) => type;
+  }
 </script>
     <div id=\\"root\\"></div>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
Place the `exports` variable global variable into a scope to prevent it from being leaked globally. 

<!-- Before/after screenshots may be helpful.  -->
Before tests:
<img width="880" alt="Screen Shot 2020-11-09 at 12 24 39 PM" src="https://user-images.githubusercontent.com/73310973/98574992-9ffc3480-2286-11eb-8c9c-a0dc7d6f0928.png">
 After tests:
<img width="605" alt="Screen Shot 2020-11-09 at 12 18 16 PM" src="https://user-images.githubusercontent.com/73310973/98575055-b5715e80-2286-11eb-8724-b37103274359.png">


## Testing

<!-- How was this change tested? -->
Updated the snapshot to reflect added scope.

## Docs

<!-- Was public documentation updated? -->
No documentation update.
