### PR TITLE
improve support for svelte npm packages

### DIFF
--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -31,7 +31,7 @@ import {
   createInstallTarget,
   findMatchingAliasEntry,
   getWebDependencyName,
-  isJavaScript,
+  getWebDependencyType,
   isPackageAliasEntry,
   MISSING_PLUGIN_SUGGESTIONS,
   parsePackageImportSpecifier,
@@ -45,7 +45,7 @@ export {printStats} from './stats';
 
 type DependencyLoc =
   | {
-      type: 'JS';
+      type: 'BUNDLE';
       loc: string;
     }
   | {
@@ -122,7 +122,7 @@ function resolveWebDependency(
       }
       const loc = path.join(packageManifestLoc, '..', exportMapValue);
       return {
-        type: isJavaScript(loc) ? 'JS' : 'ASSET',
+        type: getWebDependencyType(loc),
         loc,
       };
     } else {
@@ -131,7 +131,7 @@ function resolveWebDependency(
       if (exportMapValue) {
         const loc = path.join(packageManifestLoc, '..', exportMapValue);
         return {
-          type: isJavaScript(loc) ? 'JS' : 'ASSET',
+          type: getWebDependencyType(loc),
           loc,
         };
       }
@@ -144,7 +144,7 @@ function resolveWebDependency(
     // https://github.com/snowpackjs/snowpack/pull/999.
     const loc = fs.realpathSync.native(require.resolve(dep, {paths: [cwd]}));
     return {
-      type: isJavaScript(loc) ? 'JS' : 'ASSET',
+      type: getWebDependencyType(loc),
       loc,
     };
   }
@@ -158,7 +158,7 @@ function resolveWebDependency(
     try {
       const maybeLoc = fs.realpathSync.native(require.resolve(dep, {paths: [cwd]}));
       return {
-        type: isJavaScript(maybeLoc) ? 'JS' : 'ASSET',
+        type: getWebDependencyType(maybeLoc),
         loc: maybeLoc,
       };
     } catch (err) {
@@ -223,7 +223,7 @@ function resolveWebDependency(
     require.resolve(path.join(depManifestLoc || '', '..', foundEntrypoint)),
   );
   return {
-    type: isJavaScript(loc) ? 'JS' : 'ASSET',
+    type: getWebDependencyType(loc),
     loc,
   };
 }
@@ -359,7 +359,7 @@ export async function install(
         cwd,
         packageLookupFields,
       });
-      if (resolvedResult.type === 'JS') {
+      if (resolvedResult.type === 'BUNDLE') {
         installEntrypoints[targetName] = resolvedResult.loc;
         importMap.imports[installSpecifier] = `./${proxiedName}.js`;
         Object.entries(installAlias)

--- a/esinstall/src/rollup-plugins/rollup-plugin-css.ts
+++ b/esinstall/src/rollup-plugins/rollup-plugin-css.ts
@@ -1,5 +1,4 @@
 import {Plugin} from 'rollup';
-import {promises as fs} from 'fs';
 
 function getInjectorCode(name: string, code: string) {
   return `
@@ -29,19 +28,10 @@ __snowpack__injectStyle(${JSON.stringify(code)});\n`;
 export function rollupPluginCss() {
   return {
     name: 'snowpack:rollup-plugin-css',
-    resolveId(source, importer) {
-      if (!source.endsWith('.css')) {
-        return null;
-      }
-      return this.resolve(source, importer, {skipSelf: true}).then((resolved) => {
-        return resolved || null;
-      });
-    },
-    async load(id: string) {
+    async transform(code: string, id: string) {
       if (!id.endsWith('.css')) {
         return null;
       }
-      const code = await fs.readFile(id, {encoding: 'utf-8'});
       const humanReadableName = id.replace(/.*node_modules[\/\\]/, '').replace(/[\/\\]/g, '/');
       return getInjectorCode(humanReadableName, code);
     },

--- a/esinstall/src/util.ts
+++ b/esinstall/src/util.ts
@@ -190,8 +190,23 @@ export function createInstallTarget(specifier: string, all = true): InstallTarge
   };
 }
 
-/** Is this file JavaScript?  */
-export function isJavaScript(pathname: string) {
+/**
+ * Detect the web dependency "type" as either JS or ASSET:
+ *   - BUNDLE: Install and bundle this file with Rollup engine.
+ *   - ASSET: Copy this file directly.
+ */
+export function getWebDependencyType(pathname: string): 'ASSET' | 'BUNDLE' {
   const ext = path.extname(pathname).toLowerCase();
-  return ext === '.js' || ext === '.mjs' || ext === '.cjs';
+  // JavaScript should always be bundled.
+  if (ext === '.js' || ext === '.mjs' || ext === '.cjs') {
+    return 'BUNDLE';
+  }
+  // Svelte & Vue should always be bundled because we want to show the missing plugin
+  // error if a Svelte or Vue file is the install target. Without this, the .svelte/.vue
+  // file would be treated like an asset and sent to the web as-is.
+  if (ext === '.svelte' || ext === '.vue') {
+    return 'BUNDLE';
+  }
+  // All other files should be treated as assets (copied over directly).
+  return 'ASSET';
 }

--- a/plugins/plugin-svelte/plugin.js
+++ b/plugins/plugin-svelte/plugin.js
@@ -16,7 +16,14 @@ module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
 
   // Support importing Svelte files when you install dependencies.
   snowpackConfig.installOptions.rollup.plugins.push(
-    svelteRollupPlugin({include: '**/node_modules/**', compilerOptions: {dev: isDev}}),
+    svelteRollupPlugin({
+      include: /\.svelte$/,
+      compilerOptions: {dev: isDev},
+      // Snowpack wraps JS-imported CSS in a JS wrapper, so use
+      // Svelte's own first-class `emitCss: false` here.
+      // TODO: Remove once Snowpack adds first-class CSS import support in deps.
+      emitCss: false,
+    }),
   );
   // Support importing sharable Svelte components.
   snowpackConfig.installOptions.packageLookupFields.push('svelte');

--- a/test/esinstall/config-package-svelte/config-package-svelte.test.js
+++ b/test/esinstall/config-package-svelte/config-package-svelte.test.js
@@ -1,0 +1,27 @@
+const {install} = require('../../../esinstall/lib');
+
+require('jest-specific-snapshot'); // allows to call expect().toMatchSpecificSnapshot(filename, snapshotName)
+
+describe('config-package-svelte', () => {
+  it('fails when no svelte plugin provided', async () => {
+    return expect(() =>
+      install(['simple-svelte-autocomplete'], {cwd: __dirname, packageLookupFields: ['svelte']}),
+    ).rejects.toThrowError(`Install failed.`);
+    // TODO:
+    // Assert the reason: Failed to load ../../../node_modules/simple-svelte-autocomplete/src/SimpleAutocomplete.svelte
+    // Try installing rollup-plugin-svelte and adding it to Snowpack (https://www.snowpack.dev/#custom-rollup-plugins)
+  });
+
+  it('succeeds when svelte plugin is provided', async () => {
+    const result = await install(['simple-svelte-autocomplete'], {
+      cwd: __dirname,
+      packageLookupFields: ['svelte'],
+      rollup: {
+        plugins: [require('rollup-plugin-svelte')({include: /\.svelte$/})],
+      },
+    });
+    return expect(result.importMap).toEqual({
+      imports: {'simple-svelte-autocomplete': './simple-svelte-autocomplete.js'},
+    });
+  });
+});

--- a/test/esinstall/config-package-svelte/package.json
+++ b/test/esinstall/config-package-svelte/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "version": "1.0.1",
+  "name": "@snowpack/test-config-package-svelte",
+  "description": "Handle svelte packages",
+  "dependencies": {
+    "simple-svelte-autocomplete": "1.2.4"
+  },
+  "devDependencies": {
+    "snowpack": "^2.14.3"
+  }
+}

--- a/test/esinstall/config-package-svelte/src/index.js
+++ b/test/esinstall/config-package-svelte/src/index.js
@@ -1,0 +1,1 @@
+import 'simple-svelte-autocomplete';

--- a/yarn.lock
+++ b/yarn.lock
@@ -12725,6 +12725,11 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
+simple-svelte-autocomplete@1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/simple-svelte-autocomplete/-/simple-svelte-autocomplete-1.2.4.tgz#57be9b01e42b33d5e46b1ab2bedf3c5d1b5101cf"
+  integrity sha512-+1Y8/QKuF/MnsKFiVFd1i8JJRb5MOxHRBPvftEirNgd54YqBCDqLbg0aAxGDdpCts+yAEOABLN4c7l7/eGTyDw==
+
 simple-swizzle@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"


### PR DESCRIPTION
## Changes

- Fixes https://github.com/snowpackjs/snowpack/discussions/1808
- **esinstall:** bundle `.svelte` & `.vue` files (instead of treating them as assets).
- **@snowpack/plugin-svelte:** Fix "include" filter to correctly match `*.svelte` files.

## Testing

- Tests added.

## Docs

- N/A