### PR TITLE
fixes errors in the multi-file building example

### DIFF
--- a/www/_template/guides/plugins.md
+++ b/www/_template/guides/plugins.md
@@ -134,10 +134,10 @@ module.exports = function(snowpackConfig, pluginOptions) {
     resolve: {
       input: ['.svelte'],
       output: ['.js', '.css'],
-    }
+    },
     async load({ filePath }) {
       const fileContents = await fs.readFile(filePath, 'utf-8');
-      const { js, css } = svelte.compile(codeToCompile, { filename: filePath });
+      const { js, css } = svelte.compile(fileContents, { filename: filePath });
       return {
         '.js': js && js.code,
         '.css': css && css.code,


### PR DESCRIPTION
## Changes

For anyone following along with the reference/guide docs line-by-line, they would encounter a syntax and reference error in the multi-file building example code. 

1. The syntax error is thrown after the return statement (missing comma). 

2. Once that is fixed, the "codeToCompile" variable is undefined. 

This should fix both errors and allow readers to run the example plugin without any errors.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->
No tests added because it's a change to the documentation via a markdown file

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
No new docs added, just an update to www/_template/guides/plugins.md
