### PR TITLE
feat: add exportConditions config to esinstall

### DIFF
--- a/esinstall/README.md
+++ b/esinstall/README.md
@@ -83,9 +83,10 @@ import {
 } from './types';
 
 interface InstallOptions {
+  cwd: string;
   alias: Record<string, string>;
   lockfile?: ImportMap;
-  logLevel: LoggerLevel;
+  logger: AbstractLogger;
   verbose?: boolean;
   dest: string;
   env: EnvVarReplacements;
@@ -93,8 +94,12 @@ interface InstallOptions {
   polyfillNode: boolean;
   sourceMap?: boolean | 'inline';
   externalPackage: string[];
+  externalPackageEsm: string[];
+  packageLookupFields: string[];
+  packageExportLookupFields: string[];
   namedExports: string[];
   rollup: {
+    context?: string;
     plugins?: RollupPlugin[];
     dedupe?: string[];
   };

--- a/esinstall/package.json
+++ b/esinstall/package.json
@@ -43,7 +43,7 @@
     "@rollup/plugin-commonjs": "^16.0.0",
     "@rollup/plugin-inject": "^4.0.2",
     "@rollup/plugin-json": "^4.0.0",
-    "@rollup/plugin-node-resolve": "^10.0.0",
+    "@rollup/plugin-node-resolve": "^11.0.0",
     "@rollup/plugin-replace": "^2.3.3",
     "cjs-module-lexer": "^1.0.0",
     "es-module-lexer": "^0.3.24",

--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -234,6 +234,7 @@ interface InstallOptions {
   externalPackage: string[];
   externalPackageEsm: string[];
   packageLookupFields: string[];
+  packageExportLookupFields: string[];
   namedExports: string[];
   rollup: {
     context?: string;
@@ -259,6 +260,7 @@ function setOptionDefaults(_options: PublicInstallOptions): InstallOptions {
     externalPackageEsm: [],
     polyfillNode: false,
     packageLookupFields: [],
+    packageExportLookupFields: [],
     env: {},
     namedExports: [],
     rollup: {
@@ -290,6 +292,7 @@ export async function install(
     treeshake: isTreeshake,
     polyfillNode,
     packageLookupFields,
+    packageExportLookupFields
   } = setOptionDefaults(_options);
   const env = generateEnvObject(userEnv);
 
@@ -391,7 +394,7 @@ ${colors.dim(
         // whether to prefer built-in modules (e.g. `fs`, `path`) or local ones with the same names
         preferBuiltins: true, // Default: true
         dedupe: userDefinedRollup.dedupe || [],
-        exportConditions: packageLookupFields,
+        exportConditions: packageExportLookupFields
       }),
       rollupPluginJson({
         preferConst: true,

--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -391,6 +391,7 @@ ${colors.dim(
         // whether to prefer built-in modules (e.g. `fs`, `path`) or local ones with the same names
         preferBuiltins: true, // Default: true
         dedupe: userDefinedRollup.dedupe || [],
+        exportConditions: packageLookupFields,
       }),
       rollupPluginJson({
         preferConst: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2474,6 +2474,18 @@
     is-module "^1.0.0"
     resolve "^1.17.0"
 
+"@rollup/plugin-node-resolve@^11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.0.0.tgz#770458fb26691a686c5f29f37dded94832ffce59"
+  integrity sha512-8Hrmwjn1pLYjUxcv7U7IPP0qfnzEJWHyHE6CaZ8jbLM+8axaarJRB1jB6JgKTDp5gNga+TpsgX6F8iuvgOerKQ==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    "@types/resolve" "1.17.1"
+    builtin-modules "^3.1.0"
+    deepmerge "^4.2.2"
+    is-module "^1.0.0"
+    resolve "^1.19.0"
+
 "@rollup/plugin-replace@^2.3.3":
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-2.3.4.tgz#7dd84c17755d62b509577f2db37eb524d7ca88ca"
@@ -12339,7 +12351,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2, resolve@^1.8.1:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.3.2, resolve@^1.8.1:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
   integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==


### PR DESCRIPTION
## Changes

Rollup Plugin Node Resolve 11.0.0 adds support for custom export map resolution:
https://github.com/rollup/plugins/tree/master/packages/node-resolve#exportconditions

This is important for universal package aliasing for non-node environments. It's a blocker for using Snowpack as official dev tool in the [SolidJS](https://github.com/ryansolid/solid) framework to enable SSR. I added this as a rollup config option the same as dedupe.

Discussion: #1758

## Testing

This is a 2 liner change, mind you the update to rollup plugin node resolve 11.0.0 broke many tests before I even began adding the feature. It's possible that they've changed other resolution with the latest version.

## Docs

I updated the Readme.md on esinstall. To my knowledge the specific options aren't currently documented anywhere.
