### PR TITLE
fix(esinstall): allow `install` from sibling callers

### DIFF
--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -37,6 +37,7 @@ import {
   resolveDependencyManifest,
   sanitizePackageName,
   writeLockfile,
+  resolvePath,
 } from './util';
 
 export * from './types';
@@ -99,9 +100,7 @@ function resolveWebDependency(
     const isJSFile = ['.js', '.mjs', '.cjs'].includes(path.extname(dep));
     return {
       type: isJSFile ? 'JS' : 'ASSET',
-      // For details on why we need to call fs.realpathSync.native here and other places, see
-      // https://github.com/snowpackjs/snowpack/pull/999.
-      loc: fs.realpathSync.native(require.resolve(dep, {paths: [cwd]})),
+      loc: resolvePath(dep, cwd)
     };
   }
   // If dep is a path within a package (but without an extension), we first need
@@ -136,7 +135,7 @@ function resolveWebDependency(
   const [depManifestLoc, depManifest] = resolveDependencyManifest(dep, cwd);
   if (!depManifest) {
     try {
-      const maybeLoc = fs.realpathSync.native(require.resolve(dep, {paths: [cwd]}));
+      const maybeLoc = resolvePath(dep, cwd);
       return {
         type: 'JS',
         loc: maybeLoc,
@@ -193,8 +192,8 @@ function resolveWebDependency(
   }
   return {
     type: 'JS',
-    loc: fs.realpathSync.native(
-      require.resolve(path.join(depManifestLoc || '', '..', foundEntrypoint)),
+    loc: resolvePath(
+      path.join(depManifestLoc || '', '..', foundEntrypoint)
     ),
   };
 }

--- a/esinstall/src/util.ts
+++ b/esinstall/src/util.ts
@@ -30,7 +30,7 @@ export function parsePackageImportSpecifier(imp: string): [string, string | null
 // @see https://github.com/snowpackjs/snowpack/pull/999.
 export function resolvePath(dep: string, cwd?: string) {
   const options: { paths?: string[] } = {};
-  if (cwd) options.paths = [ __dirname, cwd ];
+  if (cwd) options.paths = [ cwd, __dirname ];
   return fs.realpathSync.native(require.resolve(dep, options));
 }
 

--- a/esinstall/src/util.ts
+++ b/esinstall/src/util.ts
@@ -26,6 +26,14 @@ export function parsePackageImportSpecifier(imp: string): [string, string | null
   return [name, rest.join('/') || null];
 }
 
+// We need `fs.realpathSync.native` here
+// @see https://github.com/snowpackjs/snowpack/pull/999.
+export function resolvePath(dep: string, cwd?: string) {
+  const options: { paths?: string[] } = {};
+  if (cwd) options.paths = [ __dirname, cwd ];
+  return fs.realpathSync.native(require.resolve(dep, options));
+}
+
 /**
  * Given a package name, look for that package's package.json manifest.
  * Return both the manifest location (if believed to exist) and the

--- a/esinstall/src/util.ts
+++ b/esinstall/src/util.ts
@@ -48,9 +48,7 @@ export function resolveDependencyManifest(dep: string, cwd: string): [string | n
   // include a package.json. If we detect that to be the reason for failure,
   // move on to our custom implementation.
   try {
-    const depManifest = fs.realpathSync.native(
-      require.resolve(`${dep}/package.json`, {paths: [cwd]}),
-    );
+    const depManifest = resolvePath(`${dep}/package.json`, cwd);
     return [depManifest, require(depManifest)];
   } catch (err) {
     // if its an export map issue, move on to our manual resolver.
@@ -66,7 +64,7 @@ export function resolveDependencyManifest(dep: string, cwd: string): [string | n
   // established & move out of experimental mode.
   let result = [null, null] as [string | null, any | null];
   try {
-    const fullPath = fs.realpathSync.native(require.resolve(dep, {paths: [cwd]}));
+    const fullPath = resolvePath(dep, cwd);
     // Strip everything after the package name to get the package root path
     // NOTE: This find-replace is very gross, replace with something like upath.
     const searchPath = `${path.sep}node_modules${path.sep}${dep.replace('/', path.sep)}`;


### PR DESCRIPTION
## Changes

* extract `resolvePath` shared utility
* added `__dirname` to `paths` list for custom `require.resolve` loader

## Testing

No tests added (yet). Would have to add static `node_modules` fixtures.

## Docs

No added docs – bug fix only.

When specifying `paths`, `require.resolve` uses _only_ the paths listed as starting points. However, by default, `require.resolve` uses its caller's location as a starting point. In most cases for `esinstall`, omitting the caller source is fine, but not always.

Example:

**File Structure**

```
/project
  /client
    /node_modules
      /PREACT/...
    /index.js
  /node_modules
    /esinstall/...
    /TARGET
    /CALLER/
      /index.js
      /node_modules
        /SCOPED/...
  /index.js
```

When `CWD` is `/project`, invoking `install(['TARGET'])` from:

* `/index.js` ✅ 
* `/client/index.js` ✅ 

.. everything is ok.

---

When `CWD` is `/project`, invoking `install(['PREACT'])` from:

* `/index.js` ❌  (not found, expected)
* `/client/index.js` ❌  (not found, NOT EXPECTED)

... `/client/index.js` fails because **only** `/project/node_modules` is searched. This means most monorepos and/or projects divided into workspaces will/_can_ fail.

This `PREACT` example will only work via `cd client && node index.js` so that `CWD` is `/project/client`, allowing `/project/client/node_modules` to be searched.

---

Now, assuming `node_modules/CALLER/index.js` has something like this:

```js
const { install } = require('esinstall');
await install(['SCOPED']);
```

...when `CWD` is `/project` _or_ `/project/client`, invoking the `CALLER` dependency from:

* `/index.js` 
* `/client/index.js`

Will cause the `CALLER` module to **miss**/not have access to its own `SCOPED` dependency.
Again, like the previous example, this is because **only** the `/project/node_modules` directory is search, given our CWD location.

This situation arises _all_ the place, especially in projects using yarn@2 and pnpm. With these, any dependency that _only_ belongs to a single dependent (either by name or by name-version combination) _will not_ be hoisted to the top-level `node_modules` directory.

---

Including `__dirname` in the custom `paths` list restores the (partial) default behavior of resolving item(s) from its caller's location. In other words, this removes/fixes the faulty assumption that everything always resides in a flat, top-level `node_modules` directory.