### PR TITLE
fix: 1. console.warn replace throw new Error

### DIFF
--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -118,7 +118,7 @@ function resolveWebDependency(
         exportMapEntry?.require ||
         exportMapEntry;
       if (typeof exportMapValue !== 'string') {
-        throw new Error(
+        console.warn(
           `Package "${packageName}" exists but package.json "exports" does not include entry for "./${packageEntrypoint}".`,
         );
       }


### PR DESCRIPTION
git repo:

https://github.com/zhusjfaker/snowpack-externalPackage-bug

https://github.com/zhusjfaker/snowpack-externalPackage-bug.git

cmd:

npm run dev

console:

No ESM dependencies found! ........

code location:

esinstall

line 270

  if (Object.keys(installEntrypoints).length === 0 && Object.keys(assetEntrypoints).length === 0) {
        throw new Error(`No ESM dependencies found!
${colors.dim(`  At least one dependency must have an ESM "module" entrypoint. You can find modern, web-ready packages at ${colors.underline('https://www.pika.dev')}`)}`);
    }```

scene:

 
I want to skip the esinstall step and replace the packages in the application with 
my own rollup packaged file in some low-code situation
