### PR TITLE
plugin-sass: fixes issue with regex not matching imports

### DIFF
--- a/plugins/plugin-sass/plugin.js
+++ b/plugins/plugin-sass/plugin.js
@@ -71,9 +71,9 @@ module.exports = function sassPlugin(_, {native, compilerOptions = {}} = {}) {
       // check no ext: "_index" (/a/b/c/foo/_index)
       this._markImportersAsChanged(filePathNoExt);
       // check no underscore: "index.scss" (/a/b/c/foo/index.scss)
-      this._markImportersAsChanged(filePath.replace(/\/_(?!.*\/_)/, '/'));
+      this._markImportersAsChanged(filePath.replace(/(.*[\\\/])_/, '$1'));
       // check no ext, no underscore: "index" (/a/b/c/foo/index)
-      this._markImportersAsChanged(filePathNoExt.replace(/\/_(?!.*\/_)/, '/'));
+      this._markImportersAsChanged(filePathNoExt.replace(/(.*[\\\/])_/, '$1'));
       // check folder import: "foo" (/a/b/c/foo)
       if (filePathNoExt.endsWith('_index')) {
         const folderPathNoIndex = filePathNoExt.substring(0, filePathNoExt.length - 7);

--- a/plugins/plugin-sass/plugin.js
+++ b/plugins/plugin-sass/plugin.js
@@ -71,9 +71,9 @@ module.exports = function sassPlugin(_, {native, compilerOptions = {}} = {}) {
       // check no ext: "_index" (/a/b/c/foo/_index)
       this._markImportersAsChanged(filePathNoExt);
       // check no underscore: "index.scss" (/a/b/c/foo/index.scss)
-      this._markImportersAsChanged(filePath.replace(/([\\\/])_/, '$1'));
+      this._markImportersAsChanged(filePath.replace(/\/_(?!.*\/_)/, '/'));
       // check no ext, no underscore: "index" (/a/b/c/foo/index)
-      this._markImportersAsChanged(filePathNoExt.replace(/([\\\/])_/, '$1'));
+      this._markImportersAsChanged(filePathNoExt.replace(/\/_(?!.*\/_)/, '/'));
       // check folder import: "foo" (/a/b/c/foo)
       if (filePathNoExt.endsWith('_index')) {
         const folderPathNoIndex = filePathNoExt.substring(0, filePathNoExt.length - 7);

--- a/plugins/plugin-sass/plugin.js
+++ b/plugins/plugin-sass/plugin.js
@@ -71,9 +71,9 @@ module.exports = function sassPlugin(_, {native, compilerOptions = {}} = {}) {
       // check no ext: "_index" (/a/b/c/foo/_index)
       this._markImportersAsChanged(filePathNoExt);
       // check no underscore: "index.scss" (/a/b/c/foo/index.scss)
-      this._markImportersAsChanged(filePath.replace(/(.*[\\\/])_/, '$1'));
+      this._markImportersAsChanged(filePath.replace(/\/_(?!.*\/)/, '$1'));
       // check no ext, no underscore: "index" (/a/b/c/foo/index)
-      this._markImportersAsChanged(filePathNoExt.replace(/(.*[\\\/])_/, '$1'));
+      this._markImportersAsChanged(filePathNoExt.replace(/\/_(?!.*\/)/, '$1'));
       // check folder import: "foo" (/a/b/c/foo)
       if (filePathNoExt.endsWith('_index')) {
         const folderPathNoIndex = filePathNoExt.substring(0, filePathNoExt.length - 7);


### PR DESCRIPTION
## Changes

If the folder structure of the project contains "_" the current regex fails to find an entry in the `importedByMap`. 

Because the sass specification allows partials to be imported without the starting "_", the importedByMap could contain entries where the filename doesn't match. This fix ensures that these files will be found, even if the folder structure contains underscores. 

old behaviour:
`"/a/b/c/_foo_/_index.scss".replace(/([\\\/])_/, '$1') === "/a/b/c/foo_/_index.scss"`

new behaviour:
`"/a/b/c/_foo_/_index.scss".replace(/(.*[\\\/])_/, '$1') === "/a/b/c/_foo_/index.scss"`

## Testing

This was tested manually by trying out different folder- and filenames.  

## Docs

Bug fix only pull request.
