### PR TITLE
Remove self-link

### DIFF
--- a/www/_template/reference/supported-files.md
+++ b/www/_template/reference/supported-files.md
@@ -14,6 +14,9 @@ Snowpack ships with built-in support for the following file types, no configurat
 - CSS Modules (`.module.css`)
 - Images & Assets (`.svg`, `.jpg`, `.png`, etc.)
 
+To customize build behavior and support new languages [check out our tooling guide](/guides/connecting-tools)
+
+
 ### JavaScript & ESM
 
 Snowpack was designed to support JavaScript's native ES Module (ESM) syntax. ESM lets you define explicit imports & exports that browsers and build tools can better understand and optimize for. If you're familiar with the `import` and `export` keywords in JavaScript, then you already know ESM!

--- a/www/_template/reference/supported-files.md
+++ b/www/_template/reference/supported-files.md
@@ -14,8 +14,6 @@ Snowpack ships with built-in support for the following file types, no configurat
 - CSS Modules (`.module.css`)
 - Images & Assets (`.svg`, `.jpg`, `.png`, etc.)
 
-To customize build behavior and support new languages [check out our tooling guide]()
-
 ### JavaScript & ESM
 
 Snowpack was designed to support JavaScript's native ES Module (ESM) syntax. ESM lets you define explicit imports & exports that browsers and build tools can better understand and optimize for. If you're familiar with the `import` and `export` keywords in JavaScript, then you already know ESM!


### PR DESCRIPTION
Looks like the "tooling guide" does not exist? Link to current page not useful, suggest removing.
