### PR TITLE
Fix ESLint example portability issue on Windows

### DIFF
--- a/docs/08-guides.md
+++ b/docs/08-guides.md
@@ -147,7 +147,7 @@ To use Sass + PostCSS, check out [this guide](https://zellwk.com/blog/eleventy-s
 // snowpack.config.json
 "plugins": [
   ["@snowpack/plugin-run-script", {
-    "cmd": "eslint 'src/**/*.{js,jsx,ts,tsx}'",
+    "cmd": "eslint \"src/**/*.{js,jsx,ts,tsx}\"",
     // Optional: Use npm package "watch" to run on every file change
     "watch": "watch \"$1\" src"
   }]


### PR DESCRIPTION
## Changes

If I use single quotes on Windows, I'll get the following error:

```text
▼ eslint

  > Watching src

  Oops! Something went wrong! :(

  ESLint: 7.13.0

  No files matching the pattern "'src/**/*.{js,jsx,ts,tsx}'" were found.
  Please check for typing mistakes in the pattern.
```

If I replace single quotes with double quotes, ESLint works fine on Windows:

```text
▼ eslint

  > Watching src
```

## Testing

Tested ad hoc on my Windows box.

## Docs

Yes, this is a docs only PR.
