### PR TITLE
Fix Skypack SDK dependencies for Yarn 2 PnP

### DIFF
--- a/skypack/package.json
+++ b/skypack/package.json
@@ -44,8 +44,11 @@
   "dependencies": {
     "cacache": "^15.0.0",
     "cachedir": "^2.3.0",
+    "etag": "^1.8.1",
+    "find-up": "^5.0.0",
     "got": "^11.1.4",
     "kleur": "^4.1.0",
+    "mkdirp": "^1.0.3",
     "p-queue": "^6.2.1",
     "rimraf": "^3.0.0",
     "rollup": "^2.23.0",


### PR DESCRIPTION
## Changes
As Yarn 2 is strict with unlisted dependencies, it errors out with following for 3 packages: `etag`, `mkdirp` and `find-up`:
```
Error: skypack tried to access mkdirp, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
```

Declared the missing `utils.ts` dependencies in skypack module package.json, used the same version as elsewhere.

## Testing
Tested locally, it is hard to do it properly as Snowpack is running Yarn v1

## Docs

Bug fix only
