### PR TITLE
Fix typo in link to customizing build pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Snowpack is a lightning-fast frontend build tool, designed to leverage JavaScrip
 
 - Develop faster, with a dev server that starts up in **50ms or less.**
 - See changes reflected [instantly in the browser.](https://www.snowpack.dev/concepts/hot-module-replacement)
-- Integrate your favorite bundler for a [production-optimized build.](https://www.snowpack.dev/concepts/build-pipelined)
+- Integrate your favorite bundler for a [production-optimized build.](https://www.snowpack.dev/concepts/build-pipeline)
 - Enjoy out-of-the-box support for [TypeScript, JSX, CSS Modules and more.](https://www.snowpack.dev/reference/supported-files)
 - Connect your favorite tools with [third-party plugins.](https://www.snowpack.dev/plugins)
 


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

This fixes a typo in the link to customizing the build pipeline.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

No tests added because it was a doc change only.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

It was a doc change to one of the links
