### PR TITLE
Fix: support Windows path separator in optimize fake build directory regex

### DIFF
--- a/snowpack/src/build/optimize.ts
+++ b/snowpack/src/build/optimize.ts
@@ -46,7 +46,7 @@ interface ScannedHtmlEntrypoint {
 // has a bug where it complains about overwriting source files even when write: false.
 // We create a fake bundle directory for now. Nothing ever actually gets written here.
 const FAKE_BUILD_DIRECTORY = path.join(PROJECT_CACHE_DIR, '~~bundle~~');
-const FAKE_BUILD_DIRECTORY_REGEX = /.*\~\~bundle\~\~\//;
+const FAKE_BUILD_DIRECTORY_REGEX = /.*\~\~bundle\~\~[\\\/]/;
 /**
  * Scan a directory and remove any empty folders, recursively.
  */
@@ -494,9 +494,9 @@ export async function runBuiltInOptimize(config: SnowpackConfig) {
   logger.debug(`bundleEntrypoints: ${JSON.stringify(bundleEntrypoints)}`);
 
   if ((!htmlEntrypoints || htmlEntrypoints.length === 0) && bundleEntrypoints.length === 0) {
-      throw new Error(
-        '[optimize] No HTML entrypoints detected. Set "entrypoints" manually if your site HTML is generated outside of Snowpack (SSR, Rails, PHP, etc.).',
-      );
+    throw new Error(
+      '[optimize] No HTML entrypoints detected. Set "entrypoints" manually if your site HTML is generated outside of Snowpack (SSR, Rails, PHP, etc.).',
+    );
   }
 
   // NOTE: esbuild has no `cwd` support, and assumes that you're always bundling the


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
Fixes wrong output paths when using new built-in optimize feature on Windows machine. Without this fix files are actually written to fake build directory.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->
Works on my machine (TM). No tests added - the fix is tiny and I did not find existing tests for this feature. 

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
No - bug fix only.