### PR TITLE
Add deps to app-template-preact-typescript

### DIFF
--- a/create-snowpack-app/app-template-preact-typescript/package.json
+++ b/create-snowpack-app/app-template-preact-typescript/package.json
@@ -31,6 +31,8 @@
     "@snowpack/plugin-typescript": "^1.1.0",
     "@snowpack/web-test-runner-plugin": "^0.1.4",
     "@testing-library/preact": "^2.0.0",
+    "@types/chai": "^4.2.14",
+    "chai": "^4.2.0",
     "prettier": "^2.0.5",
     "snowpack": "^2.17.1",
     "typescript": "^4.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2644,7 +2644,7 @@
   resolved "https://registry.yarnpkg.com/@types/canvas-confetti/-/canvas-confetti-1.3.0.tgz#c2ea6b4c280832e134cb98ea3b84775febc53b63"
   integrity sha512-vfShQvbd7XD+jT2bFTju5oALkzI5uMO7RGH8RYOTP8p5LiY9NXSr0fJp2BvfW36Qf8807ma/yev0aS5GRwQcFg==
 
-"@types/chai@^4.2.13":
+"@types/chai@^4.2.13", "@types/chai@^4.2.14":
   version "4.2.14"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.14.tgz#44d2dd0b5de6185089375d976b4ec5caf6861193"
   integrity sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ==


### PR DESCRIPTION
## Changes

Fixes #1612

Both these dependencies are present in `app-template-react-typescript`; I think they were just omitted from this in error.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
