### PR TITLE
Allow jsxFactory and jsxFragment to be passed in buildOptions for use by esbuild

### DIFF
--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -68,6 +68,8 @@ const DEFAULT_CONFIG: SnowpackUserConfig = {
     sourceMaps: false,
     watch: false,
     htmlFragments: false,
+    jsxFactory: undefined,
+    jsxFragment: undefined
   },
   testOptions: {
     files: ['__tests__/**/*', '**/*.@(spec|test).*'],
@@ -171,6 +173,8 @@ const configSchema = {
         watch: {type: 'boolean'},
         ssr: {type: 'boolean'},
         htmlFragments: {type: 'boolean'},
+        jsxFactory: {type: 'string'},
+        jsxFragment: {type: 'string'},
       },
     },
     testOptions: {

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -68,8 +68,6 @@ const DEFAULT_CONFIG: SnowpackUserConfig = {
     sourceMaps: false,
     watch: false,
     htmlFragments: false,
-    jsxFactory: undefined,
-    jsxFragment: undefined
   },
   testOptions: {
     files: ['__tests__/**/*', '**/*.@(spec|test).*'],

--- a/snowpack/src/plugins/plugin-esbuild.ts
+++ b/snowpack/src/plugins/plugin-esbuild.ts
@@ -30,11 +30,17 @@ export function esbuildPlugin(config: SnowpackConfig, {input}: {input: string[]}
     async load({filePath}) {
       esbuildService = esbuildService || (await startService());
       const contents = await fs.readFile(filePath, 'utf-8');
+      let jsxFactory = config.buildOptions.jsxFactory;
+      let jsxFragment = config.buildOptions.jsxFragment;
       const isPreact = checkIsPreact(filePath, contents);
+      if (isPreact) {
+        jsxFactory || (jsxFactory = 'h')
+        jsxFragment || (jsxFragment = 'Fragment')
+      }
       const {code, map, warnings} = await esbuildService!.transform(contents, {
         loader: getLoader(filePath),
-        jsxFactory: isPreact ? 'h' : undefined,
-        jsxFragment: isPreact ? 'Fragment' : undefined,
+        jsxFactory,
+        jsxFragment,
         sourcefile: filePath,
         sourcemap: config.buildOptions.sourceMaps,
       });

--- a/snowpack/src/plugins/plugin-esbuild.ts
+++ b/snowpack/src/plugins/plugin-esbuild.ts
@@ -30,13 +30,9 @@ export function esbuildPlugin(config: SnowpackConfig, {input}: {input: string[]}
     async load({filePath}) {
       esbuildService = esbuildService || (await startService());
       const contents = await fs.readFile(filePath, 'utf-8');
-      let jsxFactory = config.buildOptions.jsxFactory;
-      let jsxFragment = config.buildOptions.jsxFragment;
       const isPreact = checkIsPreact(filePath, contents);
-      if (isPreact) {
-        jsxFactory || (jsxFactory = 'h')
-        jsxFragment || (jsxFragment = 'Fragment')
-      }
+      let jsxFactory = config.buildOptions.jsxFactory ?? (isPreact ? 'h' : undefined);
+      let jsxFragment = config.buildOptions.jsxFragment ?? (isPreact ? 'Fragment' : undefined);
       const {code, map, warnings} = await esbuildService!.transform(contents, {
         loader: getLoader(filePath),
         jsxFactory,

--- a/snowpack/src/types/snowpack.ts
+++ b/snowpack/src/types/snowpack.ts
@@ -229,6 +229,8 @@ export interface SnowpackConfig {
     sourceMaps: boolean;
     watch: boolean;
     htmlFragments: boolean;
+    jsxFactory: string | undefined;
+    jsxFragment: string | undefined;
   };
   testOptions: {
     files: string[];

--- a/www/_template/reference/configuration.md
+++ b/www/_template/reference/configuration.md
@@ -194,11 +194,11 @@ module.exports = {
 
 - Rename your web modules directory.
 
-#### buildOptions.jsxFactory | `string` | Default: `React.createElement` or `h` if Preact is detected
+#### buildOptions.jsxFactory | `string` | Default: `React.createElement` (or `h` if Preact import is detected)
 
 - Set the name of the used function to create JSX elements.
 
-#### buildOptions.jsxFragment | `string` | Default: `React.Fragment` or `Fragment` if Preact is detected
+#### buildOptions.jsxFragment | `string` | Default: `React.Fragment` (or `Fragment` if Preact import is detected)
 
 - Set the name of the used function to create JSX fragments.
 

--- a/www/_template/reference/configuration.md
+++ b/www/_template/reference/configuration.md
@@ -194,6 +194,14 @@ module.exports = {
 
 - Rename your web modules directory.
 
+#### buildOptions.jsxFactory | `string` | Default: `React.createElement` or `h` if Preact is detected
+
+- Set the name of the used function to create JSX elements.
+
+#### buildOptions.jsxFragment | `string` | Default: `React.Fragment` or `Fragment` if Preact is detected
+
+- Set the name of the used function to create JSX fragments.
+
 ### config.testOptions
 
 #### testOptions.files | `string[]` | Default: `["__tests__/**/*", "**/*.@(spec|test).*"]`


### PR DESCRIPTION
## Changes

This PR adds the options jsxFactory and jsxFragment to the buildOptions object within the snowpack config. It allows users to specify a custom jsx factory and fragment function without needing to use babel instead of esbuild. Nothing complex, just passing the options through as esbuild already supports them.

## Testing

WIP - This PR is a draft because I wasn't sure how best to create the tests for these options. A recommendation on what kind of test is required from the project's maintainers here is appreciated. I'll update the PR accordingly.

## Docs

Added the options to the reference docs for the build options.
