### PR TITLE
feat: Support WASM as top-level import/resource

### DIFF
--- a/docs/04-features.md
+++ b/docs/04-features.md
@@ -191,7 +191,7 @@ Popular frameworks can also be set up for HMR. **[Create Snowpack App (CSA)](htt
 - Svelte: [A few lines of code](https://github.com/snowpackjs/snowpack/blob/master/create-snowpack-app/app-template-svelte/src/index.js#L9-L16)
 - Vue: [A few lines of code](https://github.com/snowpackjs/snowpack/blob/master/create-snowpack-app/app-template-vue/src/index.js#L7-L14)
 
-For more advanced, bare-metal HMR integrations, Snowpack created [ESM-HMR](https://github.com/snowpackjs/esm-hot-module-replacement-spec), a standard HMR API for any ESM-based dev environment. Any HMR integration built for ESM-HMR will run on Snowpack and any other ESM-HMR-enabled dev server. To use the HMR API directly (via `import.meta.hot`) check out [the ESM-HMR spec](https://github.com/snowpackjs/esm-hot-module-replacement-spec) to learn more.
+For more advanced, bare-metal HMR integrations, Snowpack created [ESM-HMR](https://github.com/snowpackjs/esm-hmr), a standard HMR API for any ESM-based dev environment. Any HMR integration built for ESM-HMR will run on Snowpack and any other ESM-HMR-enabled dev server. To use the HMR API directly (via `import.meta.hot`) check out [the ESM-HMR spec](https://github.com/snowpackjs/esm-hmr) to learn more.
 
 ```js
 if (import.meta.hot) {
@@ -204,7 +204,7 @@ if (import.meta.hot) {
 }
 ```
 
-- 👉 **[Check out the full ESM-HMR spec.](https://github.com/snowpackjs/esm-hot-module-replacement-spec)**
+- 👉 **[Check out the full ESM-HMR spec.](https://github.com/snowpackjs/esm-hmr)**
 
 ### Dev Request Proxy
 

--- a/docs/10-reference.md
+++ b/docs/10-reference.md
@@ -179,10 +179,6 @@ Options:
 
 - **`devOptions.port`** | `number` | Default: `8080`
   - The port number to run the dev server on.
-- **`devOptions.bundle`** | `boolean`
-  - Create an optimized, bundled build for production.
-  - You must have [Parcel](https://parceljs.org/) as a dev dependency in your project.
-  - If undefined, this option will be enabled if the `parcel` package is found.
 - **`devOptions.fallback`** | `string` | Default: `"index.html"`
   - When using the Single-Page Application (SPA) pattern, this is the HTML "shell" file that gets served for every (non-resource) user route. Make sure that you configure your production servers to serve this as well.
 - **`devOptions.open`** | `string` | Default: `"default"`

--- a/snowpack/src/build/build-import-proxy.ts
+++ b/snowpack/src/build/build-import-proxy.ts
@@ -119,15 +119,15 @@ function generateWasmImportProxy({
   hmr: boolean;
   config: SnowpackConfig;
 }) {
-  const wasmImportProxyCode = `export default async () => {
-  const response = await fetch(${JSON.stringify(url)});
-  const resultObj = await WebAssembly.instantiateStreaming(response, {
-    module: {},
-    env: {
-      abort() {
-      },
+  const wasmImportProxyCode = `export default async (importObjects={
+  module: {},
+  env: {
+    abort() {
     },
-  });
+  },
+}) => {
+  const response = await fetch(${JSON.stringify(url)});
+  const resultObj = await WebAssembly.instantiateStreaming(response, importObjects);
   return resultObj.instance;
 }
   `

--- a/snowpack/src/build/build-import-proxy.ts
+++ b/snowpack/src/build/build-import-proxy.ts
@@ -119,18 +119,17 @@ function generateWasmImportProxy({
   hmr: boolean;
   config: SnowpackConfig;
 }) {
-  const wasmImportProxyCode = `
-  export default async () => {
-    const response = await fetch(${JSON.stringify(url)});
-    const resultObj = await WebAssembly.instantiateStreaming(response, {
-      module: {},
-      env: {
-        abort() {
-        },
+  const wasmImportProxyCode = `export default async () => {
+  const response = await fetch(${JSON.stringify(url)});
+  const resultObj = await WebAssembly.instantiateStreaming(response, {
+    module: {},
+    env: {
+      abort() {
       },
-    });
-    return resultObj.instance;
-  }
+    },
+  });
+  return resultObj.instance;
+}
   `
   return wrapImportMeta({code: wasmImportProxyCode, hmr, env: false, config});
 }

--- a/snowpack/src/build/build-import-proxy.ts
+++ b/snowpack/src/build/build-import-proxy.ts
@@ -119,7 +119,7 @@ function generateWasmImportProxy({
   hmr: boolean;
   config: SnowpackConfig;
 }) {
-  const wasmImportProxyCode = `export default async (importObjects={
+  const wasmImportProxyCode = `export default async (importObject={
   module: {},
   env: {
     abort() {
@@ -127,7 +127,7 @@ function generateWasmImportProxy({
   },
 }) => {
   const response = await fetch(${JSON.stringify(url)});
-  const resultObj = await WebAssembly.instantiateStreaming(response, importObjects);
+  const resultObj = await WebAssembly.instantiateStreaming(response, importObject);
   return resultObj.instance;
 }
   `


### PR DESCRIPTION
## Discussion
https://github.com/snowpackjs/snowpack/discussions/1053

## Usage
<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->


```js
// in src/js/index.js
import factorialWasm from "./factorial.wasm";

const instance = await factorialWasm(/*importObject*/);
console.log(instance.exports.factorial(5)); //120
```

```js
// in _dist_/js/factorial.wasm.proxy.js
export default async (importObject={
  module: {},
  env: {
    abort() {
    },
  },
}) => {
  const response = await fetch("/_dist_/js/factorial.wasm");
  const resultObj = await WebAssembly.instantiateStreaming(response, importObject);
  return resultObj.instance;
}
```

## Changes

Create wasm import proxy function (`generateWasmImportProxy`) for automatically load wasm instance. (`snowpack/src/build/build-import-proxy.ts`)

1. Allow we use import to relative `.wasm` file and `node_modules` dependency
2. Once we import it, bundler will build it to `_dist_`  or `web_modules`

Note: In fact, we can manually do this `.wasm.proxy.js` logic in client-side after copying `.wasm` to public folder, but it will hard to use the dependency wasm.

## Reviewer
@FredKSchott 

## Todo

- [x] Pass the `importObjects` when instance create

## Testing
TBD
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs
TBD
