### PR TITLE
Fix HMR Regression

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -842,12 +842,16 @@ export async function startDevServer(commandOptions: CommandOptions): Promise<Sn
         code = await transformEsmImports(code as string, (imp) => {
           const importUrl = path.posix.resolve(path.posix.dirname(reqPath), imp);
           const node = hmrEngine.getEntry(importUrl);
-          if (node && node.needsReplacement) {
-            node.mtime = mtime;
+          if (node == null) return imp;
+          if (node.needsReplacement) {
             hmrEngine.markEntryForReplacement(node, false);
+            node.mtime = mtime;
           }
-          if (node && node.mtime) {
+          if (node.mtime && !node.isHmrAccepted) {
             return `${imp}?mtime=${node.mtime}`;
+          }
+          if (node.needsReplacement) {
+            return `${imp}?mtime=${mtime}`;
           }
           return imp;
         });

--- a/snowpack/src/hmr-server-engine.ts
+++ b/snowpack/src/hmr-server-engine.ts
@@ -10,6 +10,7 @@ interface Dependency {
   isHmrAccepted: boolean;
   needsReplacement: boolean;
   needsReplacementCount: number;
+  mtime: string | null;
 }
 
 type HMRMessage =
@@ -103,6 +104,7 @@ export class EsmHmrEngine {
       needsReplacementCount: 0,
       isHmrEnabled: false,
       isHmrAccepted: false,
+      mtime: null,
     };
     this.dependencyTree.set(sourceUrl, newEntry);
     return newEntry;

--- a/test-dev/__snapshots__/dev.test.ts.snap
+++ b/test-dev/__snapshots__/dev.test.ts.snap
@@ -10,7 +10,7 @@ exports[`snowpack dev smoke: html 1`] = `
     <meta name=\\"description\\" content=\\"Web site created using create-snowpack-app\\" />
     <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"/index.css\\" />
     <title>Snowpack App</title>
-  <script type=\\"module\\" integrity=\\"sha384-Z1OPSs1KV1TOmQHeoGF8XyUQcMaBnM0p0xip/dmSSpZWySqHrGOuQ5R4sSJgwPrM\\" src=\\"/__snowpack__/hmr-client.js\\"></script><script type=\\"module\\" integrity=\\"sha384-LH/mFhEGRB4jHedP0nqOoIUwc4VX8eWJxEL+qTGWtroqiLJ2vxX169J0oSBMHL5o\\" src=\\"/__snowpack__/hmr-error-overlay.js\\"></script></head>
+  <script type=\\"module\\" integrity=\\"sha384-pHNSeKqrgg0SdJS23mfjET+fO1iZTvTUWK7l3Gr4nfJ5QimYzlozwy6jWEHFbnVB\\" src=\\"/__snowpack__/hmr-client.js\\"></script><script type=\\"module\\" integrity=\\"sha384-LH/mFhEGRB4jHedP0nqOoIUwc4VX8eWJxEL+qTGWtroqiLJ2vxX169J0oSBMHL5o\\" src=\\"/__snowpack__/hmr-error-overlay.js\\"></script></head>
   <body>
     <img id=\\"img\\" src=\\"/logo.svg\\" />
     <canvas id=\\"canvas\\"></canvas>


### PR DESCRIPTION
https://github.com/snowpackjs/snowpack/discussions/1620

## Changes

It fixes a regression introduced in https://github.com/snowpackjs/snowpack/commit/c5490fd9fc474293b3a930b6bb09541e5027d689

Copied from the discussion:

If I have a module tree like this:

App imports Guide

Guide imports Bubble

Bubble exports a string const

Guide uses the string in a React compnoent

If I change Bubble, then HMR works and I see the new Bubble
If I change Guide AFTER that, then the previous version of Bubble is used, which regresses the first HMR.

Here's a video:

Screen Recording 2020-11-16 at 9.05.19 PM.mp4.zip

Here's a repro:

https://github.com/aaronjensen/snowpack-hmr-repro

## Testing

Manually, using the repro

## Docs

No, it's a bug fix.
