### PR TITLE
plugin-webpack: support development and production browserslist modes

### DIFF
--- a/plugins/plugin-webpack/plugin.js
+++ b/plugins/plugin-webpack/plugin.js
@@ -177,6 +177,16 @@ function getSplitChunksConfig({numEntries}) {
   };
 }
 
+function getPresetEnvTargets({browserslist}) {
+  if(Array.isArray(browserslist) || typeof browserslist === "string") {
+    return browserslist;
+  } else if(typeof browserslist === "object" && "production" in browserslist) {
+    return browserslist.production;
+  } else {
+    return '>0.75%, not ie 11, not UCAndroid >0, not OperaMini all'
+  }
+}
+
 module.exports = function plugin(config, args = {}) {
   // Deprecated: args.mode
   if (args.mode && args.mode !== 'production') {
@@ -236,8 +246,7 @@ module.exports = function plugin(config, args = {}) {
           encoding: 'utf-8',
         }),
       );
-      const presetEnvTargets =
-        tempBuildManifest.browserslist || '>0.75%, not ie 11, not UCAndroid >0, not OperaMini all';
+      const presetEnvTargets = getPresetEnvTargets(tempBuildManifest)
 
       let extendConfig = (cfg) => cfg;
       if (typeof args.extendConfig === 'function') {


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
added support for having seperate broserslists in a package.json file for production and development
see #654 for more information

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->
i tested it using my previously broken project which now works because of this

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
a kind of bug fix but also adding support for something that the rest of snowpack recognises
