### PR TITLE
Skip export map nested conditions

### DIFF
--- a/esinstall/src/types.ts
+++ b/esinstall/src/types.ts
@@ -54,3 +54,12 @@ export interface LoggerOptions {
   /** (optional) change name at beginning of line */
   name?: string;
 }
+
+export type ExportMapEntry =
+  | string
+  | {
+      browser?: ExportMapEntry;
+      import?: ExportMapEntry;
+      default?: ExportMapEntry;
+      require?: ExportMapEntry;
+    };

--- a/test/esinstall/package-entrypoints/export-map-object-browser-object/entrypoint.js
+++ b/test/esinstall/package-entrypoints/export-map-object-browser-object/entrypoint.js
@@ -1,0 +1,1 @@
+export const a = 'b';

--- a/test/esinstall/package-entrypoints/export-map-object-browser-object/package.json
+++ b/test/esinstall/package-entrypoints/export-map-object-browser-object/package.json
@@ -1,0 +1,14 @@
+{
+  "version": "1.2.3",
+  "name": "export-map-object-browser",
+  "description": "With dot slash",
+  "module": "./entrypoint.js",
+  "exports": {
+    ".": {
+      "browser": {
+        "development": "./no-exists.js",
+        "production": "./also-no-exists.js"
+      }
+    }
+  }
+}

--- a/test/esinstall/package-entrypoints/package-entrypoints-export-map.test.js
+++ b/test/esinstall/package-entrypoints/package-entrypoints-export-map.test.js
@@ -21,6 +21,9 @@ describe('package-entrypoints browser configuration', () => {
 
       // ".": { "require": "index.js" }
       'export-map-object-require',
+
+      // "." : { "browser": { "development": "index.js" } }
+      'export-map-object-browser-object',
     ];
 
     const {


### PR DESCRIPTION
Node has support for nested conditions that we don't yet support: https://nodejs.org/api/packages.html#packages_nested_conditions

We should do so in the future.

However for now it's unclear how the community is using these conditions. It seems that `nanoid` is using them via use of Parcel. So we should research what Parcel is doing here and support something similar.

For now this makes it so that we bail out if there are nested conditions like:

```json
{
  "module": "./module-entry.js",
  "exports": {
    ".": {
      "browser": {
        "development": "./browser-dev.js"
      }
    }
  }
}
```

For now we are going to resolve this to `module-entry.js`.

Fixes https://github.com/snowpackjs/snowpack/discussions/1974

## Changes

Changes resolution of exports map.

## Testing

Entry point test added to the esinstall package-entrypoints tests.

## Docs

None.
