### PR TITLE
fix sourcemap in dev mode

### DIFF
--- a/plugins/plugin-react-refresh/plugin.js
+++ b/plugins/plugin-react-refresh/plugin.js
@@ -33,7 +33,7 @@ function transformHtml(contents) {
 
 const babel = require('@babel/core');
 const IS_FAST_REFRESH_ENABLED = /\$RefreshReg\$\(/;
-async function transformJs(contents, id, skipTransform, srcPath, inputSourceMap, sourceMaps) {
+async function transformJs(contents, id, skipTransform, inputSourceMap, sourceMaps) {
   let fastRefreshEnhancedCode;
   let outputMap;
 
@@ -51,7 +51,6 @@ async function transformJs(contents, id, skipTransform, srcPath, inputSourceMap,
       filename: id,
       ast: false,
       compact: false,
-      sourceFileName: srcPath,
       sourceMaps,
       inputSourceMap: inputSourceMap ? JSON.parse(inputSourceMap) : undefined,
       configFile: false,
@@ -104,7 +103,7 @@ if (import.meta.hot) {
 module.exports = function reactRefreshTransform(snowpackConfig, {babel}) {
   return {
     name: '@snowpack/plugin-react-refresh',
-    transform({contents, fileExt, id, isDev, srcPath, inputSourceMap}) {
+    transform({contents, fileExt, id, isDev, inputSourceMap}) {
       // Use long-form "=== false" to handle older Snowpack versions
       if (snowpackConfig.devOptions.hmr === false) {
         return;
@@ -116,7 +115,7 @@ module.exports = function reactRefreshTransform(snowpackConfig, {babel}) {
         const skipTransform = babel === false;
         const sourceMaps =
           snowpackConfig.buildOptions && snowpackConfig.buildOptions.sourceMaps ? true : false;
-        return transformJs(contents, id, skipTransform, srcPath, inputSourceMap, sourceMaps);
+        return transformJs(contents, id, skipTransform, inputSourceMap, sourceMaps);
       }
       if (fileExt === '.html') {
         return transformHtml(contents);

--- a/snowpack/src/build/build-pipeline.ts
+++ b/snowpack/src/build/build-pipeline.ts
@@ -112,10 +112,7 @@ async function runPipelineLoadStep(
   };
 }
 
-/**
- * Todo: should we remove composeSourceMaps
- */
-export async function composeSourceMaps(
+async function composeSourceMaps(
   id: string,
   base: string | RawSourceMap,
   derived: string | RawSourceMap,
@@ -167,7 +164,6 @@ async function runPipelineTransformStep(
           isDev,
           fileExt: destExt,
           id: filePath,
-          srcPath,
           inputSourceMap: destMap,
           // @ts-ignore: Deprecated
           filePath: fileName,
@@ -197,6 +193,9 @@ async function runPipelineTransformStep(
             // if source maps disabled, don’t return any
             if (map) {
               outputMap = typeof map === 'object' ? JSON.stringify(map) : map;
+              if (destBuildFile.map) {
+                outputMap = await composeSourceMaps(filePath, destBuildFile.map, outputMap);
+              }
             } else if (destExt === '.js' || destExt === '.css') {
               logger.warn(`source-map file not found in [${debugPath}]`, {name: step.name});
             }

--- a/snowpack/src/commands/build.ts
+++ b/snowpack/src/commands/build.ts
@@ -174,7 +174,7 @@ class FileBuilder {
               const cssFilename = outFilename.replace(/\.js$/i, '.css');
               code = `import './${cssFilename}';\n` + code;
             }
-            code = wrapImportMeta({code, env: true, hmr: false, config: this.config});
+            code = wrapImportMeta({code, env: true, hmr: false, config: this.config}).code;
             if (map) code = jsSourceMappingURL(code, sourceMappingURL);
             this.filesToResolve[outLoc] = {
               baseExt: fileExt,

--- a/snowpack/src/types/snowpack.ts
+++ b/snowpack/src/types/snowpack.ts
@@ -97,6 +97,8 @@ export interface PluginTransformOptions {
   contents: string | Buffer;
   isDev: boolean;
   isHmrEnabled: boolean;
+  srcPath: string;
+  inputSourceMap?: string;
 }
 
 export interface PluginRunOptions {

--- a/snowpack/src/types/snowpack.ts
+++ b/snowpack/src/types/snowpack.ts
@@ -97,7 +97,6 @@ export interface PluginTransformOptions {
   contents: string | Buffer;
   isDev: boolean;
   isHmrEnabled: boolean;
-  srcPath: string;
   inputSourceMap?: string;
 }
 

--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -12,6 +12,7 @@ import open from 'open';
 import path from 'path';
 import rimraf from 'rimraf';
 import {clearCache as clearSkypackCache} from 'skypack';
+import {RawSourceMap} from 'source-map';
 import url from 'url';
 import localPackageSource from './sources/local';
 import skypackPackageSource from './sources/skypack';
@@ -338,6 +339,12 @@ export function cssSourceMappingURL(code: string, sourceMappingURL: string) {
 /** JS sourceMappingURL */
 export function jsSourceMappingURL(code: string, sourceMappingURL: string) {
   return code.replace(/\n*$/, '') + `\n//# sourceMappingURL=${sourceMappingURL}\n`; // strip ending lines & append source map (with linebreaks for safety)
+}
+
+export function offsetSourceMap(map: string | RawSourceMap, lineOffset: number) {
+  const decodedMap = typeof map === 'string' ? (JSON.parse(map) as RawSourceMap) : map;
+  decodedMap.mappings = ';'.repeat(lineOffset) + decodedMap.mappings;
+  return decodedMap;
 }
 
 /** URL relative */


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
- added one new options to the PluginTransformOptions. 
- plugin-react-refresh now returns the contents and source-map.
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->
I am stuck on how to configure the plugin-react-refresh to make babel's skipEnvCheck option to be true.
I am really appreciate if anyone could help.
## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
bug fix only. But the plugin API changed with new options. Should we mark it in the document?