### PR TITLE
docs: fix img src in getting started tutorial

### DIFF
--- a/www/_template/tutorials/getting-started.md
+++ b/www/_template/tutorials/getting-started.md
@@ -193,7 +193,7 @@ Include it in your project by adding it to index.html in the `<head>`
     <title>Starter Snowpack App</title>
 ```
 
-<div class="frame"><img src="/img/guides/getting-started/snowpack-font-css.gif" alt="image showing the effects of the new CSS file: the font has changed from serif to sans-serif" class="screenshot"/></div>
+<div class="frame"><img src="/img/guides/getting-started/snowpack-font-css.jpg" alt="image showing the effects of the new CSS file: the font has changed from serif to sans-serif" class="screenshot"/></div>
 
 ## Build for production/deployment
 


### PR DESCRIPTION
In the getting started tutorial page under adding css section, the image link was broken.
[Link to page](https://www.snowpack.dev/tutorials/getting-started#adding-css)

## Changes

![image](https://user-images.githubusercontent.com/51525368/101374969-d99b7c00-38d4-11eb-9eeb-379df9ba948f.png)


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
