### PR TITLE
esinstall: Update external packages support

### DIFF
--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -229,6 +229,7 @@ interface InstallOptions {
   polyfillNode: boolean;
   sourceMap?: boolean | 'inline';
   externalPackage: string[];
+  externalPackageEsm: string[];
   packageLookupFields: string[];
   namedExports: string[];
   rollup: {
@@ -252,6 +253,7 @@ function setOptionDefaults(_options: PublicInstallOptions): InstallOptions {
     logger: console,
     dest: 'web_modules',
     externalPackage: [],
+    externalPackageEsm: [],
     polyfillNode: false,
     packageLookupFields: [],
     env: {},
@@ -277,7 +279,8 @@ export async function install(
     logger,
     dest: destLoc,
     namedExports,
-    externalPackage: externalPackages,
+    externalPackage,
+    externalPackageEsm,
     sourceMap,
     env: userEnv,
     rollup: userDefinedRollup,
@@ -294,7 +297,7 @@ export async function install(
     installTargets
       .filter(
         (dep) =>
-          !externalPackages.some((packageName) => isImportOfPackage(dep.specifier, packageName)),
+          !externalPackage.some((packageName) => isImportOfPackage(dep.specifier, packageName)),
       )
       .map((dep) => dep.specifier)
       .map((specifier) => {
@@ -359,7 +362,7 @@ ${colors.dim(
   const inputOptions: InputOptions = {
     input: installEntrypoints,
     context: userDefinedRollup.context,
-    external: (id) => externalPackages.some((packageName) => isImportOfPackage(id, packageName)),
+    external: (id) => externalPackage.some((packageName) => isImportOfPackage(id, packageName)),
     treeshake: {moduleSideEffects: 'no-external'},
     plugins: [
       rollupPluginAlias({
@@ -388,7 +391,7 @@ ${colors.dim(
       rollupPluginReplace(generateEnvReplacements(env)),
       rollupPluginCommonjs({
         extensions: ['.js', '.cjs'],
-        externalEsm: process.env.EXTERNAL_ESM_PACKAGES || [],
+        esmExternals: externalPackageEsm,
         requireReturnsDefault: 'auto',
       } as RollupCommonJSOptions),
       rollupPluginWrapInstallTargets(!!isTreeshake, autoDetectNamedExports, installTargets, logger),

--- a/test/esinstall/config-external/package.json
+++ b/test/esinstall/config-external/package.json
@@ -9,19 +9,23 @@
   "snowpack": {
     "installOptions": {
       "externalPackage": [
+        "config-external-pkg-b",
+        "config-external-pkg-c"
+      ],
+      "externalPackageEsm": [
         "config-external-pkg-b"
       ]
     },
     "install": [
-      "config-external-pkg-a"
-    ],
-    "buildOptions": {
-      "minify": false
-    }
+      "config-external-pkg-a",
+      "config-external-pkg-cjs"
+    ]
   },
   "dependencies": {
     "config-external-pkg-a": "file:./packages/config-external-pkg-a",
-    "config-external-pkg-b": "file:./packages/config-external-pkg-b"
+    "config-external-pkg-b": "file:./packages/config-external-pkg-b",
+    "config-external-pkg-c": "file:./packages/config-external-pkg-c",
+    "config-external-pkg-cjs": "file:./packages/config-external-pkg-cjs"
   },
   "devDependencies": {
     "snowpack": "^2.14.3"

--- a/test/esinstall/config-external/packages/config-external-pkg-a/entrypoint.js
+++ b/test/esinstall/config-external/packages/config-external-pkg-a/entrypoint.js
@@ -1,3 +1,4 @@
 import {foo} from 'config-external-pkg-b';
 import {foo as foo_} from 'config-external-pkg-b/entrypoint';
-console.log(foo, foo_);
+import bar from 'config-external-pkg-c';
+console.log(foo, foo_, bar);

--- a/test/esinstall/config-external/packages/config-external-pkg-c/entrypoint.js
+++ b/test/esinstall/config-external/packages/config-external-pkg-c/entrypoint.js
@@ -1,0 +1,1 @@
+module.exports = {foo: 42};

--- a/test/esinstall/config-external/packages/config-external-pkg-c/package.json
+++ b/test/esinstall/config-external/packages/config-external-pkg-c/package.json
@@ -1,0 +1,6 @@
+
+{
+  "name": "config-external-pkg-c",
+  "version": "1.2.3",
+  "module":  "entrypoint.js"
+}

--- a/test/esinstall/config-external/packages/config-external-pkg-cjs/entrypoint.js
+++ b/test/esinstall/config-external/packages/config-external-pkg-cjs/entrypoint.js
@@ -1,0 +1,3 @@
+const foo = require('config-external-pkg-b');
+const _foo = require('config-external-pkg-c');
+console.log(foo, _foo);

--- a/test/esinstall/config-external/packages/config-external-pkg-cjs/package.json
+++ b/test/esinstall/config-external/packages/config-external-pkg-cjs/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "config-external-pkg-cjs",
+  "version": "1.2.3",
+  "main":  "entrypoint.js"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5275,6 +5275,12 @@ config-chain@^1.1.11, config-chain@^1.1.12:
 "config-external-pkg-b@file:./test/esinstall/config-external/packages/config-external-pkg-b":
   version "1.2.3"
 
+"config-external-pkg-c@file:./test/esinstall/config-external/packages/config-external-pkg-c":
+  version "1.2.3"
+
+"config-external-pkg-cjs@file:./test/esinstall/config-external/packages/config-external-pkg-cjs":
+  version "1.2.3"
+
 connect-history-api-fallback@^1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz#8b32089359308d111115d81cad3fceab888f97bc"


### PR DESCRIPTION
## Changes

- update outdated externalEsm  to new esmExternals 
- Add ability to pass esmExternals via option instead of process.env

## Testing

- Test added

## Docs

- N/A (behavior is not publicly useful)