### PR TITLE
Removed utf8 encoding

### DIFF
--- a/plugins/web-test-runner-plugin/plugin.js
+++ b/plugins/web-test-runner-plugin/plugin.js
@@ -37,7 +37,7 @@ To Resolve:
         return;
       }
       const reqPath = request.path;
-      const result = await server.loadUrl(reqPath, {isSSR: false, encoding: 'utf8'});
+      const result = await server.loadUrl(reqPath, {isSSR: false});
       return {body: result.contents, type: result.contentType};
     },
     transformImport({source}) {


### PR DESCRIPTION
The utf8 encoding breaks images from loading. Only noticed because I've built a small image editor and needed to load the image into canvas. Using this plugin broke some of my tests. Removing it fixes the issue and doesn't appear to have any negative effects.

More details here https://github.com/modernweb-dev/web/issues/980

## Changes

Removed default utf8 encoding, to allow images to be served correctly.

## Testing

Not tested because I removed code, not added it. So I'd presume any tests written for this would break if I
broke anything :wink: 

## Docs

bug fix only
