### PR TITLE
Fix build of large css with Webpack

### DIFF
--- a/plugins/plugin-webpack/plugin.js
+++ b/plugins/plugin-webpack/plugin.js
@@ -97,7 +97,7 @@ function emitHTMLFiles({doms, jsEntries, stats, baseUrl, buildDirectory, htmlMin
 }
 
 function getSplitChunksConfig({numEntries}) {
-  const isCssModule = module => module.type === `css/mini-extract`
+  const isCss = module => module.type === `css/mini-extract`
   /**
    * Implements a version of granular chunking, as described at https://web.dev/granular-chunking-nextjs/.
    */
@@ -116,7 +116,7 @@ function getSplitChunksConfig({numEntries}) {
        */
       lib: {
         test(module) {
-          return !isCssModule(module) && module.size() > 100000 && /web_modules[/\\]/.test(module.identifier());
+          return !isCss(module) && module.size() > 100000 && /web_modules[/\\]/.test(module.identifier());
         },
         name(module) {
           /**
@@ -138,7 +138,7 @@ function getSplitChunksConfig({numEntries}) {
       // modules used by all entrypoints end up in commons
       commons: {
         test(module) {
-          return !isCssModule(module)
+          return !isCss(module)
         },
         name: 'commons',
         // don't create a commons chunk until there are 2+ entries
@@ -148,7 +148,7 @@ function getSplitChunksConfig({numEntries}) {
       // modules used by multiple chunks can be pulled into shared chunks
       shared: {
         test(module) {
-          return !isCssModule(module)
+          return !isCss(module)
         },
         name(module, chunks) {
           const hash = crypto
@@ -165,7 +165,7 @@ function getSplitChunksConfig({numEntries}) {
       // Bundle all css & lazy css into one stylesheet to make sure lazy components do not break
       styles: {
         test(module) {
-          return isCssModule(module)
+          return isCss(module)
         },
         name: `styles`,
         priority: 40,


### PR DESCRIPTION
## Changes

This PR fixes a build failure of the Webpack plugin when processing large chunks of css. This is a regression of what was first brought of in this [discussion](https://github.com/snowpackjs/snowpack/discussions/1162), has been fixed in [PR](https://github.com/snowpackjs/snowpack/pull/1215) and has been reintroduced by [PR](https://github.com/snowpackjs/snowpack/pull/1616). 

The new behavior adds a separate chunk for css just like is is also handled in [Gatsby](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/webpack.config.js#L589).

While investigating where the fix has been lost I also noticed that there are 6 commits within the last 3 weeks that have been committed to master, but are not on the main branch, which seems to be the new default branch. Would probably be a good idea to merge master into main 😉

## Testing

Performed a manual test on a project that suffered from this error. 

## Docs

Just a bug fix. No docs.