### PR TITLE
limit outputted remote urls to one

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -1296,7 +1296,8 @@ export async function startDevServer(commandOptions: CommandOptions): Promise<Sn
   const ips = Object.values(os.networkInterfaces())
     .reduce((every: os.NetworkInterfaceInfo[], i) => [...every, ...(i || [])], [])
     .filter((i) => i.family === 'IPv4' && i.internal === false)
-    .map((i) => i.address);
+    .map((i) => i.address)
+    .slice(0, 1);
   const protocol = config.devOptions.secure ? 'https:' : 'http:';
   messageBus.emit(paintEvent.SERVER_START, {
     protocol,

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -1293,17 +1293,16 @@ export async function startDevServer(commandOptions: CommandOptions): Promise<Sn
   }
 
   // Announce server has started
-  const ips = Object.values(os.networkInterfaces())
+  const remoteIps = Object.values(os.networkInterfaces())
     .reduce((every: os.NetworkInterfaceInfo[], i) => [...every, ...(i || [])], [])
     .filter((i) => i.family === 'IPv4' && i.internal === false)
-    .map((i) => i.address)
-    .slice(0, 1);
+    .map((i) => i.address);
   const protocol = config.devOptions.secure ? 'https:' : 'http:';
   messageBus.emit(paintEvent.SERVER_START, {
     protocol,
     hostname,
     port,
-    ips,
+    remoteIp: remoteIps[0],
     startTimeMs: Math.round(performance.now() - serverStart),
   });
 

--- a/snowpack/src/commands/paint.ts
+++ b/snowpack/src/commands/paint.ts
@@ -74,15 +74,15 @@ export async function getPort(defaultPort: number): Promise<number> {
 }
 
 export function getServerInfoMessage(
-  {startTimeMs, port, protocol, hostname, ips}: ServerInfo,
+  {startTimeMs, port, protocol, hostname, remoteIp}: ServerInfo,
   isBuilding = false,
 ) {
   let output = '';
   const isServerStarted = startTimeMs > 0 && port > 0 && protocol;
   if (isServerStarted) {
     output += `  ${colors.bold(colors.cyan(`${protocol}//${hostname}:${port}`))}`;
-    for (const ip of ips) {
-      output += `${colors.cyan(` • `)}${colors.bold(colors.cyan(`${protocol}//${ip}:${port}`))}`;
+    if (remoteIp) {
+      output += `${colors.cyan(` • `)}${colors.bold(colors.cyan(`${protocol}//${remoteIp}:${port}`))}`;
     }
     output += '\n';
     output += colors.dim(
@@ -104,7 +104,7 @@ interface ServerInfo {
   hostname: string;
   protocol: string;
   startTimeMs: number;
-  ips: string[];
+  remoteIp?: string;
 }
 
 interface WorkerState {


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
Limit outputted remote URLs to one. 

**Before:**
```
snowpack

  http://localhost:8080 • http://192.168.1.144:8080 • http://192.168.64.1:8080 • http://172.20.192.1:8080 • http://172.23.48.1:8080 • http://172.31.176.1:8080 • http://172.19.96.1:8080
  Server started in 167ms.
```

**After:**
```
snowpack

  http://localhost:8080 • http://192.168.1.144:8080
  Server started in 167ms.

```

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->
I am not sure how to test this.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
- N/A
