### PR TITLE
Esinstall: Allow resolution of inner package files

### DIFF
--- a/esinstall/src/rollup-plugins/rollup-plugin-node-process-polyfill.ts
+++ b/esinstall/src/rollup-plugins/rollup-plugin-node-process-polyfill.ts
@@ -6,6 +6,7 @@ const PROCESS_MODULE_NAME = 'process';
 export function rollupPluginNodeProcessPolyfill(env = {}): Plugin {
   const injectPlugin = inject({
     process: PROCESS_MODULE_NAME,
+    include: ['*.js', '*.mjs', '*.cjs'],
   });
 
   return {

--- a/esinstall/src/util.ts
+++ b/esinstall/src/util.ts
@@ -184,3 +184,9 @@ export function createInstallTarget(specifier: string, all = true): InstallTarge
     named: [],
   };
 }
+
+/** Is this file JavaScript?  */
+export function isJavaScript(pathname: string) {
+  const ext = path.extname(pathname).toLowerCase();
+  return ext === '.js' || ext === '.mjs' || ext === '.cjs';
+}


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

**Before**
```
esinstall('react/LICENSE');

// [ERROR] Package " node_modules/react/LICENSE" not found. Have you installed it?
```

**After**
```
esinstall('react/LICENSE');

// ✅
```

## Testing

Tested in local build setup. Tested against:

- @material-ui__core@4.11.0
- @vue__runtime-dom@3.0.2
- antd@4.8.4 
- aria-query@4.2.2
- bulma@0.9.1
- lit-element@2.4.0
- lit-html@1.3.0
- preact@10.5.7
- react-dom@17.0.1
- react@17.0.1
- svelte@3.29.7 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
