### PR TITLE
Update links referencing master to main

### DIFF
--- a/create-snowpack-app/app-scripts-lit-element/package.json
+++ b/create-snowpack-app/app-scripts-lit-element/package.json
@@ -7,7 +7,7 @@
     "access": "public"
   },
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-scripts-lit-element#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-scripts-lit-element#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/create-snowpack-app/app-scripts-preact/package.json
+++ b/create-snowpack-app/app-scripts-preact/package.json
@@ -7,7 +7,7 @@
     "access": "public"
   },
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-scripts-preact#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-scripts-preact#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/create-snowpack-app/app-scripts-react/package.json
+++ b/create-snowpack-app/app-scripts-react/package.json
@@ -7,7 +7,7 @@
     "access": "public"
   },
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-scripts-react#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-scripts-react#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/create-snowpack-app/app-scripts-svelte/package.json
+++ b/create-snowpack-app/app-scripts-svelte/package.json
@@ -7,7 +7,7 @@
     "access": "public"
   },
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-scripts-svelte#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-scripts-svelte#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/create-snowpack-app/app-scripts-vue/package.json
+++ b/create-snowpack-app/app-scripts-vue/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "snowpack.config.js",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-scripts-vue#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-scripts-vue#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/create-snowpack-app/app-template-11ty/README.md
+++ b/create-snowpack-app/app-template-11ty/README.md
@@ -17,7 +17,7 @@ You will also see any lint errors in the console.
 Builds a static copy of your site to the `build/` folder.
 Your app is ready to be deployed!
 
-**For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.
+**For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.
 
 ### Q: What about Eject?
 

--- a/create-snowpack-app/app-template-11ty/package.json
+++ b/create-snowpack-app/app-template-11ty/package.json
@@ -3,7 +3,7 @@
   "description": "A preconfigured template for Snowpack with Eleventy",
   "version": "1.9.8",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-11ty#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-11ty#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/create-snowpack-app/app-template-blank-typescript/README.md
+++ b/create-snowpack-app/app-template-blank-typescript/README.md
@@ -17,7 +17,7 @@ You will also see any lint errors in the console.
 Builds a static copy of your site to the `build/` folder.
 Your app is ready to be deployed!
 
-**For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.
+**For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.
 
 ### Q: What about Eject?
 

--- a/create-snowpack-app/app-template-blank-typescript/package.json
+++ b/create-snowpack-app/app-template-blank-typescript/package.json
@@ -3,7 +3,7 @@
   "description": "A preconfigured template for Snowpack with Typescript",
   "version": "1.9.12",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-blank-typescript#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-blank-typescript#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/create-snowpack-app/app-template-blank/README.md
+++ b/create-snowpack-app/app-template-blank/README.md
@@ -17,7 +17,7 @@ You will also see any lint errors in the console.
 Builds a static copy of your site to the `build/` folder.
 Your app is ready to be deployed!
 
-**For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.
+**For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.
 
 ### Q: What about Eject?
 

--- a/create-snowpack-app/app-template-blank/package.json
+++ b/create-snowpack-app/app-template-blank/package.json
@@ -3,7 +3,7 @@
   "description": "A preconfigured template for Snowpack with Prettier",
   "version": "1.6.24",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-blank#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-blank#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/create-snowpack-app/app-template-lit-element-typescript/package.json
+++ b/create-snowpack-app/app-template-lit-element-typescript/package.json
@@ -3,7 +3,7 @@
   "description": "A preconfigured template for Snowpack with TypeScript and LitElement",
   "version": "1.11.2",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-lit-element-typescript#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-lit-element-typescript#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/create-snowpack-app/app-template-lit-element/package.json
+++ b/create-snowpack-app/app-template-lit-element/package.json
@@ -3,7 +3,7 @@
   "description": "A preconfigured template for Snowpack with LitElement",
   "version": "1.9.11",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-lit-element#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-lit-element#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/create-snowpack-app/app-template-minimal/README.md
+++ b/create-snowpack-app/app-template-minimal/README.md
@@ -17,7 +17,7 @@ You will also see any lint errors in the console.
 Builds a static copy of your site to the `build/` folder.
 Your app is ready to be deployed!
 
-**For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.
+**For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.
 
 ### Q: What about Eject?
 

--- a/create-snowpack-app/app-template-minimal/package.json
+++ b/create-snowpack-app/app-template-minimal/package.json
@@ -3,7 +3,7 @@
   "description": "A preconfigured minimal template for Snowpack",
   "version": "1.0.4",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-preact#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-preact#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/create-snowpack-app/app-template-preact-typescript/package.json
+++ b/create-snowpack-app/app-template-preact-typescript/package.json
@@ -3,7 +3,7 @@
   "description": "A preconfigured template for Snowpack with Preact and Typescript",
   "version": "1.3.1",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-preact-typescript#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-preact-typescript#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/create-snowpack-app/app-template-preact/package.json
+++ b/create-snowpack-app/app-template-preact/package.json
@@ -3,7 +3,7 @@
   "description": "A preconfigured template for Snowpack with Preact",
   "version": "1.11.8",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-preact#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-preact#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/create-snowpack-app/app-template-react-typescript/package.json
+++ b/create-snowpack-app/app-template-react-typescript/package.json
@@ -3,7 +3,7 @@
   "description": "A preconfigured template for Snowpack with React and TypeScript",
   "version": "1.15.2",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-react-typescript#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-react-typescript#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/create-snowpack-app/app-template-react/package.json
+++ b/create-snowpack-app/app-template-react/package.json
@@ -3,7 +3,7 @@
   "description": "A preconfigured template for Snowpack with React",
   "version": "1.12.7",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-react#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-react#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/create-snowpack-app/app-template-svelte-typescript/README.md
+++ b/create-snowpack-app/app-template-svelte-typescript/README.md
@@ -22,7 +22,7 @@ See the section about running tests for more information.
 Builds a static copy of your site to the `build/` folder.
 Your app is ready to be deployed!
 
-**For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.
+**For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.
 
 ### Q: What about Eject?
 

--- a/create-snowpack-app/app-template-svelte-typescript/package.json
+++ b/create-snowpack-app/app-template-svelte-typescript/package.json
@@ -3,7 +3,7 @@
   "description": "A preconfigured template for Snowpack with Svelte and TypeScript",
   "version": "1.12.2",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-svelte-typescript#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-svelte-typescript#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/create-snowpack-app/app-template-svelte/README.md
+++ b/create-snowpack-app/app-template-svelte/README.md
@@ -22,7 +22,7 @@ See the section about running tests for more information.
 Builds a static copy of your site to the `build/` folder.
 Your app is ready to be deployed!
 
-**For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.
+**For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.
 
 ### Q: What about Eject?
 

--- a/create-snowpack-app/app-template-svelte/package.json
+++ b/create-snowpack-app/app-template-svelte/package.json
@@ -3,7 +3,7 @@
   "description": "A preconfigured template for Snowpack with Svelte",
   "version": "1.10.8",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-svelte#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-svelte#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/create-snowpack-app/app-template-vue-typescript/package.json
+++ b/create-snowpack-app/app-template-vue-typescript/package.json
@@ -3,7 +3,7 @@
   "description": "A preconfigured template for Snowpack with Vue and TypeScript",
   "version": "1.11.2",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-vue-typescript#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-vue-typescript#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/create-snowpack-app/app-template-vue/package.json
+++ b/create-snowpack-app/app-template-vue/package.json
@@ -3,7 +3,7 @@
   "description": "A preconfigured template for Snowpack with Vue",
   "version": "1.10.11",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-vue#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-vue#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/create-snowpack-app/cli/README.md
+++ b/create-snowpack-app/cli/README.md
@@ -6,19 +6,19 @@ npx create-snowpack-app new-dir --template @snowpack/app-template-NAME [--use-ya
 
 ## Official App Templates
 
-- [@snowpack/app-template-blank](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-blank)
-- [@snowpack/app-template-blank-typescript](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-blank-typescript)
-- [@snowpack/app-template-11ty](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-11ty)
-- [@snowpack/app-template-lit-element](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-lit-element)
-- [@snowpack/app-template-lit-element-typescript](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-lit-element-typescript)
-- [@snowpack/app-template-preact](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-preact)
-- [@snowpack/app-template-preact-typescript](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-preact-typescript)
-- [@snowpack/app-template-react](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-react)
-- [@snowpack/app-template-react-typescript](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-react-typescript)
-- [@snowpack/app-template-svelte](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-svelte)
-- [@snowpack/app-template-svelte-typescript](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-svelte-typescript)
-- [@snowpack/app-template-vue](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-vue)
-- [@snowpack/app-template-vue-typescript](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-vue-typescript)
+- [@snowpack/app-template-blank](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-blank)
+- [@snowpack/app-template-blank-typescript](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-blank-typescript)
+- [@snowpack/app-template-11ty](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-11ty)
+- [@snowpack/app-template-lit-element](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-lit-element)
+- [@snowpack/app-template-lit-element-typescript](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-lit-element-typescript)
+- [@snowpack/app-template-preact](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-preact)
+- [@snowpack/app-template-preact-typescript](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-preact-typescript)
+- [@snowpack/app-template-react](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-react)
+- [@snowpack/app-template-react-typescript](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-react-typescript)
+- [@snowpack/app-template-svelte](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-svelte)
+- [@snowpack/app-template-svelte-typescript](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-svelte-typescript)
+- [@snowpack/app-template-vue](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-vue)
+- [@snowpack/app-template-vue-typescript](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-vue-typescript)
 
 ### Featured Community Templates
 

--- a/create-snowpack-app/cli/package.json
+++ b/create-snowpack-app/cli/package.json
@@ -2,7 +2,7 @@
   "name": "create-snowpack-app",
   "version": "1.8.7",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/cli#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/cli#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/esinstall/package.json
+++ b/esinstall/package.json
@@ -14,7 +14,7 @@
     "esbuild",
     "cjs"
   ],
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/esinstall#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/esinstall#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/plugins/babel-plugin-package-import/package.json
+++ b/plugins/babel-plugin-package-import/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.5",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/babel-plugin-package-import#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/plugins/babel-plugin-package-import#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/plugins/plugin-babel/package.json
+++ b/plugins/plugin-babel/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.4",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-babel#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-babel#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/plugins/plugin-build-script/package.json
+++ b/plugins/plugin-build-script/package.json
@@ -3,7 +3,7 @@
   "name": "@snowpack/plugin-build-script",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-build-script#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-build-script#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/plugins/plugin-dotenv/package.json
+++ b/plugins/plugin-dotenv/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.4",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-dotenv#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-dotenv#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/plugins/plugin-optimize/package.json
+++ b/plugins/plugin-optimize/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.9",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-optimize#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-optimize#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/plugins/plugin-postcss/package.json
+++ b/plugins/plugin-postcss/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.7",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-postcss#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-postcss#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/plugins/plugin-react-refresh/package.json
+++ b/plugins/plugin-react-refresh/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.7",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-react-refresh#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-react-refresh#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/plugins/plugin-run-script/package.json
+++ b/plugins/plugin-run-script/package.json
@@ -3,7 +3,7 @@
   "name": "@snowpack/plugin-run-script",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-run-script#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-run-script#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/plugins/plugin-sass/package.json
+++ b/plugins/plugin-sass/package.json
@@ -3,7 +3,7 @@
   "name": "@snowpack/plugin-sass",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-sass#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-sass#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/plugins/plugin-svelte/package.json
+++ b/plugins/plugin-svelte/package.json
@@ -3,7 +3,7 @@
   "version": "3.3.0",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-svelte#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-svelte#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/plugins/plugin-typescript/package.json
+++ b/plugins/plugin-typescript/package.json
@@ -3,7 +3,7 @@
   "name": "@snowpack/plugin-typescript",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-typescript#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-typescript#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/plugins/plugin-vue/package.json
+++ b/plugins/plugin-vue/package.json
@@ -3,7 +3,7 @@
   "version": "2.2.5",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-vue#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-vue#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/plugins/plugin-webpack/package.json
+++ b/plugins/plugin-webpack/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.1",
   "main": "plugin.js",
   "license": "MIT",
-  "homepage": "https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-webpack#readme",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-webpack#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/snowpackjs/snowpack.git",

--- a/snowpack/assets/babel-plugin.js
+++ b/snowpack/assets/babel-plugin.js
@@ -3,5 +3,5 @@ console.error('');
 console.error('  npm install --save-dev @snowpack/babel-plugin-package-import');
 console.error('');
 console.error(
-  'Learn more: https://github.com/snowpackjs/snowpack/tree/master/plugins/babel-plugin-package-import',
+  'Learn more: https://github.com/snowpackjs/snowpack/tree/main/plugins/babel-plugin-package-import',
 );

--- a/test/create-snowpack-app/__snapshots__/create-snowpack-app.test.js.snap
+++ b/test/create-snowpack-app/__snapshots__/create-snowpack-app.test.js.snap
@@ -7362,7 +7362,7 @@ exports[`create-snowpack-app app-template-minimal > build: package.json 1`] = `
   \\"description\\": \\"A preconfigured minimal template for Snowpack\\",
   \\"version\\": \\"1.0.4\\",
   \\"license\\": \\"MIT\\",
-  \\"homepage\\": \\"https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app/app-template-preact#readme\\",
+  \\"homepage\\": \\"https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-template-preact#readme\\",
   \\"repository\\": {
     \\"type\\": \\"git\\",
     \\"url\\": \\"https://github.com/snowpackjs/snowpack.git\\",

--- a/www/_template/guides/connecting-tools.md
+++ b/www/_template/guides/connecting-tools.md
@@ -41,7 +41,7 @@ Open up `snowpack.config.js` and add the name of your new plugin to the plugins 
   ],
 ```
 
-What about the other optional configuration options? [The `@snowpack/plugin-sass` documentation](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-sass) lists all the options and where to put them in the `snowpack.config.js` file. If I wanted the `compressed` output `style` I'd turn the `@snowpack/plugin-sass` value into an array with an object containing the configuration:
+What about the other optional configuration options? [The `@snowpack/plugin-sass` documentation](https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-sass) lists all the options and where to put them in the `snowpack.config.js` file. If I wanted the `compressed` output `style` I'd turn the `@snowpack/plugin-sass` value into an array with an object containing the configuration:
 
 ```diff
 // snowpack.config.js
@@ -69,7 +69,7 @@ If you can't find a plugin that fits your needs and don't want to write your own
 }
 ```
 
-This plugin allows you to connect any CLI into your build process. Just give it a `cmd` CLI command that can take input from `stdin` and emit the build result via `stdout`. Check out the [plugin documentation](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-build-script) for more information.
+This plugin allows you to connect any CLI into your build process. Just give it a `cmd` CLI command that can take input from `stdin` and emit the build result via `stdout`. Check out the [plugin documentation](https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-build-script) for more information.
 
 #### @snowpack/plugin-run-script
 
@@ -83,7 +83,7 @@ This plugin allows you to connect any CLI into your build process. Just give it 
 }
 ```
 
-This plugin allows you to run any CLI command as a part of your dev and build workflow. This plugin doesn't affect your build output, but it is useful for connecting developer tooling directly into Snowpack. Use this to add meaningful feedback to your dev console as you type, like TypeScript type-checking and ESLint lint errors. This doesn't affect how Snowpack builds your site. Check out the [plugin documentation](https://github.com/snowpackjs/snowpack/tree/master/plugins/plugin-run-script) for more information.
+This plugin allows you to run any CLI command as a part of your dev and build workflow. This plugin doesn't affect your build output, but it is useful for connecting developer tooling directly into Snowpack. Use this to add meaningful feedback to your dev console as you type, like TypeScript type-checking and ESLint lint errors. This doesn't affect how Snowpack builds your site. Check out the [plugin documentation](https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-run-script) for more information.
 
 ### Examples
 

--- a/www/_template/posts/2020-07-30-snowpack-2-7-release.md
+++ b/www/_template/posts/2020-07-30-snowpack-2-7-release.md
@@ -80,7 +80,7 @@ If you don't use a bundler in production, you'll still see a smaller build. That
 
 Last week, [Svelte announced official support for TypeScript](https://svelte.dev/blog/svelte-and-typescript). We're huge fans of both projects and couldn't pass up the chance to test the new support out in a brand new Svelte + TypeScript app template for Snowpack.
 
-Visit [Create Snowpack App](https://github.com/snowpackjs/snowpack/tree/master/create-snowpack-app) for a list of all of our new app templates.
+Visit [Create Snowpack App](https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app) for a list of all of our new app templates.
 
 ## Thank You, Contributors!
 


### PR DESCRIPTION
## Changes

The default branch was changed to `main` in https://github.com/snowpackjs/snowpack/pull/1632
This PR updates the master references to main in package.json and READMEs.

## Testing

<!-- How was this change tested? -->
Yes, links were clicked in the README to ensure they go to main branch.

## Docs

<!-- Was public documentation updated? -->
Yes. The references to master were updated to main in READMEs.
