### PR TITLE
improve the createConfiguration API

### DIFF
--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -889,7 +889,7 @@ export function validatePluginLoadResult(
 
 class ConfigValidationError extends Error {
   constructor(errors: Error[]) {
-    super(`Configuration Error:\n${errors.map((err) => `  - ${err.toString()}`).join('\n')}`);
+    super(`Configuration Error:\n${errors.map((err) => `  - ${err.toString()}`).join(os.EOL)}`);
   }
 }
 


### PR DESCRIPTION
## Changes

- `createConfiguration()` had an odd API that returned errors instead of throwing them
- this helped our internal TS usage, but is a bit unexpected for external use
- this PR gives it a more normal function return value of just the config object

## Testing

- Covered by existing tests

## Docs

- N/A
