### PR TITLE
add buildProject JS API, clean up config API

### DIFF
--- a/snowpack/index.esm.mjs
+++ b/snowpack/index.esm.mjs
@@ -1,5 +1,7 @@
 import Pkg from './lib/index.js';
 
 export const startDevServer = Pkg.startDevServer;
+export const buildProject = Pkg.buildProject;
 export const loadAndValidateConfig = Pkg.loadAndValidateConfig;
+export const createConfiguration = Pkg.createConfiguration;
 export const getUrlForFile = Pkg.getUrlForFile;

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -903,7 +903,7 @@ export function createConfiguration(
   return [null, normalizeConfig(mergedConfig)];
 }
 
-export function loadAndValidateConfig(flags: CLIFlags, pkgManifest: any): SnowpackConfig {
+export function loadConfigurationForCLI(flags: CLIFlags, pkgManifest: any): SnowpackConfig {
   const explorerSync = cosmiconfigSync(CONFIG_NAME, {
     // only support these 5 types of config for now
     searchPlaces: [

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -888,7 +888,7 @@ export function validatePluginLoadResult(
 }
 
 export function createConfiguration(
-  config: SnowpackUserConfig,
+  config: SnowpackUserConfig = {},
 ): [ValidatorResult['errors'], undefined] | [null, SnowpackConfig] {
   const {errors: validationErrors} = validate(config, configSchema, {
     propertyName: CONFIG_NAME,

--- a/snowpack/src/index.ts
+++ b/snowpack/src/index.ts
@@ -7,32 +7,17 @@ import {command as initCommand} from './commands/init';
 import {command as buildCommand} from './commands/build';
 import {command as installCommand} from './commands/install';
 import {command as devCommand} from './commands/dev';
-import {loadAndValidateConfig} from './config.js';
 import {logger} from './logger';
-import {CLIFlags} from './types/snowpack';
+import {loadConfigurationForCLI} from './config';
+import {CLIFlags, CommandOptions} from './types/snowpack';
 import {clearCache, readLockfile} from './util.js';
-export {createConfiguration} from './config.js';
 export * from './types/snowpack';
 
 // Stable API (remember to include all in "./index.esm.js" wrapper)
 export {startDevServer} from './commands/dev';
-export {loadAndValidateConfig};
+export {buildProject} from './commands/build';
+export {loadConfigurationForCLI as loadAndValidateConfig, createConfiguration} from './config.js';
 export {getUrlForFile} from './build/file-urls';
-
-/** @deprecated: Promoted to startDevServer() **/
-export const unstable__startDevServer = () => {
-  throw new Error(`[snowpack 2.15] unstable__startServer() is now startDevServer()`);
-};
-/** @deprecated: Promoted to loadAndValidateConfig() **/
-export const unstable__loadAndValidateConfig = () => {
-  throw new Error(
-    `[snowpack 2.15] unstable__loadAndValidateConfig() is now loadAndValidateConfig()`,
-  );
-};
-/** @deprecated: Promoted to getUrlForFile() **/
-export const unstable__getUrlForFile = () => {
-  throw new Error(`[snowpack 2.15] unstable__getUrlForFile() is now getUrlForFile()`);
-};
 
 const cwd = process.cwd();
 
@@ -112,16 +97,14 @@ export async function cli(args: string[]) {
     process.env.NODE_ENV = process.env.NODE_ENV || 'development';
   }
 
-  const config = loadAndValidateConfig(cliFlags, pkgManifest);
+  const config = loadConfigurationForCLI(cliFlags, pkgManifest);
   logger.debug(`config loaded: ${util.format(config)}`);
   const lockfile = await readLockfile(cwd);
   logger.debug(`lockfile ${lockfile ? 'loaded.' : 'not loaded'}`);
-  const commandOptions = {
+  const commandOptions: CommandOptions = {
     cwd,
     config,
     lockfile,
-    pkgManifest,
-    logger,
   };
 
   if (cmd === 'add') {

--- a/snowpack/src/sources/skypack.ts
+++ b/snowpack/src/sources/skypack.ts
@@ -53,11 +53,7 @@ export default {
 
   async load(
     spec: string,
-    {
-      config,
-      lockfile,
-      pkgManifest,
-    }: {config: SnowpackConfig; lockfile: ImportMap | null; pkgManifest: any},
+    {config, lockfile}: {config: SnowpackConfig; lockfile: ImportMap | null},
   ): Promise<string> {
     let body: string;
     if (
@@ -74,9 +70,7 @@ export default {
       } else if (lockfile && lockfile.imports[packageName + '/']) {
         body = (await fetchCDN(lockfile.imports[packageName + '/'] + packagePath)).body;
       } else {
-        const _packageSemver =
-          (config.webDependencies && config.webDependencies[packageName]) ||
-          (pkgManifest?.dependencies && pkgManifest.dependencies[packageName]);
+        const _packageSemver = config.webDependencies && config.webDependencies[packageName];
         if (!_packageSemver) {
           logFetching(packageName);
         }

--- a/snowpack/src/types/snowpack.ts
+++ b/snowpack/src/types/snowpack.ts
@@ -63,7 +63,14 @@ export interface SnowpackDevServer {
   onFileChange: (callback: OnFileChangeCallback) => void;
   shutdown(): Promise<void>;
 }
-export interface SnowpackBuildServer {
+
+export type SnowpackBuildResultFileManifest = Record<
+  string,
+  {source: string; contents: string | Buffer}
+>;
+
+export interface SnowpackBuildResult {
+  result: SnowpackBuildResultFileManifest;
   onFileChange: (callback: OnFileChangeCallback) => void;
   shutdown(): Promise<void>;
 }
@@ -303,6 +310,7 @@ export interface ImportMap {
 }
 
 export interface CommandOptions {
+  // TODO(fks): remove `cwd`, replace with a new `config.root` property on SnowpackConfig.
   cwd: string;
   config: SnowpackConfig;
   lockfile: ImportMap | null;

--- a/snowpack/src/types/snowpack.ts
+++ b/snowpack/src/types/snowpack.ts
@@ -63,6 +63,10 @@ export interface SnowpackDevServer {
   onFileChange: (callback: OnFileChangeCallback) => void;
   shutdown(): Promise<void>;
 }
+export interface SnowpackBuildServer {
+  onFileChange: (callback: OnFileChangeCallback) => void;
+  shutdown(): Promise<void>;
+}
 
 export type SnowpackBuiltFile = {
   code: string | Buffer;
@@ -302,7 +306,6 @@ export interface CommandOptions {
   cwd: string;
   config: SnowpackConfig;
   lockfile: ImportMap | null;
-  pkgManifest: any;
 }
 
 export type LoggerLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent'; // same as Pino
@@ -328,7 +331,7 @@ export interface PackageSource {
    */
   load(
     spec: string,
-    options: {config: SnowpackConfig; lockfile: ImportMap | null; pkgManifest: any},
+    options: {config: SnowpackConfig; lockfile: ImportMap | null},
   ): Promise<Buffer | string>;
   /** Resolve a package import to URL (ex: "react" -> "/web_modules/react") */
   resolvePackageImport(spec: string, importMap: ImportMap, config: SnowpackConfig): string | false;


### PR DESCRIPTION
/cc @drwpow, @Rich-Harris

## Changes

- New `buildProject()` JS API.
  - this builds the entire project. If you need per-file builds, continue to use the dev server (`startDevServer`).
  - this allows for better programatic usage + helps us improve testing via the JS API. (/cc @drwpow)
- Cleans up config API (no breaking changes now, but `loadAndValidateConfig()` will be removed in v3.0 since it confuses usage with the much simpler `createConfiguration()` method). 

## Testing

- Covered by existing tests

## Docs

- TODO