### PR TITLE
Prevent search shortcut from typing "k"

### DIFF
--- a/www/_includes/layouts/components/nav.njk
+++ b/www/_includes/layouts/components/nav.njk
@@ -77,6 +77,7 @@
 
     document.onkeydown = function (e) {
       if ((e.ctrlKey || e.metaKey) && e.which == 75) {
+        e.preventDefault();
         searchFormInputEl.focus();
       }
     };


### PR DESCRIPTION
## Changes

Prevents the letter "k" from being typed into the search box.

- OS: Linux Mint 16
- Browser: Chrome 87.0.4280.88

**Expected**: typing meta+k, places focus on searchbox
**Actual**: typing meta+k, places focus on searchbox and adds the letter "k" 

![Peek 2020-12-11 03-15](https://user-images.githubusercontent.com/4437/101880720-5fcbf280-3b61-11eb-8cef-6b3bcec7c6d3.gif)

## Testing

Done manually.

## Docs

No docs, bug fix only.