### PR TITLE
plugin-webpack: reference webpack loaders with require.resolve for yarn pnp compat

### DIFF
--- a/plugins/plugin-webpack/plugin.js
+++ b/plugins/plugin-webpack/plugin.js
@@ -231,7 +231,7 @@ module.exports = function plugin(config, args = {}) {
               exclude: /node_modules/,
               use: [
                 {
-                  loader: 'babel-loader',
+                  loader: require.resolve('babel-loader'),
                   options: {
                     cwd: buildDirectory,
                     configFile: false,
@@ -239,7 +239,7 @@ module.exports = function plugin(config, args = {}) {
                     compact: true,
                     presets: [
                       [
-                        '@babel/preset-env',
+                        require.resolve('@babel/preset-env'),
                         {
                           targets: presetEnvTargets,
                           bugfixes: true,
@@ -267,7 +267,7 @@ module.exports = function plugin(config, args = {}) {
                   loader: MiniCssExtractPlugin.loader,
                 },
                 {
-                  loader: 'css-loader',
+                  loader: require.resolve('css-loader'),
                 },
               ],
             },
@@ -278,7 +278,7 @@ module.exports = function plugin(config, args = {}) {
                   loader: MiniCssExtractPlugin.loader,
                 },
                 {
-                  loader: 'css-loader',
+                  loader: require.resolve('css-loader'),
                   options: {
                     modules: true,
                   },
@@ -290,7 +290,7 @@ module.exports = function plugin(config, args = {}) {
               exclude: [/\.js?$/, /\.json?$/, /\.css$/],
               use: [
                 {
-                  loader: 'file-loader',
+                  loader: require.resolve('file-loader'),
                   options: {
                     name: assetsOutputPattern,
                   },


### PR DESCRIPTION
Replaces implicit Webpack loader resolution (e.g. `loader: 'babel-loader'`) with an explicit `require.resolve` call (e.g. `loader: require.resolve('babel-loader')`). This should be a noop for regular npm/yarn installs, but is required when using Yarn 2 PnP and `pnp-webpack-plugin` (because Yarn 2 overrides Node's module resolution, but not Webpack's enhanced-resolve).

Context: https://github.com/arcanis/pnp-webpack-plugin#usage

In my project, I'm using Yarn 2 and `pnp-webpack-plugin` like so:

```
    ['@snowpack/plugin-webpack', {
      extendConfig: (config) => {
        return merge(config, {
          resolve: {
            plugins: [
              PnpWebpackPlugin,
            ],
          },
          resolveLoader: {
            plugins: [
              PnpWebpackPlugin.moduleLoader(module),
            ],
          },
        });
      },
    }],
```

Before this patch, the build fails with `Entry module not found: Error: Can't resolve 'babel-loader'`. After applying my changes, it succeeds.

## Changes

Loader paths are resolved with `require.resolve` instead of Webpack's `enhanced-resolve`.

## Testing

Existing tests pass. A real regression test (that installs the required packages under pnp) would be complex, and doesn't seem like it would provide a ton of value.

## Docs

No documentation, since this is a bug fix.