### PR TITLE
Docs: fixing broken links, auditing guides

### DIFF
--- a/www/_template/guides.md
+++ b/www/_template/guides.md
@@ -12,7 +12,7 @@ title: Guides
   grid-auto-flow: dense;
   }
   .discord-banner {
-    grid-column: 1 / -1;     
+    grid-column: 1 / -1;
     border: 1px solid #2e2077;
     background-color: #545eec;
     display: flex;
@@ -23,7 +23,7 @@ title: Guides
     padding: 1.25rem;
   margin: 1.5rem 0 1rem;
 background: #545eec;
-box-shadow:  10px 10px 30px #4750c966, 
+box-shadow:  10px 10px 30px #4750c966,
              -10px -10px 30px #616cff66;
   }
   .discord-banner > * {
@@ -41,7 +41,7 @@ box-shadow:  10px 10px 30px #4750c966,
 
   .news-item {
     display: flex;
-    grid-column: span 1;  
+    grid-column: span 1;
     overflow: hidden;
     font-family: Open Sans,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif;
     color: #1a202c;
@@ -76,7 +76,7 @@ box-shadow:  10px 10px 30px #4750c966,
 }
 
 .news-item:nth-child(5n+0) .news-item-image {
-  background: #f2709c; 
+  background: #f2709c;
     background: linear-gradient(30deg, #ff9472, #f2709c);
 }
 .news-item:nth-child(5n+1) .news-item-image {
@@ -110,12 +110,12 @@ background: linear-gradient(30deg, #A7BFE8, #6190E8);
 <div class="content">
 
 - [Routing](/guides/routing)
-- [Server-Side Render](/guides/server-side-render)
+- [Server-Side Rendering](/guides/server-side-render)
 - [SSL, HTTPS, and HTTP/2 in Development](/guides/https-ssl-certificates)
 - [Connecting your dev tools](/guides/connecting-tools)
 - [Bundling for Deployment](/guides/bundling)
 - [Testing](/guides/testing)
-
+- [Leaving Snowpack](/guides/leaving-snowpack)
 </div>
 
 <br/>

--- a/www/_template/guides/bundling.md
+++ b/www/_template/guides/bundling.md
@@ -1,6 +1,7 @@
 ---
 layout: layouts/content.njk
 title: Bundling your Snowpack site for production
+published: true
 ---
 
 `snowpack build` is fine for many projects, but you also may still want to bundle to optimize code, especially with large projects. Snowpack handles legacy browser support, code minification, code-splitting, tree-shaking, dead code elimination, and other performance optimizations via bundling. In this step you'll install the Webpack plugin and use it to build our project.

--- a/www/_template/guides/connecting-tools.md
+++ b/www/_template/guides/connecting-tools.md
@@ -2,6 +2,7 @@
 layout: layouts/content.njk
 title: The Snowpack Guide to connecting your favorite tools
 description: 'How do you use your favorite tools in Snowpack? This Guide will help you get started'
+published: true
 ---
 
 One of the most common questions we get is "How do I connect my favorite tool to Snowpack?" In this guide we'll go over the three different ways that you can integrate third-party tooling into your Snowpack dev environment or build pipeline:
@@ -49,7 +50,7 @@ What about the other optional configuration options? [The `@snowpack/plugin-sass
   ],
 ```
 
-If there isn't a plugin yet, you might be interested in making one. Check out our [Guide to creating a plugin](/guide/plugins)
+If there isn't a plugin yet, you might be interested in making one. Check out our [Plugin API](/reference/plugins)
 
 ## Connect any other Script/CLI using plugin-run-script and plugin-build-script
 

--- a/www/_template/guides/hmr.md
+++ b/www/_template/guides/hmr.md
@@ -1,7 +1,12 @@
 ---
 layout: layouts/content.njk
 title: Hot Module Replacement (HMR)
+published: false
 ---
+
+<div class="stub">
+This article is a stub, you can help fix it by removing duplicate content from /concepts/hot-module-replacement and writing it in a <a href="https://documentation.divio.com/how-to-guides/">guide format</a>
+</div>
 
 Hot Module Replacement (HMR) is the ability for Snowpack to push file changes to the browser without triggering a full page refresh. This article is about enabling HMR and connecting to the HMR dev server.
 
@@ -17,7 +22,7 @@ You can tell if HMR is connected by checking your browser dev console. If you se
 
 ### Enable HMR: Snowpack Dev Server
 
-HMR is enabled by default when you run `snowpack dev`. The Snowpack dev server will add the necessary scripts for your browser, and no configuration is required for most users. You can toggle this support off during development via the [`devOptions.hmr` configuration option](/configuration).
+HMR is enabled by default when you run `snowpack dev`. The Snowpack dev server will add the necessary scripts for your browser, and no configuration is required for most users. You can toggle this support off during development via the [`devOptions.hmr` configuration option](/reference/configuration).
 
 ### Enable HMR: Custom Server
 

--- a/www/_template/guides/jest.md
+++ b/www/_template/guides/jest.md
@@ -3,6 +3,7 @@ layout: layouts/content.njk
 title: 'Jest'
 tags: communityGuide
 img: 'https://moumen-soliman.github.io/frontend-helper/static/img/jest.6d3adcf.jpg'
+published: true
 ---
 
 [Jest](https://jestjs.io/) is a popular Node.js test runner for Node.js & web projects. Jest can be used with any frontend project as long as you configure how Jest should build your frontend files to run on Node.js. Many projects will try to manage this configuration for you, since it can get complicated.

--- a/www/_template/guides/leaving-snowpack.md
+++ b/www/_template/guides/leaving-snowpack.md
@@ -1,9 +1,8 @@
 ---
 layout: layouts/content.njk
 title: Leaving Snowpack
+published: true
 ---
-
-### Leaving Snowpack
 
 Snowpack is designed for zero lock-in. If you ever feel the need to add a traditional application bundler to your stack (for whatever reason!) you can do so in seconds.
 

--- a/www/_template/guides/optimize.md
+++ b/www/_template/guides/optimize.md
@@ -1,7 +1,12 @@
 ---
 layout: layouts/content.njk
 title: Optimize for production
+published: false
 ---
+
+<div class="stub">
+This article is a stub, you can help fix it by removing duplicate content from /guides/bundling and writing it in a <a href="https://documentation.divio.com/how-to-guides/">guide format</a>
+</div>
 
 There are several plugins available to optimize your final build with popular bundlers like Webpack, Parcel, and (more recently) Rollup. Third-party bundlers are well-tested and well-supported, making them a great choice for production builds.
 

--- a/www/_template/guides/preact.md
+++ b/www/_template/guides/preact.md
@@ -4,8 +4,6 @@ title: Preact
 tags: communityGuide
 ---
 
-## Preact
-
 You can import and use Preact without any custom configuration needed.
 
 **To use `preact/compat`:** (the Preact+React compatability layer) alias the "compat" package to React in your install options:

--- a/www/_template/guides/react-global-imports.md
+++ b/www/_template/guides/react-global-imports.md
@@ -1,6 +1,7 @@
 ---
 layout: layouts/content.njk
 title: React + babel-plugin-import-global
+published: false
 ---
 
 <div class="notification">

--- a/www/_template/guides/react-loadable-components.md
+++ b/www/_template/guides/react-loadable-components.md
@@ -1,6 +1,7 @@
 ---
 layout: layouts/content.njk
 title: React + Loadable Components
+published: false
 ---
 
 <div class="notification">

--- a/www/_template/guides/routing.md
+++ b/www/_template/guides/routing.md
@@ -1,10 +1,11 @@
 ---
 layout: layouts/content.njk
 title: Routing
+published: true
 ---
 
 <div class="notification">
-Status: Experimental 
+Status: Experimental
 </div>
 
 As a web build tool, Snowpack has no knowledge of how (or where) your application is served in production. But Snowpack's dev server can be customized to recreate something close to your production environment for local development.

--- a/www/_template/guides/sass.md
+++ b/www/_template/guides/sass.md
@@ -2,7 +2,12 @@
 layout: layouts/content.njk
 title: 'Sass'
 tags: communityGuide
+published: true
 ---
+
+<div class="stub">
+This article is a stub, you can help expand it into <a href="https://documentation.divio.com/how-to-guides/">guide format</a>
+</div>
 
 [Sass](https://www.sass-lang.com/) is a stylesheet language that’s compiled to CSS. It allows you to use variables, nested rules, mixins, functions, and more, all with a fully CSS-compatible syntax. Sass helps keep large stylesheets well-organized and makes it easy to share design within and across projects.
 

--- a/www/_template/guides/server-side-render.md
+++ b/www/_template/guides/server-side-render.md
@@ -1,6 +1,7 @@
 ---
 layout: layouts/content.njk
 title: Server-Side Rendering (SSR)
+published: true
 ---
 
 Server-side rendering (SSR) refers to several similar developer stories:
@@ -32,7 +33,7 @@ The downside of this static approach is that you need to wait for Snowpack to bu
 ### Option 2: On Demand (Middleware)
 
 <div class="notification">
-Status: Experimental 
+Status: Experimental
 </div>
 
 The best developer experience is achieved by loading files on-demand. This removes any need for work on startup, giving you a faster developer environment no matter how large your project grows.

--- a/www/_template/guides/tailwind-css.md
+++ b/www/_template/guides/tailwind-css.md
@@ -2,6 +2,7 @@
 layout: layouts/content.njk
 title: 'Tailwind CSS'
 tags: communityGuide
+published: true
 ---
 
 [Tailwind](https://tailwindcss.com) is a popular class-based CSS utility library.

--- a/www/_template/guides/testing.md
+++ b/www/_template/guides/testing.md
@@ -1,6 +1,7 @@
 ---
 layout: layouts/content.njk
 title: Testing
+published: true
 ---
 
 Snowpack supports all of the popular JavaScript testing frameworks that you're already familiar with. Mocha, Jest, Jasmine, AVA and Cypress are all supported in Snowpack applications, if integrated correctly.

--- a/www/_template/guides/vue.md
+++ b/www/_template/guides/vue.md
@@ -4,7 +4,10 @@ title: Vue
 tags: communityGuide
 ---
 
-## Vue
+<div class="stub">
+This article is a stub, you can help expand it into <a href="https://documentation.divio.com/how-to-guides/">guide format</a>
+</div>
+To support `.vue` files you will need the [Vue Plugin](https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-vue), which uses Vue 3.
 
 ```js
 // snowpack.config.json

--- a/www/_template/guides/workbox.md
+++ b/www/_template/guides/workbox.md
@@ -4,7 +4,9 @@ title: Workbox
 tags: communityGuide
 ---
 
-### Workbox
+<div class="stub">
+This article is a stub, you can help expand it into <a href="https://documentation.divio.com/how-to-guides/">guide format</a>
+</div>
 
 The [Workbox CLI](https://developers.google.com/web/tools/workbox/modules/workbox-cli) integrates well with Snowpack. Run the wizard to bootstrap your first configuration file, and then run `workbox generateSW` to generate your service worker.
 

--- a/www/_template/index.njk
+++ b/www/_template/index.njk
@@ -24,7 +24,7 @@ layout: layouts/base.njk
               <p>Snowpack is a modern frontend build tool for faster web development. Snowpack pushes changes instantly to the browser, saving you hours of development time traditionally spent waiting around for your bundler.</p>
 
               <div class="feature-list-buttons">
-                <a href="/quick-start" class="button button-primary feature-list-button">Get started</a>
+                <a href="/tutorials/quick-start" class="button button-primary feature-list-button">Get started</a>
                 <a href="/concepts/how-snowpack-works" class="button feature-list-button">Learn more</a>
               </div>
 

--- a/www/_template/tutorials/getting-started.md
+++ b/www/_template/tutorials/getting-started.md
@@ -170,7 +170,7 @@ You should now see a nifty confetti effect on your site.
 
 IMAGE: Gif showing site loading with a confetti effect
 
-> 💡 Tip: not all NPM modules may work well in the browser. If it's dependent on Node.js built-in modules you'll need to polyfill Node. Read more about how to do this on our [features page.](/features)
+> 💡 Tip: not all NPM modules may work well in the browser. If it's dependent on Node.js built-in modules you'll need to polyfill Node. Read more about how to do this on our [Starting a New Project page.](/tutorials/getting-started#using-npm-packages)
 
 ## Adding CSS
 

--- a/www/src/css/components/_old.scss
+++ b/www/src/css/components/_old.scss
@@ -19,6 +19,16 @@ body {
   }
 }
 
+// Stub
+.stub {
+  padding: 0.5rem;
+
+  font-weight: bold;
+  background-color: #f0db4f;
+  a {
+    text-decoration: underline;
+  }
+}
 // Button
 
 .button {
@@ -79,8 +89,8 @@ a.button {
   border: 1px solid #0006;
   border-radius: 4px;
   cursor: pointer;
-  transition: transform 0.5s ease-in-out, width, background-color, transform, color,
-    fill, stroke 0.5s ease-out;
+  transition: transform 0.5s ease-in-out, width, background-color, transform,
+    color, fill, stroke 0.5s ease-out;
 
   svg,
   .faded {


### PR DESCRIPTION
## Changes

Fixing any broken links, auditing guides files, adding `published:false` to those not on the guides page so we can more easily know what's linked. Adding stub info to stub guides and styling. 2

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
