### PR TITLE
chore: bump version for release

### DIFF
--- a/plugins/plugin-postcss/package.json
+++ b/plugins/plugin-postcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowpack/plugin-postcss",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "main": "plugin.js",
   "license": "MIT",
   "homepage": "https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-postcss#readme",


### PR DESCRIPTION
## Changes

Please see #1641, I forgot to bump version and I can install only version 1.0.7 where there's no `execa` in deps.

## Testing

Just bumped version for postcss plugin in package.json to publish a new version.

## Docs

bugfix only