### PR TITLE
add link to plugin-optimize

### DIFF
--- a/www/_template/guides/bundling.md
+++ b/www/_template/guides/bundling.md
@@ -33,4 +33,4 @@ Again run
 npm run build
 ```
 
-> 💡 Tip: Want to optimize your site code without a bundler? Check out our plugin-optimize.
+> 💡 Tip: Want to optimize your site code without a bundler? Check out our [plugin-optimize](https://www.skypack.dev/view/@snowpack/plugin-optimize).


### PR DESCRIPTION
## Changes

Added a link to https://www.skypack.dev/view/@snowpack/plugin-optimize for the Tip mentioning plugin-optimize.

Before:
![before](https://user-images.githubusercontent.com/465547/101048565-02dda480-3583-11eb-89bb-7393bf740c4e.png)
After:
![after](https://user-images.githubusercontent.com/465547/101048559-01ac7780-3583-11eb-8153-82235008a8bf.png)




## Testing

No tests added. Afaict there are not tests for www.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
This is an update to the docs.
