### PR TITLE
fix: check for http in baseUrl

### DIFF
--- a/plugins/plugin-webpack/plugin.js
+++ b/plugins/plugin-webpack/plugin.js
@@ -76,7 +76,9 @@ function emitHTMLFiles({doms, jsEntries, stats, baseUrl, buildDirectory, htmlMin
         for (const cssFile of cssFiles) {
           const linkEl = dom.window.document.createElement('link');
           linkEl.setAttribute('rel', 'stylesheet');
-          linkEl.href = path.posix.join(baseUrl, cssFile);
+          linkEl.href = url.parse(baseUrl).protocol
+            ? url.resolve(baseUrl, cssFile)
+            : path.posix.join(baseUrl, cssFile);
           head.append(linkEl);
         }
         originalScriptEl.remove();


### PR DESCRIPTION
## Changes
same as #993 for linkEl.href

## Testing

I tested it locally.

baseUrl = https://mysite.com

before
```
<link rel="stylesheet" href="https:/mysite.com/css/lib~index.c776aa551d1c3764cf76.css"/>
```

after
```
<link rel="stylesheet" href="https://mysite.com/css/lib~index.c776aa551d1c3764cf76.css"/>
```
## Docs

bug fix only
