### PR TITLE
Removing instances of grid-body

### DIFF
--- a/www/_includes/layouts/content-with-cover.njk
+++ b/www/_includes/layouts/content-with-cover.njk
@@ -53,7 +53,7 @@ layout: layouts/base.njk
       {% include 'layouts/components/menu.njk' %}
     </aside>
 
-    <article id="grid-body" class="snow-view-main">
+    <article class="snow-view-main">
       <div class="content">
         <h2 class="content-title">
           {{ title }}

--- a/www/_includes/layouts/content.njk
+++ b/www/_includes/layouts/content.njk
@@ -11,7 +11,7 @@ layout: layouts/base.njk
 
     {% include 'layouts/components/subnav.njk' %}
 
-    <article id="grid-body" class="snow-view-main">
+    <article class="snow-view-main">
       <div class="content">
         <h2 class="content-title">
           {{ title }}

--- a/www/_includes/layouts/main.njk
+++ b/www/_includes/layouts/main.njk
@@ -9,7 +9,7 @@ layout: layouts/base.njk
       {% include 'layouts/components/menu.njk' %}
     </aside>
 
-    <article id="grid-body" class="snow-view-main">
+    <article class="snow-view-main">
       {{ content | safe }}
     </article>
 

--- a/www/_includes/layouts/post.njk
+++ b/www/_includes/layouts/post.njk
@@ -131,7 +131,7 @@
         <script defer src="https://buttons.github.io/buttons.js"></script>
       </div>
     </div>
-    <div id="grid-body" class="grid-body">
+    <div class="grid-body">
 <article class="markdown-body">
       {{ content | safe }}
     </article>

--- a/www/_template/index.njk
+++ b/www/_template/index.njk
@@ -12,9 +12,9 @@ description: 'Snowpack is a lightning-fast frontend build tool, designed for the
       {% include 'layouts/components/menu.njk' %}
     </aside>
 
-    <article id="grid-body" class="snow-view-main">
+    <article class="snow-view-main">
       <div class="content">
-        <article id="grid-body" class="grid-body">
+        <article class="grid-body">
           <a class="img-banner" href="https://osawards.com/javascript/2020" target="_blank" rel="noopener noreferrer">
             <img src="/img/JSAwardWinner.png" alt="2020 JavaScript Open Source Award Winner banner"/>
           </a>

--- a/www/src/js/index.js
+++ b/www/src/js/index.js
@@ -39,7 +39,7 @@ function setActiveToc() {
 
   const headings = [
     ...document.querySelectorAll(
-      '#grid-body h1, #grid-body h2, #grid-body h3, #grid-body h4',
+      '.content-body h1, .content-body h2, .content-body h3, .content-body h4',
     ),
   ].filter((el) => !!el.id);
   const scrolledToBeginning = window.scrollY === 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6528,6 +6528,28 @@ escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+esinstall@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/esinstall/-/esinstall-0.4.0.tgz#b228ed75919b0b87ca0c28ab28f6888d59b92788"
+  integrity sha512-aOGbM1/AYSPMBspYmmNcqlhmUEpVh0wEXj6+IKP8W+rdyyXPYzYOEtjilH8XDc9P7UFTeB8VIfdtJiLGQkpDVA==
+  dependencies:
+    "@rollup/plugin-alias" "^3.0.1"
+    "@rollup/plugin-commonjs" "^16.0.0"
+    "@rollup/plugin-inject" "^4.0.2"
+    "@rollup/plugin-json" "^4.0.0"
+    "@rollup/plugin-node-resolve" "^10.0.0"
+    "@rollup/plugin-replace" "^2.3.3"
+    cjs-module-lexer "^1.0.0"
+    es-module-lexer "^0.3.24"
+    is-builtin-module "^3.0.0"
+    kleur "^4.1.1"
+    mkdirp "^1.0.3"
+    rimraf "^3.0.0"
+    rollup "^2.34.0"
+    rollup-plugin-node-polyfills "^0.2.1"
+    validate-npm-package-name "^3.0.0"
+    vm2 "^3.9.2"
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"


### PR DESCRIPTION
## Changes

Removing `id=“grid-body”` from templates, as it’s no longer used and it was causing a search indexing bug. 

## Testing
NA

## Docs
Docs
