### PR TITLE
Mark @web/dev-server import as external

### DIFF
--- a/plugins/web-test-runner-plugin/plugin.js
+++ b/plugins/web-test-runner-plugin/plugin.js
@@ -13,7 +13,10 @@ To Resolve:
   }
   const pkgManifest = require(path.join(cwd, 'package.json'));
   const config = snowpack.loadAndValidateConfig(
-    {devOptions: {hmr: false, open: 'none', output: 'stream'}},
+    {
+      externalPackage: ['/__web-dev-server__web-socket.js'],
+      devOptions: {hmr: false, open: 'none', output: 'stream'},
+    },
     pkgManifest,
   );
   let server;


### PR DESCRIPTION


## Changes

Marks an internal @web/dev-server import as external that would otherwise cause an error in snowpacks install process. This is imported by [`@web/test-runner-commands`](https://github.com/modernweb-dev/web/blob/master/packages/test-runner-commands/browser/commands.mjs)

See discussion #1732 for further details

## Testing

After adding this to my local snowpack config, my tests could run. After removing it an deleting the snowpack cache the tests failed again and finally after applying this patch they started to work again.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
No docs, only a bug fix to avoid having to document an otherwise necessary config change.
