### PR TITLE
Only tree-shake JS files

### DIFF
--- a/esinstall/src/rollup-plugins/rollup-plugin-wrap-install-targets.ts
+++ b/esinstall/src/rollup-plugins/rollup-plugin-wrap-install-targets.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import {Plugin} from 'rollup';
 import {VM as VM2} from 'vm2';
 import {AbstractLogger, InstallTarget} from '../types';
-import {getWebDependencyName, isRemoteUrl, isTruthy} from '../util';
+import {getWebDependencyName, isJavaScript, isRemoteUrl, isTruthy} from '../util';
 
 // Use CJS intentionally here! ESM interface is async but CJS is sync, and this file is sync
 const {parse} = require('cjs-module-lexer');
@@ -117,6 +117,9 @@ export function rollupPluginWrapInstallTargets(
       const input = inputOptions.input as {[entryAlias: string]: string};
       for (const [key, val] of Object.entries(input)) {
         if (isRemoteUrl(val)) {
+          continue;
+        }
+        if (!isJavaScript(val)) {
           continue;
         }
         const allInstallTargets = installTargets.filter(

--- a/esinstall/src/util.ts
+++ b/esinstall/src/util.ts
@@ -190,6 +190,11 @@ export function createInstallTarget(specifier: string, all = true): InstallTarge
   };
 }
 
+export function isJavaScript(pathname: string): boolean {
+  const ext = path.extname(pathname).toLowerCase();
+  return (ext === '.js' || ext === '.mjs' || ext === '.cjs');
+}
+
 /**
  * Detect the web dependency "type" as either JS or ASSET:
  *   - BUNDLE: Install and bundle this file with Rollup engine.
@@ -198,7 +203,7 @@ export function createInstallTarget(specifier: string, all = true): InstallTarge
 export function getWebDependencyType(pathname: string): 'ASSET' | 'BUNDLE' {
   const ext = path.extname(pathname).toLowerCase();
   // JavaScript should always be bundled.
-  if (ext === '.js' || ext === '.mjs' || ext === '.cjs') {
+  if (isJavaScript(pathname)) {
     return 'BUNDLE';
   }
   // Svelte & Vue should always be bundled because we want to show the missing plugin


### PR DESCRIPTION
## Changes

- Only tree-shake JS files (fix issue where esinstall can't tree-shake a `.svelte` file)

## Testing

- Tested in https://github.com/bfanger/snowpack-svelte-in-node-modules-bug

## Docs

- N/A