### PR TITLE
Removed line-height from button

### DIFF
--- a/www/src/css/components/_old.scss
+++ b/www/src/css/components/_old.scss
@@ -40,7 +40,6 @@ body {
   font-size: 22px;
   font-family: inherit;
   font-family: 'Overpass', sans-serif;
-  line-height: normal;
   white-space: nowrap;
   text-align: center;
   text-decoration: none;


### PR DESCRIPTION
## Changes

The new website is awesome! I really like the changes. However my eye was instantly drawn to the line height in the Get Started button, when i removed it i noticed that it affected alot of small places. 

Before, with line-height:
![with-line-height-normal](https://user-images.githubusercontent.com/22930449/100850946-d2174580-3484-11eb-8c5a-dd1323c53e36.PNG)

After, line-height removed:
![line-height-removed](https://user-images.githubusercontent.com/22930449/100850999-df343480-3484-11eb-82f6-e46fb11df24e.PNG)

Its a small change, but it makes a big difference to how the buttons looks. Im no designer but i noticed it straight away. Of course, id understand if you think this is a silly change. Im not one to create random PRs on repos for the hell of it.

## Testing

Manual test of seeing the change in the browser
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

No docs update needed. This is purely a visual change
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
