### PR TITLE
Fix async test

### DIFF
--- a/test/esinstall/import-nothing/import-nothing.test.js
+++ b/test/esinstall/import-nothing/import-nothing.test.js
@@ -2,7 +2,7 @@ const {install} = require('../../../esinstall/lib');
 
 describe('error-no-dep-list', () => {
   it('importing nothing', async () => {
-    expect(() =>
+    return expect(() =>
       install(
         [
           /* nothing! */

--- a/yarn.lock
+++ b/yarn.lock
@@ -6425,12 +6425,6 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-"error-file-ext-dep-a@file:./test/esinstall/error-file-ext/packages/error-file-ext-dep-a":
-  version "1.0.0"
-
-"error-file-ext-dep-b@file:./test/esinstall/error-file-ext/packages/error-file-ext-dep-b":
-  version "1.0.0"
-
 es-abstract@^1.17.2:
   version "1.17.7"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.7.tgz#a4de61b2f66989fc7421676c1cb9787573ace54c"


### PR DESCRIPTION
## Changes

Minor change for async test. Still passes, but getting in before this test starts failing and we don’t notice because Jest doesn’t wait for it.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
