### PR TITLE
Added snowpack-svelte-ts-tw to community templates

### DIFF
--- a/create-snowpack-app/cli/README.md
+++ b/create-snowpack-app/cli/README.md
@@ -33,4 +33,5 @@ npx create-snowpack-app new-dir --template @snowpack/app-template-NAME [--use-ya
 - [snowpack-react-ssr](https://github.com/matthoffner/snowpack-react-ssr) (React + Server Side Rendering)
 - [snowpack-app-template-preact-hmr-tailwind](https://github.com/Mozart409/snowpack-app-template-preact-hmr-tailwind) (Snowpack + Preact + HMR + Tailwindcss)
 - [snowpack-mdx-chakra](https://github.com/molebox/snowpack-mdx)(An opinionated template setup with MDX, Chakra-ui for styling, theme and components, and React Router v6 for routing.)
+- [snowpack-svelte-ts-tw](https://github.com/GarrettCannon/snowpack-svelte-ts-tw) (Snowpack + Svelte + Typescript + TailwindCSS)
 - PRs that add a link to this list are welcome!


### PR DESCRIPTION
## Changes
Added a template I created [snowpack-svelte-ts-tw](https://github.com/GarrettCannon/snowpack-svelte-ts-tw) to the community template list. Snowpack + Svelte + Typescript + TailwindCSS!

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->


## Testing
I tested by running the Create-Snowpack-App commands against this template and everything seemed to work 👍 
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->



## Docs
The README for snowpack/create-snowpack-app/cli was updated to show my template.
<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

