### PR TITLE
Follow symlinks forever

### DIFF
--- a/snowpack/src/commands/build.ts
+++ b/snowpack/src/commands/build.ts
@@ -390,6 +390,7 @@ export async function command(commandOptions: CommandOptions) {
       absolute: true,
       nodir: true,
       dot: true,
+      follow: true,
     });
     for (const installedFileLoc of allFiles) {
       if (
@@ -419,6 +420,7 @@ export async function command(commandOptions: CommandOptions) {
       absolute: true,
       nodir: true,
       dot: true,
+      follow: true,
     });
     for (const rawLocOnDisk of allFiles) {
       const fileLoc = path.resolve(rawLocOnDisk); // this is necessary since glob.sync() returns paths with / on windows.  path.resolve() will switch them to the native path separator.


### PR DESCRIPTION
## Changes

It allows symlinks that contain directories with files in them to be followed and built properly.

First mentioned here: https://github.com/snowpackjs/snowpack/discussions/1242

For reference: https://github.com/isaacs/node-glob/issues/139

## Testing

Manually with https://github.com/aaronjensen/snowpack-symlink-repro

## Docs

No, it's a bug fix.
