### PR TITLE
chore: add app-template-glimmer to community templates

### DIFF
--- a/create-snowpack-app/cli/README.md
+++ b/create-snowpack-app/cli/README.md
@@ -35,4 +35,5 @@ npx create-snowpack-app new-dir --template @snowpack/app-template-NAME [--use-ya
 - [snowpack-mdx-chakra](https://github.com/molebox/snowpack-mdx)(An opinionated template setup with MDX, Chakra-ui for styling, theme and components, and React Router v6 for routing.)
 - [snowpack-svelte-ts-tw](https://github.com/GarrettCannon/snowpack-svelte-ts-tw) (Snowpack + Svelte + Typescript + TailwindCSS)
 - [snowpack-template-tailwind](https://github.com/jonalvarezz/snowpack-template-tailwind) (Snowpack + TailwindCSS + Autopublish to GitHub Pages)
+- [snowpack-app-template-glimmer](https://github.com/rajasegar/snowpack-app-template-glimmer) (Snowpack + [Glimmer.js](https://glimmerjs.com))
 - PRs that add a link to this list are welcome!


### PR DESCRIPTION
## Changes

This adds a new template called `snowpack-app-template-glimmer` to the list of community templates for CSA

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
