### PR TITLE
[optimize] support generic file references

### DIFF
--- a/snowpack/src/build/optimize.ts
+++ b/snowpack/src/build/optimize.ts
@@ -403,6 +403,7 @@ async function processEntrypoints(
  */
 async function runEsbuildOnBuildDirectory(
   bundleEntrypoints: string[],
+  allFiles: string[],
   config: SnowpackConfig,
   esbuildService: esbuild.Service,
 ): Promise<{manifest: ESBuildMetaManifest; outputFiles: esbuild.OutputFile[]}> {
@@ -419,6 +420,9 @@ async function runEsbuildOnBuildDirectory(
     publicPath: config.buildOptions.baseUrl,
     minify: config.experiments.optimize!.minify,
     target: config.experiments.optimize!.target,
+    external: Array.from(new Set(allFiles.map((f) => '*' + path.extname(f)))).filter(
+      (ext) => ext !== '*.js' && ext !== '*.mjs' && ext !== '*.css',
+    ),
   });
   const manifestFile = outputFiles!.find((f) => f.path.endsWith('build-manifest.json'))!;
   const manifestContents = manifestFile.text;
@@ -510,6 +514,7 @@ export async function runBuiltInOptimize(config: SnowpackConfig) {
   const esbuildService = await esbuild.startService();
   const {manifest, outputFiles} = await runEsbuildOnBuildDirectory(
     bundleEntrypoints,
+    allBuildFiles,
     config,
     esbuildService,
   );


### PR DESCRIPTION
## Changes

- When bundling with esbuild, assume anything that isn't CSS or JS is an external file reference.
- Snowpack's build pipeline passes esbuild a web-native site/application, meaning anything not bundled can be safely assumed to be valid as-is. We bundle in place, so existing URL/file references will continue to work.
- See https://github.com/snowpackjs/snowpack/discussions/1837#discussioncomment-203687

## Testing

- No optimize tests yet, still experimental.

## Docs

- N/A