### PR TITLE
Fail build when Webpack produces warnings or errors

### DIFF
--- a/plugins/plugin-webpack/README.md
+++ b/plugins/plugin-webpack/README.md
@@ -57,6 +57,7 @@ The options object is optional.
 - `extendConfig: (config: WebpackConfig) => WebpackConfig` - extend your webpack config, see below.
 - `manifest: boolean | string` - Enable generating a manifest file. The default value is `false`, the default file name is `./asset-manifest.json` if setting manifest to `true`. The relative path is resolved from the output directory.
 - `htmlMinifierOptions: boolean | object` - [See below](#minify-html).
+- `ignoreWarnings: boolean` - Does not fail the build when Webpack emits warnings. The default value is `true`.
 
 #### Extending The Default Webpack Config
 

--- a/plugins/plugin-webpack/README.md
+++ b/plugins/plugin-webpack/README.md
@@ -57,7 +57,7 @@ The options object is optional.
 - `extendConfig: (config: WebpackConfig) => WebpackConfig` - extend your webpack config, see below.
 - `manifest: boolean | string` - Enable generating a manifest file. The default value is `false`, the default file name is `./asset-manifest.json` if setting manifest to `true`. The relative path is resolved from the output directory.
 - `htmlMinifierOptions: boolean | object` - [See below](#minify-html).
-- `ignoreWarnings: boolean` - Does not fail the build when Webpack emits warnings. The default value is `true`.
+- `failOnWarnings: boolean` - Does fail the build when Webpack emits warnings. The default value is `false`.
 
 #### Extending The Default Webpack Config
 

--- a/plugins/plugin-webpack/plugin.js
+++ b/plugins/plugin-webpack/plugin.js
@@ -199,8 +199,6 @@ module.exports = function plugin(config, args = {}) {
       ? './asset-manifest.json'
       : undefined;
 
-  const ignoreWarnings = args.ignoreWarnings === undefined ? true : args.ignoreWarnings
-
   // Webpack handles minification for us, so its safe to always
   // disable Snowpack's default minifier.
   config.buildOptions.minify = false;
@@ -363,11 +361,16 @@ module.exports = function plugin(config, args = {}) {
             reject(err);
             return;
           }
-          if (stats.hasErrors() || (stats.hasWarnings() && !ignoreWarnings)) {
-            const info = stats.toJson(extendedConfig.stats);
-            console.error(info.warnings.join('\n-----\n'));
-            console.error(info.errors.join('\n-----\n'));
-            reject(Error(`Webpack build failed with ${info.errors} error(s) and ${info.warnings} warning(s)`));
+          const info = stats.toJson(extendedConfig.stats);
+          if (stats.hasErrors()) {
+            console.error('Webpack errors:\n' + info.errors.join('\n-----\n'));
+            reject(Error(`Webpack failed with ${info.errors} error(s).`));
+          }
+          if (stats.hasWarnings()) {
+            console.error('Webpack warnings:\n' + info.warnings.join('\n-----\n'));
+            if (args.failOnWarnings) {
+              reject(Error(`Webpack failed with ${info.warnings} warnings(s).`));
+            }
           }
           resolve(stats);
         });

--- a/plugins/plugin-webpack/plugin.js
+++ b/plugins/plugin-webpack/plugin.js
@@ -365,11 +365,13 @@ module.exports = function plugin(config, args = {}) {
           if (stats.hasErrors()) {
             console.error('Webpack errors:\n' + info.errors.join('\n-----\n'));
             reject(Error(`Webpack failed with ${info.errors} error(s).`));
+            return;
           }
           if (stats.hasWarnings()) {
             console.error('Webpack warnings:\n' + info.warnings.join('\n-----\n'));
             if (args.failOnWarnings) {
               reject(Error(`Webpack failed with ${info.warnings} warnings(s).`));
+              return;
             }
           }
           resolve(stats);

--- a/plugins/plugin-webpack/plugin.js
+++ b/plugins/plugin-webpack/plugin.js
@@ -199,6 +199,8 @@ module.exports = function plugin(config, args = {}) {
       ? './asset-manifest.json'
       : undefined;
 
+  const ignoreWarnings = args.ignoreWarnings === undefined ? true : args.ignoreWarnings
+
   // Webpack handles minification for us, so its safe to always
   // disable Snowpack's default minifier.
   config.buildOptions.minify = false;
@@ -361,10 +363,11 @@ module.exports = function plugin(config, args = {}) {
             reject(err);
             return;
           }
-          if (stats.hasErrors()) {
+          if (stats.hasErrors() || (stats.hasWarnings() && !ignoreWarnings)) {
             const info = stats.toJson(extendedConfig.stats);
             console.error(info.warnings.join('\n-----\n'));
             console.error(info.errors.join('\n-----\n'));
+            reject(Error(`Webpack build failed with ${info.errors} error(s) and ${info.warnings} warning(s)`));
           }
           resolve(stats);
         });


### PR DESCRIPTION
Fixes #1527

## Changes

This change makes the Snowpack build fail when Webpack produces errors.
It also adds an option to fail the build on warnings as well as that also often indicates some misconfiguration. Failure on warnings is however optional and is disabled by default to be non-breaking. I was not sure here whether this should be the default.

## Testing

I tested it manually by linking the plugin against a snowpack build that succeeded despite having errors.
However the error message I returned in the reject method does not show up in the log. Is this expected?

## Docs

I updated the docs of the plugin to reflect the new option.
