### PR TITLE
Fix: empty folder isDirectory check condition

### DIFF
--- a/snowpack/src/build/optimize.ts
+++ b/snowpack/src/build/optimize.ts
@@ -51,7 +51,7 @@ const FAKE_BUILD_DIRECTORY_REGEX = /.*\~\~bundle\~\~[\\\/]/;
  * Scan a directory and remove any empty folders, recursively.
  */
 async function removeEmptyFolders(directoryLoc: string): Promise<boolean> {
-  if ((await fs.stat(directoryLoc)).isDirectory()) {
+  if (!(await fs.stat(directoryLoc)).isDirectory()) {
     return false;
   }
   // If folder is empty, clear it


### PR DESCRIPTION
## Changes

Doesn't stop empty folder cleaning logic if it detects a folder, otherwise all the empty folders remain.

## Testing

Ran on my windows machine and it deleted those pesky empty folders quite nicely.

## Docs

n/a