### PR TITLE
Update the minimum version of React to use Fast Refresh

### DIFF
--- a/plugins/plugin-react-refresh/package.json
+++ b/plugins/plugin-react-refresh/package.json
@@ -18,8 +18,8 @@
     "react-refresh": "^0.9.0"
   },
   "peerDependencies": {
-    "react": ">=16.10.0",
-    "react-dom": ">=16.10.0"
+    "react": ">=16.9.0",
+    "react-dom": ">=16.9.0"
   },
   "gitHead": "a01616bb0787d56cd782f94cecf2daa12c7594e4"
 }


### PR DESCRIPTION
## Changes
The minimum version of React to use Fast Refresh is `16.9`
So change `>=16.10` to `>=16.9`.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing
This is a modified version of peerDependencies, so no testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs
This is a modified version of peerDependencies, so no docs
<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

## Reference
https://github.com/facebook/react/issues/16604#issuecomment-528663101