### PR TITLE
Fix search hotspot

### DIFF
--- a/www/src/css/components/_search.scss
+++ b/www/src/css/components/_search.scss
@@ -36,6 +36,7 @@
     padding: 6px 12px;
     color: #c2ced9;
     font-size: 16px;
+    pointer-events: none;
 
     & * {
       font-family: $code;
@@ -83,14 +84,13 @@
     -webkit-font-smoothing: antialiased;
 
     &:focus {
-        color: white;
-    border-color: rgba($white, 0.75);
+      color: white;
+      border-color: rgba($white, 0.75);
 
-    &::placeholder {
-        color:  rgba($white, 0.8);
+      &::placeholder {
+        color: rgba($white, 0.8);
       }
-  
-}
+    }
     &::placeholder {
       color: #c2ced9;
     }


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

![Screen Shot 2020-12-01 at 11 55 10](https://user-images.githubusercontent.com/1369770/100784441-6e314600-33cc-11eb-9aca-552e8d87b76d.png)

This area, when clicked, doesn‘t focus on the search. I’d expect clicking in here to focus on search. This makes it so

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

