### PR TITLE
Updating docs to reference main branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ The `--verbose` flag enables additional logs which will help to identify the sou
 
 ## Pull Request Guidelines
 
-Checkout a topic branch from a base branch, e.g. `master`, and merge back against that branch.
+Checkout a topic branch from a base branch, e.g. `main`, and merge back against that branch.
 
 If adding a feature, it probably should have been brought up in a [discussion](https://github.com/snowpackjs/snowpack/discussions) instead before the PR was created.
 

--- a/www/_includes/layouts/subnav.njk
+++ b/www/_includes/layouts/subnav.njk
@@ -3,5 +3,5 @@
   {{ content | toc | safe }}
   <hr/>
   <h4>Suggest a change</h4>
-  <a href="https://github.com/snowpackjs/snowpack/blob/master/www/{{ page.inputPath }}">Edit this page on GitHub</a>
+  <a href="https://github.com/snowpackjs/snowpack/blob/main/www/{{ page.inputPath }}">Edit this page on GitHub</a>
 </aside>

--- a/www/_template/community.md
+++ b/www/_template/community.md
@@ -95,7 +95,7 @@ usersList:
     {% endif %}
   </a>
 {% endfor %}
-<a href="https://github.com/snowpackjs/snowpack/edit/master/docs/00.md" target="_blank" title="Add Your Project/Company!" class="add-company-button" >
+<a href="https://github.com/snowpackjs/snowpack/edit/main/www/_template/community.md" target="_blank" title="Add Your Project/Company!" class="add-company-button" >
   <svg style="height: 22px; margin-right: 8px;" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="plus" class="company-logo" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"></path></svg>
   Add your logo
 </a>

--- a/www/_template/configuration.md
+++ b/www/_template/configuration.md
@@ -162,7 +162,7 @@ Options:
 - **`installOptions.rollup`** | `Object`
   - Snowpack uses Rollup internally to install your packages. This `rollup` config option gives you deeper control over the internal rollup configuration that we use.
   - **`installOptions.rollup.plugins`** - Specify [Custom Rollup plugins](#installing-non-js-packages) if you are dealing with non-standard files.
-  - **`installOptions.rollup.dedupe`** - If needed, deduplicate multiple versions/copies of a packages to a single one. This helps prevent issues with some packages when multiple versions are installed from your node_modules tree. See [rollup-plugin-node-resolve](https://github.com/rollup/plugins/tree/master/packages/node-resolve#usage) for more documentation.
+  - **`installOptions.rollup.dedupe`** - If needed, deduplicate multiple versions/copies of a packages to a single one. This helps prevent issues with some packages when multiple versions are installed from your node_modules tree. See [rollup-plugin-node-resolve](https://github.com/rollup/plugins/tree/main/packages/node-resolve#usage) for more documentation.
   - **`installOptions.rollup.context`** - Specify top-level `this` value. Useful to silence install errors caused by legacy common.js packages that reference a top-level this variable, which does not exist in a pure ESM environment. Note that the `'THIS_IS_UNDEFINED'` warning (`The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten`) is silenced by default, unless `--verbose` is used.
 
 #### `config.devOptions`

--- a/www/_template/features.md
+++ b/www/_template/features.md
@@ -192,7 +192,7 @@ You can use environment variables in HTML files. All occurrences of `%SNOWPACK_P
 }
 ```
 
-Add the `@snowpack/plugin-dotenv` plugin to your dev environment to automatically load environment variables from your project `.env` files. Visit the [plugin README](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-dotenv) to learn more.
+Add the `@snowpack/plugin-dotenv` plugin to your dev environment to automatically load environment variables from your project `.env` files. Visit the [plugin README](https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-dotenv) to learn more.
 
 ## Hot Module Replacement
 
@@ -204,12 +204,12 @@ Snowpack supports full HMR out-of-the-box for the following served files:
 - CSS Modules
 - JSON
 
-Popular frameworks can also be set up for HMR. **[Create Snowpack App (CSA)](https://github.com/snowpackjs/snowpack/blob/master/create-snowpack-app) ships with HMR enabled by default for all of the following frameworks.** If you're not using CSA, you can setup HMR in your application with a simple plugin or a few lines of code:
+Popular frameworks can also be set up for HMR. **[Create Snowpack App (CSA)](https://github.com/snowpackjs/snowpack/blob/main/create-snowpack-app) ships with HMR enabled by default for all of the following frameworks.** If you're not using CSA, you can setup HMR in your application with a simple plugin or a few lines of code:
 
 - Preact: [@prefresh/snowpack](https://www.npmjs.com/package/@prefresh/snowpack)
 - React: [@snowpack/plugin-react-refresh](https://www.npmjs.com/package/@snowpack/plugin-react-refresh)
-- Svelte: [A few lines of code](https://github.com/snowpackjs/snowpack/blob/master/create-snowpack-app/app-template-svelte/src/index.js#L9-L16)
-- Vue: [A few lines of code](https://github.com/snowpackjs/snowpack/blob/master/create-snowpack-app/app-template-vue/src/index.js#L7-L14)
+- Svelte: [A few lines of code](https://github.com/snowpackjs/snowpack/blob/main/create-snowpack-app/app-template-svelte/src/index.js#L9-L16)
+- Vue: [A few lines of code](https://github.com/snowpackjs/snowpack/blob/main/create-snowpack-app/app-template-vue/src/index.js#L7-L14)
 
 For more advanced, bare-metal HMR integrations, Snowpack created [ESM-HMR](https://github.com/snowpackjs/esm-hot-module-replacement-spec), a standard HMR API for any ESM-based dev environment. Any HMR integration built for ESM-HMR will run on Snowpack and any other ESM-HMR-enabled dev server. To use the HMR API directly (via `import.meta.hot`) check out [the ESM-HMR spec](https://github.com/snowpackjs/esm-hot-module-replacement-spec) to learn more.
 
@@ -382,7 +382,7 @@ module.exports = {
 };
 ```
 
-[See an example setup](https://github.com/snowpackjs/snowpack/blob/master/create-snowpack-app/app-template-react) in on of our Create Snowpack App starter templates.
+[See an example setup](https://github.com/snowpackjs/snowpack/blob/main/create-snowpack-app/app-template-react) in on of our Create Snowpack App starter templates.
 
 ## JSX
 

--- a/www/_template/getting-started.md
+++ b/www/_template/getting-started.md
@@ -14,7 +14,7 @@ In this guide you'll learn
 - Building your first project
 - Customizing Snowpack with plugins
 
-> 💡 Tip: This guide will walk you through creating the [Snowpack minimal app template](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/ from scratch. You can see the final result [here](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/), along with more [examples](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/cli) to get you started
+> 💡 Tip: This guide will walk you through creating the [Snowpack minimal app template](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/ from scratch. You can see the final result [here](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/), along with more [examples](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/cli) to get you started
 
 Prerequisites: Snowpack is a command line tool installed from npm. This guide assumes a basic understanding of JavaScript, npm, and how to run commands in the terminal.
 
@@ -231,7 +231,7 @@ What's next? Our docs site has several great resources
 - [Bundling for production guide](/guides/bundling): how to connect a bundler like Webpack to optimize code for production deployments
 - [Features](/features): a list of all the built in features Snowpack supports right out of the box
 - [Plugins](/plugins): a list of plugins that allow you to integrate your favorite tools with Snowpack
-- [Templates/Examples](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/cli): pre-built projects you can build on or just explore using many popular frameworks and tools
+- [Templates/Examples](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/cli): pre-built projects you can build on or just explore using many popular frameworks and tools
 - [Guides](/guides): Step by step deep dives on building with and for Snowpack. Includes frameworks like React and Svelte.
 
 If you have any questions, comments, or corrections, we'd love to hear from you in the Snowpack [discussion](https://github.com/snowpackjs/snowpack/discussions) forum or our [Snowpack Discord community](https://discord.gg/rS8SnRk).

--- a/www/_template/guides/plugins.md
+++ b/www/_template/guides/plugins.md
@@ -41,7 +41,7 @@ Snowpack plugins support a `run()` method which lets you run any CLI tool and co
 
 Snowpack builds you a runnable, unbundled website by default, but you can optimize this final build with your favorite bundler (webpack, Rollup, Parcel, etc.) through the plugin `optimize()` method. When a bundler plugin is used, Snowpack will run the bundler on your build automatically to optimize it.
 
-See our official [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-webpack) bundler plugin for an example of using the current interface.
+See our official [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-webpack) bundler plugin for an example of using the current interface.
 
 ## How to Write a Plugin
 
@@ -252,7 +252,7 @@ This is an (obviously) simplified version of the `@snowpack/plugin-webpack` plug
 
 ## Plugin API
 
-Check out our ["SnowpackPlugin" TypeScript definition](https://github.com/snowpackjs/snowpack/tree/master/snowpack/src/types/snowpack.ts) for a fully documented and up-to-date summary of the Plugin API and all supported options.
+Check out our ["SnowpackPlugin" TypeScript definition](https://github.com/snowpackjs/snowpack/tree/main/snowpack/src/types/snowpack.ts) for a fully documented and up-to-date summary of the Plugin API and all supported options.
 
 ### knownEntrypoints
 
@@ -273,7 +273,7 @@ config(snowpackConfig) {
 
 Use this hook to read or make changes to the completed Snowpack configuration object. This is currently the recommended way to access the Snowpack configuration, since the one passed to the top-level plugin function is not yet finalized and may be incomplete.
 
-- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/master/snowpack/src/types/snowpack.ts).
+- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/main/snowpack/src/types/snowpack.ts).
 
 ### resolve
 
@@ -289,43 +289,43 @@ If your plugin defines a `load()` method, Snowpack will need to know what files 
 
 - `input`: An array of file extensions that this plugin will load.
 - `output`: The set of all file extensions that this plugin's `load()` method will output.
-- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/master/snowpack/src/types/snowpack.ts).
+- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/main/snowpack/src/types/snowpack.ts).
 
 ### load()
 
 Load a file from disk and build it for your application. This is most useful for taking a file type that can't run in the browser (TypeScript, Sass, Vue, Svelte) and returning JS and/or CSS. It can even be used to load JS/CSS files directly from disk with a build step like Babel or PostCSS.
 
 - See above for an example of how to use this method.
-- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/master/snowpack/src/types/snowpack.ts).
+- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/main/snowpack/src/types/snowpack.ts).
 
 ### transform()
 
 Transform a file's contents. Useful for making changes to all types of output (JS, CSS, etc.) regardless of how they were loaded from disk.
 
 - See above for an example of how to use this method.
-- Example: [@snowpack/plugin-postcss](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-postcss)
-- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/master/snowpack/src/types/snowpack.ts).
+- Example: [@snowpack/plugin-postcss](https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-postcss)
+- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/main/snowpack/src/types/snowpack.ts).
 
 ### run()
 
 Run a CLI command, and connect it's output into the Snowpack console. Useful for connecting tools like TypeScript.
 
-- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/master/snowpack/src/types/snowpack.ts).
+- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/main/snowpack/src/types/snowpack.ts).
 
 ### optimize()
 
 Snowpack’s bundler plugin API is still experimental and may change in a future release. See our official bundler plugins for an example of using the current interface:
 
-- Example: [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-webpack)
+- Example: [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-webpack)
 - Example: [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle)
-- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/master/snowpack/src/types/snowpack.ts).
+- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/main/snowpack/src/types/snowpack.ts).
 
 ### onChange()
 
 Get notified any time a watched file changes. This can be useful when paired with the `markChanged()` plugin method, to mark multiple files changed at once.
 
-- See [@snowpack/plugin-sass](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-sass/plugin.js) for an example of how to use this method.
-- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/master/snowpack/src/types/snowpack.ts).
+- See [@snowpack/plugin-sass](https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-sass/plugin.js) for an example of how to use this method.
+- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/main/snowpack/src/types/snowpack.ts).
 
 ## Plugin API Methods
 
@@ -338,8 +338,8 @@ this.markChanged('/some/file/path.scss');
 
 Manually mark a file as changed, regardless of whether the file changed on disk or not. This can be useful when paired with the `markChanged()` plugin hook, to mark multiple files changed at once.
 
-- See [@snowpack/plugin-sass](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-sass/plugin.js) for an example of how to use this method.
-- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/master/snowpack/src/types/snowpack.ts).
+- See [@snowpack/plugin-sass](https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-sass/plugin.js) for an example of how to use this method.
+- [Full TypeScript definition](https://github.com/snowpackjs/snowpack/tree/main/snowpack/src/types/snowpack.ts).
 
 ## Publishing a Plugin
 

--- a/www/_template/guides/react.md
+++ b/www/_template/guides/react.md
@@ -22,7 +22,7 @@ In this guide, you'll go from an empty directory to a fully configured Snowpack 
 
 Prerequisites: Snowpack is a command line tool installed from npm. This guide assumes a basic understanding of Node.js, npm, and how to run commands in the terminal. Knowledge of React is not required, Snowpack is a great way to learn React!
 
-> 💡 Tip: if you want to jump to the end to see a full featured React setup, the [Create Snowpack App React template](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-react) comes with everything you'll learn in this guide plus other useful tools.
+> 💡 Tip: if you want to jump to the end to see a full featured React setup, the [Create Snowpack App React template](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-react) comes with everything you'll learn in this guide plus other useful tools.
 
 ## Getting started
 
@@ -196,7 +196,7 @@ When you add assets like images or CSS, Snowpack includes them in your final bui
 
 > 💡 Tip: as you're doing this, you should not need to reload the page or restart Snowpack. Snowpack automatically updates the project in the browser as you edit code.
 
-Add this file [`logo.svg`](https://github.com/snowpackjs/snowpack/blob/master/create-snowpack-app/app-template-react/src/logo.svg) to your `src` directory. Now you can import it into your `App.jsx` and use it in an `img` tag to display it.
+Add this file [`logo.svg`](https://github.com/snowpackjs/snowpack/blob/main/create-snowpack-app/app-template-react/src/logo.svg) to your `src` directory. Now you can import it into your `App.jsx` and use it in an `img` tag to display it.
 
 ```diff
   import React, { useState, useEffect } from 'react';
@@ -332,14 +332,14 @@ Great job! You're now ready to build the React project of your dreams with Snowp
 
 <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-text="I just learned how to build a React app with #Snowpack. Check out the tutorial:" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
-At this point you have the basics and have a great starter for any React project. But if you compare with the official [Snowpack React template](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-react) you'll notice it has some other developer tools you might find useful:
+At this point you have the basics and have a great starter for any React project. But if you compare with the official [Snowpack React template](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-react) you'll notice it has some other developer tools you might find useful:
 
 - [Prettier](https://prettier.io/)—a popular code formatter
 
 - [Tests](https://www.snowpack.dev/#testing)—Snowpack supports any popular JavaScript testing framework
 
-- [`@snowpack/plugin-dotenv`](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-dotenv)—Use `dotenv` in your Snowpack. This is useful for environment specific variables
+- [`@snowpack/plugin-dotenv`](https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-dotenv)—Use `dotenv` in your Snowpack. This is useful for environment specific variables
 
-If you'd like to use Typescript with Snowpack and React, check out the [Snowpack React Typescript](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-react-typescript) starter.
+If you'd like to use Typescript with Snowpack and React, check out the [Snowpack React Typescript](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-react-typescript) starter.
 
 If you have any questions, comments, or corrections, we'd love to hear from you in the Snowpack [discussion](https://github.com/snowpackjs/snowpack/discussions) forum or our [Snowpack Discord community](https://discord.gg/rS8SnRk).

--- a/www/_template/plugins.njk
+++ b/www/_template/plugins.njk
@@ -77,7 +77,7 @@ permalink: '/plugins/'
   <div class="content">
     <h3 class="pluginPage-subheading">Customize your build pipeline with Snowpack plugins</h3>
     <p class="pluginPage-intro">To learn more about our plugin system, read our
-      <a href="/getting-start">getting started</a>
+      <a href="/getting-started">getting started</a>
       guide.<br/>Can't find what you need? <a href="/guides/plugins">Creating your own plugin is easy!</a>
     </p>
     <div class="pluginPage-count" id="total-result-count"></div>

--- a/www/_template/posts/2020-05-26-snowpack-2-0-release.md
+++ b/www/_template/posts/2020-05-26-snowpack-2-0-release.md
@@ -129,15 +129,15 @@ The easiest way to get started with Snowpack is with [Create Snowpack App (CSA)]
 npx create-snowpack-app new-dir --template [SELECT FROM BELOW] [--use-yarn]
 ```
 
-- [@snowpack/app-template-blank](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-blank)
-- [@snowpack/app-template-react](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-react)
-- [@snowpack/app-template-react-typescript](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-react-typescript)
-- [@snowpack/app-template-preact](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-preact)
-- [@snowpack/app-template-svelte](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-svelte)
-- [@snowpack/app-template-vue](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-vue)
-- [@snowpack/app-template-lit-element](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-lit-element)
-- [@snowpack/app-template-11ty](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-11ty)
-- **[See all community templates](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app)**
+- [@snowpack/app-template-blank](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-blank)
+- [@snowpack/app-template-react](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-react)
+- [@snowpack/app-template-react-typescript](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-react-typescript)
+- [@snowpack/app-template-preact](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-preact)
+- [@snowpack/app-template-svelte](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-svelte)
+- [@snowpack/app-template-vue](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-vue)
+- [@snowpack/app-template-lit-element](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-lit-element)
+- [@snowpack/app-template-11ty](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-11ty)
+- **[See all community templates](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app)**
 
 🐹 Happy hacking!
 

--- a/www/guides/react.md
+++ b/www/guides/react.md
@@ -20,7 +20,7 @@ In this guide, you'll go from an empty directory to a fully configured Snowpack 
 
 Prerequisites: Snowpack is a command line tool installed from npm. This guide assumes a basic understanding of Node.js, npm, and how to run commands in the terminal. Knowledge of React is not required, Snowpack is a great way to learn React!
 
-> 💡 Tip: if you want to jump to the end to see a full featured React setup, the [Create Snowpack App React template](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-react) comes with everything you'll learn in this guide plus other useful tools.
+> 💡 Tip: if you want to jump to the end to see a full featured React setup, the [Create Snowpack App React template](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-react) comes with everything you'll learn in this guide plus other useful tools.
 
 ## Getting started
 
@@ -142,7 +142,7 @@ You'll need to restart Snowpack for configuration file changes. When you start u
 Create a new file at `src/App.jsx` and paste the following code into this new file to create an `App` component:
 
 ```jsx
-import React, {useState, useEffect} from 'react';
+import React, { useState, useEffect } from 'react';
 
 function App() {
   // Create the count state.
@@ -194,7 +194,7 @@ When you add assets like images or CSS, Snowpack includes them in your final bui
 
 > 💡 Tip: as you're doing this, you should not need to reload the page or restart Snowpack. Snowpack automatically updates the project in the browser as you edit code.
 
-Add this file [`logo.svg`](https://github.com/snowpackjs/snowpack/blob/master/create-snowpack-app/app-template-react/src/logo.svg) to your `src` directory. Now you can import it into your `App.jsx` and use it in an `img` tag to display it.
+Add this file [`logo.svg`](https://github.com/snowpackjs/snowpack/blob/main/create-snowpack-app/app-template-react/src/logo.svg) to your `src` directory. Now you can import it into your `App.jsx` and use it in an `img` tag to display it.
 
 ```diff
   import React, { useState, useEffect } from 'react';
@@ -330,14 +330,14 @@ Great job! You're now ready to build the React project of your dreams with Snowp
 
 <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-text="I just learned how to build a React app with #Snowpack. Check out the tutorial:" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
-At this point you have the basics and have a great starter for any React project. But if you compare with the official [Snowpack React template](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-react) you'll notice it has some other developer tools you might find useful:
+At this point you have the basics and have a great starter for any React project. But if you compare with the official [Snowpack React template](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-react) you'll notice it has some other developer tools you might find useful:
 
 - [Prettier](https://prettier.io/)—a popular code formatter
 
 - [Tests](https://www.snowpack.dev/#testing)—Snowpack supports any popular JavaScript testing framework
 
-- [`@snowpack/plugin-dotenv`](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-dotenv)—Use `dotenv` in your Snowpack. This is useful for environment specific variables
+- [`@snowpack/plugin-dotenv`](https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-dotenv)—Use `dotenv` in your Snowpack. This is useful for environment specific variables
 
-If you'd like to use Typescript with Snowpack and React, check out the [Snowpack React Typescript](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-react-typescript) starter.
+If you'd like to use Typescript with Snowpack and React, check out the [Snowpack React Typescript](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-react-typescript) starter.
 
 If you have any questions, comments, or corrections, we'd love to hear from you in the Snowpack [discussion](https://github.com/snowpackjs/snowpack/discussions) forum or our [Snowpack Discord community](https://discord.gg/rS8SnRk).


### PR DESCRIPTION
## Changes

We're changing the default branch to `main` and some links in the docs referenced `master`. I've updated these links. 

## Testing

Will run link checker. 

## Docs

Is docs
