### PR TITLE
improve import.meta.env bundling performance

### DIFF
--- a/test/build/base-url/base-url.test.js
+++ b/test/build/base-url/base-url.test.js
@@ -27,18 +27,18 @@ describe('buildOptions.baseUrl', () => {
   it('import.meta.env works', () => {
     // env is present in index.js
     expect(files['/index.js']).toEqual(
-      expect.stringContaining(`import __SNOWPACK_ENV__ from './__snowpack__/env.js';`),
+      expect.stringContaining(`import * as __SNOWPACK_ENV__ from './__snowpack__/env.js';`),
     );
     expect(files['/index.js']).toEqual(
-      expect.stringContaining(`import.meta.env = __SNOWPACK_ENV__;`),
+      expect.stringContaining(`console.log(__SNOWPACK_ENV__)`),
     );
 
     // env is present in _dist_/index.js too
     expect(files['/_dist_/index.js']).toEqual(
-      expect.stringContaining(`import __SNOWPACK_ENV__ from '../__snowpack__/env.js';`),
+      expect.stringContaining(`import * as __SNOWPACK_ENV__ from '../__snowpack__/env.js';`),
     );
     expect(files['/_dist_/index.js']).toEqual(
-      expect.stringContaining(`import.meta.env = __SNOWPACK_ENV__;`),
+      expect.stringContaining(`console.log(__SNOWPACK_ENV__)`),
     );
   });
 });

--- a/test/build/config-extends-plugins/config-extends-plugins.test.js
+++ b/test/build/config-extends-plugins/config-extends-plugins.test.js
@@ -12,7 +12,7 @@ describe('config: extends', () => {
   it('loads the appropriate plugins', () => {
     const snowpackEnv = fs.readFileSync(path.join(cwd, '__snowpack__', 'env.js'), 'utf8');
     expect(snowpackEnv).toEqual(
-      expect.stringContaining(`"SNOWPACK_PUBLIC_SECRET_VALUE":"pumpernickel"`),
+      expect.stringContaining(`export const SNOWPACK_PUBLIC_SECRET_VALUE = "pumpernickel";`),
     );
   });
 });

--- a/test/build/config-meta-dir/config-meta-dir.test.js
+++ b/test/build/config-meta-dir/config-meta-dir.test.js
@@ -20,10 +20,10 @@ describe('config: buildOptions.metaDir', () => {
 
   it('resolves snowpack env', () => {
     expect(files['/index.js']).toEqual(
-      expect.stringContaining(`import __SNOWPACK_ENV__ from './static/snowpack/env.js';`),
+      expect.stringContaining(`import * as __SNOWPACK_ENV__ from './static/snowpack/env.js';`),
     );
     expect(files['/sub/index.js']).toEqual(
-      expect.stringContaining(`import __SNOWPACK_ENV__ from '../static/snowpack/env.js';`),
+      expect.stringContaining(`import * as __SNOWPACK_ENV__ from '../static/snowpack/env.js';`),
     );
   });
 });

--- a/test/create-snowpack-app/__snapshots__/create-snowpack-app.test.js.snap
+++ b/test/create-snowpack-app/__snapshots__/create-snowpack-app.test.js.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`create-snowpack-app app-template-11ty > build: __snowpack__/env.js 1`] = `"export default {\\"MODE\\":\\"production\\",\\"NODE_ENV\\":\\"production\\",\\"SSR\\":false};"`;
+exports[`create-snowpack-app app-template-11ty > build: __snowpack__/env.js 1`] = `
+"export const MODE = \\"production\\";
+export const NODE_ENV = \\"production\\";
+export const SSR = false;"
+`;
 
 exports[`create-snowpack-app app-template-11ty > build: about/index.html 1`] = `
 "<!DOCTYPE html>
@@ -618,7 +622,11 @@ exports[`create-snowpack-app app-template-11ty > build: web_modules/import-map.j
 }"
 `;
 
-exports[`create-snowpack-app app-template-blank > build: __snowpack__/env.js 1`] = `"export default {\\"MODE\\":\\"production\\",\\"NODE_ENV\\":\\"production\\",\\"SSR\\":false};"`;
+exports[`create-snowpack-app app-template-blank > build: __snowpack__/env.js 1`] = `
+"export const MODE = \\"production\\";
+export const NODE_ENV = \\"production\\";
+export const SSR = false;"
+`;
 
 exports[`create-snowpack-app app-template-blank > build: allFiles 1`] = `
 Array [
@@ -1191,7 +1199,11 @@ exports[`create-snowpack-app app-template-blank > build: web_modules/import-map.
 }"
 `;
 
-exports[`create-snowpack-app app-template-blank-typescript > build: __snowpack__/env.js 1`] = `"export default {\\"MODE\\":\\"production\\",\\"NODE_ENV\\":\\"production\\",\\"SSR\\":false};"`;
+exports[`create-snowpack-app app-template-blank-typescript > build: __snowpack__/env.js 1`] = `
+"export const MODE = \\"production\\";
+export const NODE_ENV = \\"production\\";
+export const SSR = false;"
+`;
 
 exports[`create-snowpack-app app-template-blank-typescript > build: allFiles 1`] = `
 Array [
@@ -1760,7 +1772,11 @@ exports[`create-snowpack-app app-template-blank-typescript > build: web_modules/
 }"
 `;
 
-exports[`create-snowpack-app app-template-lit-element > build: __snowpack__/env.js 1`] = `"export default {\\"MODE\\":\\"production\\",\\"NODE_ENV\\":\\"production\\",\\"SSR\\":false};"`;
+exports[`create-snowpack-app app-template-lit-element > build: __snowpack__/env.js 1`] = `
+"export const MODE = \\"production\\";
+export const NODE_ENV = \\"production\\";
+export const SSR = false;"
+`;
 
 exports[`create-snowpack-app app-template-lit-element > build: allFiles 1`] = `
 Array [
@@ -4538,7 +4554,11 @@ LitElement.render = render$1;
 export { LitElement, css, customElement, html, property };"
 `;
 
-exports[`create-snowpack-app app-template-lit-element-typescript > build: __snowpack__/env.js 1`] = `"export default {\\"MODE\\":\\"production\\",\\"NODE_ENV\\":\\"production\\",\\"SSR\\":false};"`;
+exports[`create-snowpack-app app-template-lit-element-typescript > build: __snowpack__/env.js 1`] = `
+"export const MODE = \\"production\\";
+export const NODE_ENV = \\"production\\";
+export const SSR = false;"
+`;
 
 exports[`create-snowpack-app app-template-lit-element-typescript > build: allFiles 1`] = `
 Array [
@@ -7316,7 +7336,11 @@ LitElement.render = render$1;
 export { LitElement, css, customElement, html, property };"
 `;
 
-exports[`create-snowpack-app app-template-minimal > build: __snowpack__/env.js 1`] = `"export default {\\"MODE\\":\\"production\\",\\"NODE_ENV\\":\\"production\\",\\"SSR\\":false};"`;
+exports[`create-snowpack-app app-template-minimal > build: __snowpack__/env.js 1`] = `
+"export const MODE = \\"production\\";
+export const NODE_ENV = \\"production\\";
+export const SSR = false;"
+`;
 
 exports[`create-snowpack-app app-template-minimal > build: allFiles 1`] = `
 Array [
@@ -7406,7 +7430,11 @@ module.exports = {
 };"
 `;
 
-exports[`create-snowpack-app app-template-preact > build: __snowpack__/env.js 1`] = `"export default {\\"MODE\\":\\"production\\",\\"NODE_ENV\\":\\"production\\",\\"SSR\\":false};"`;
+exports[`create-snowpack-app app-template-preact > build: __snowpack__/env.js 1`] = `
+"export const MODE = \\"production\\";
+export const NODE_ENV = \\"production\\";
+export const SSR = false;"
+`;
 
 exports[`create-snowpack-app app-template-preact > build: allFiles 1`] = `
 Array [
@@ -7597,7 +7625,11 @@ var t,u,r,o=0,i=[],c=n.__b,f=n.__r,e=n.diffed,a=n.__c,v=n.unmount;function m(t,r
 export { y as useEffect, l as useState };"
 `;
 
-exports[`create-snowpack-app app-template-preact-typescript > build: __snowpack__/env.js 1`] = `"export default {\\"MODE\\":\\"production\\",\\"NODE_ENV\\":\\"production\\",\\"SSR\\":false};"`;
+exports[`create-snowpack-app app-template-preact-typescript > build: __snowpack__/env.js 1`] = `
+"export const MODE = \\"production\\";
+export const NODE_ENV = \\"production\\";
+export const SSR = false;"
+`;
 
 exports[`create-snowpack-app app-template-preact-typescript > build: allFiles 1`] = `
 Array [
@@ -7791,7 +7823,11 @@ var t,u,r,o=0,i=[],c=n.__b,f=n.__r,e=n.diffed,a=n.__c,v=n.unmount;function m(t,r
 export { y as useEffect, l as useState };"
 `;
 
-exports[`create-snowpack-app app-template-react > build: __snowpack__/env.js 1`] = `"export default {\\"MODE\\":\\"production\\",\\"NODE_ENV\\":\\"production\\",\\"SSR\\":false};"`;
+exports[`create-snowpack-app app-template-react > build: __snowpack__/env.js 1`] = `
+"export const MODE = \\"production\\";
+export const NODE_ENV = \\"production\\";
+export const SSR = false;"
+`;
 
 exports[`create-snowpack-app app-template-react > build: allFiles 1`] = `
 Array [
@@ -7925,15 +7961,15 @@ if (typeof document !== 'undefined') {
 `;
 
 exports[`create-snowpack-app app-template-react > build: dist/index.js 1`] = `
-"import __SNOWPACK_ENV__ from '../__snowpack__/env.js';
+"import * as __SNOWPACK_ENV__ from '../__snowpack__/env.js';
 import.meta.env = __SNOWPACK_ENV__;
 import React from \\"../web_modules/react.js\\";
 import ReactDOM from \\"../web_modules/react-dom.js\\";
 import App2 from \\"./App.js\\";
 import \\"./index.css.proxy.js\\";
 ReactDOM.render(/* @__PURE__ */ React.createElement(React.StrictMode, null, /* @__PURE__ */ React.createElement(App2, null)), document.getElementById(\\"root\\"));
-if (import.meta.hot) {
-  import.meta.hot.accept();
+if (undefined /* [snowpack] import.meta.hot */ ) {
+  undefined /* [snowpack] import.meta.hot */ .accept();
 }"
 `;
 
@@ -8329,7 +8365,11 @@ function checkDCE() {
 export default reactDom;"
 `;
 
-exports[`create-snowpack-app app-template-react-typescript > build: __snowpack__/env.js 1`] = `"export default {\\"MODE\\":\\"production\\",\\"NODE_ENV\\":\\"production\\",\\"SSR\\":false};"`;
+exports[`create-snowpack-app app-template-react-typescript > build: __snowpack__/env.js 1`] = `
+"export const MODE = \\"production\\";
+export const NODE_ENV = \\"production\\";
+export const SSR = false;"
+`;
 
 exports[`create-snowpack-app app-template-react-typescript > build: allFiles 1`] = `
 Array [
@@ -8463,15 +8503,15 @@ if (typeof document !== 'undefined') {
 `;
 
 exports[`create-snowpack-app app-template-react-typescript > build: dist/index.js 1`] = `
-"import __SNOWPACK_ENV__ from '../__snowpack__/env.js';
+"import * as __SNOWPACK_ENV__ from '../__snowpack__/env.js';
 import.meta.env = __SNOWPACK_ENV__;
 import React from \\"../web_modules/react.js\\";
 import ReactDOM from \\"../web_modules/react-dom.js\\";
 import App2 from \\"./App.js\\";
 import \\"./index.css.proxy.js\\";
 ReactDOM.render(/* @__PURE__ */ React.createElement(React.StrictMode, null, /* @__PURE__ */ React.createElement(App2, null)), document.getElementById(\\"root\\"));
-if (import.meta.hot) {
-  import.meta.hot.accept();
+if (undefined /* [snowpack] import.meta.hot */ ) {
+  undefined /* [snowpack] import.meta.hot */ .accept();
 }"
 `;
 
@@ -8867,7 +8907,11 @@ function checkDCE() {
 export default reactDom;"
 `;
 
-exports[`create-snowpack-app app-template-svelte > build: __snowpack__/env.js 1`] = `"export default {\\"MODE\\":\\"production\\",\\"NODE_ENV\\":\\"production\\",\\"SSR\\":false};"`;
+exports[`create-snowpack-app app-template-svelte > build: __snowpack__/env.js 1`] = `
+"export const MODE = \\"production\\";
+export const NODE_ENV = \\"production\\";
+export const SSR = false;"
+`;
 
 exports[`create-snowpack-app app-template-svelte > build: allFiles 1`] = `
 Array [
@@ -9004,7 +9048,7 @@ export default App;"
 `;
 
 exports[`create-snowpack-app app-template-svelte > build: dist/index.js 1`] = `
-"import __SNOWPACK_ENV__ from '../__snowpack__/env.js';
+"import * as __SNOWPACK_ENV__ from '../__snowpack__/env.js';
 import.meta.env = __SNOWPACK_ENV__;
 import App from \\"./App.js\\";
 let app = new App({
@@ -9013,9 +9057,9 @@ let app = new App({
 export default app;
 // Hot Module Replacement (HMR) - Remove this snippet to remove HMR.
 // Learn more: https://www.snowpack.dev/concepts/hot-module-replacement
-if (import.meta.hot) {
-  import.meta.hot.accept();
-  import.meta.hot.dispose(() => {
+if (undefined /* [snowpack] import.meta.hot */ ) {
+  undefined /* [snowpack] import.meta.hot */ .accept();
+  undefined /* [snowpack] import.meta.hot */ .dispose(() => {
     app.$destroy();
   });
 }"
@@ -9059,7 +9103,11 @@ exports[`create-snowpack-app app-template-svelte > build: web_modules/svelte.js 
 
 exports[`create-snowpack-app app-template-svelte > build: web_modules/svelte/internal.js 1`] = `"export { S as SvelteComponent, a as append, b as attr, d as detach, e as element, i as init, c as insert, n as noop, s as safe_not_equal, f as set_data, g as space, t as text } from '../common/index-XXXXXXXX.js';"`;
 
-exports[`create-snowpack-app app-template-svelte-typescript > build: __snowpack__/env.js 1`] = `"export default {\\"MODE\\":\\"production\\",\\"NODE_ENV\\":\\"production\\",\\"SSR\\":false};"`;
+exports[`create-snowpack-app app-template-svelte-typescript > build: __snowpack__/env.js 1`] = `
+"export const MODE = \\"production\\";
+export const NODE_ENV = \\"production\\";
+export const SSR = false;"
+`;
 
 exports[`create-snowpack-app app-template-svelte-typescript > build: allFiles 1`] = `
 Array [
@@ -9196,16 +9244,16 @@ export default App;"
 `;
 
 exports[`create-snowpack-app app-template-svelte-typescript > build: dist/index.js 1`] = `
-"import __SNOWPACK_ENV__ from '../__snowpack__/env.js';
+"import * as __SNOWPACK_ENV__ from '../__snowpack__/env.js';
 import.meta.env = __SNOWPACK_ENV__;
 import App2 from \\"./App.js\\";
 var app = new App2({
   target: document.body
 });
 export default app;
-if (import.meta.hot) {
-  import.meta.hot.accept();
-  import.meta.hot.dispose(() => {
+if (undefined /* [snowpack] import.meta.hot */ ) {
+  undefined /* [snowpack] import.meta.hot */ .accept();
+  undefined /* [snowpack] import.meta.hot */ .dispose(() => {
     app.$destroy();
   });
 }"
@@ -9249,7 +9297,11 @@ exports[`create-snowpack-app app-template-svelte-typescript > build: web_modules
 
 exports[`create-snowpack-app app-template-svelte-typescript > build: web_modules/svelte/internal.js 1`] = `"export { S as SvelteComponent, a as append, b as attr, d as detach, e as element, i as init, c as insert, n as noop, s as safe_not_equal, f as set_data, g as space, t as text } from '../common/index-XXXXXXXX.js';"`;
 
-exports[`create-snowpack-app app-template-vue > build: __snowpack__/env.js 1`] = `"export default {\\"MODE\\":\\"production\\",\\"NODE_ENV\\":\\"production\\",\\"SSR\\":false};"`;
+exports[`create-snowpack-app app-template-vue > build: __snowpack__/env.js 1`] = `
+"export const MODE = \\"production\\";
+export const NODE_ENV = \\"production\\";
+export const SSR = false;"
+`;
 
 exports[`create-snowpack-app app-template-vue > build: allFiles 1`] = `
 Array [
@@ -9356,7 +9408,7 @@ export default defaultExport"
 `;
 
 exports[`create-snowpack-app app-template-vue > build: dist/index.js 1`] = `
-"import __SNOWPACK_ENV__ from '../__snowpack__/env.js';
+"import * as __SNOWPACK_ENV__ from '../__snowpack__/env.js';
 import.meta.env = __SNOWPACK_ENV__;
 import { createApp } from \\"../web_modules/vue.js\\";
 import App from \\"./App.js\\";
@@ -9364,9 +9416,9 @@ const app = createApp(App);
 app.mount(\\"#app\\");
 // Hot Module Replacement (HMR) - Remove this snippet to remove HMR.
 // Learn more: https://www.snowpack.dev/concepts/hot-module-replacement
-if (import.meta.hot) {
-  import.meta.hot.accept();
-  import.meta.hot.dispose(() => {
+if (undefined /* [snowpack] import.meta.hot */ ) {
+  undefined /* [snowpack] import.meta.hot */ .accept();
+  undefined /* [snowpack] import.meta.hot */ .dispose(() => {
     app.unmount();
   });
 }"
@@ -14416,7 +14468,11 @@ function normalizeContainer(container) {
 export { createApp, createBlock, createTextVNode, createVNode, openBlock, toDisplayString };"
 `;
 
-exports[`create-snowpack-app app-template-vue-typescript > build: __snowpack__/env.js 1`] = `"export default {\\"MODE\\":\\"production\\",\\"NODE_ENV\\":\\"production\\",\\"SSR\\":false};"`;
+exports[`create-snowpack-app app-template-vue-typescript > build: __snowpack__/env.js 1`] = `
+"export const MODE = \\"production\\";
+export const NODE_ENV = \\"production\\";
+export const SSR = false;"
+`;
 
 exports[`create-snowpack-app app-template-vue-typescript > build: allFiles 1`] = `
 Array [
@@ -14747,7 +14803,7 @@ export default defineComponent({
 `;
 
 exports[`create-snowpack-app app-template-vue-typescript > build: dist/index.js 1`] = `
-"import __SNOWPACK_ENV__ from '../__snowpack__/env.js';
+"import * as __SNOWPACK_ENV__ from '../__snowpack__/env.js';
 import.meta.env = __SNOWPACK_ENV__;
 import { createApp } from \\"../web_modules/vue.js\\";
 import App from \\"./App.js\\";
@@ -14755,9 +14811,9 @@ const app = createApp(App);
 app.mount(\\"#app\\");
 // Hot Module Replacement (HMR) - Remove this snippet to remove HMR.
 // Learn more: https://www.snowpack.dev/concepts/hot-module-replacement
-if (import.meta.hot) {
-  import.meta.hot.accept();
-  import.meta.hot.dispose(() => {
+if (undefined /* [snowpack] import.meta.hot */ ) {
+  undefined /* [snowpack] import.meta.hot */ .accept();
+  undefined /* [snowpack] import.meta.hot */ .dispose(() => {
     app.unmount();
   });
 }"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2551,14 +2551,6 @@
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"
   integrity sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==
 
-"@types/babel-plugin-tester@^9.0.0":
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/@types/babel-plugin-tester/-/babel-plugin-tester-9.0.1.tgz#5f1dc3b9da821b119f74544cda308d1e040c4cba"
-  integrity sha512-RGZzADCDXd9MIxQzOM2I6guMFRtZw+XwVx+vmPliPAvGeh228ZYA3hoTEF9u3jNR2Nf/gyb55HI3D9pMl3m1LA==
-  dependencies:
-    "@types/babel__core" "*"
-    "@types/prettier" "*"
-
 "@types/babel-types@*", "@types/babel-types@^7.0.0":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/babel-types/-/babel-types-7.0.9.tgz#01d7b86949f455402a94c788883fe4ba574cad41"
@@ -2569,7 +2561,7 @@
   resolved "https://registry.yarnpkg.com/@types/babel__code-frame/-/babel__code-frame-7.0.2.tgz#e0c0f1648cbc09a9d4e5b4ed2ae9a6f7c8f5aeb0"
   integrity sha512-imO+jT/yjOKOAS5GQZ8SDtwiIloAGGr6OaZDKB0V5JVaSfGZLat5K5/ZRtyKW6R60XHV3RHYPTFfhYb+wDKyKg==
 
-"@types/babel__core@*", "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
+"@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.12"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.12.tgz#4d8e9e51eb265552a7e4f1ff2219ab6133bdfb2d"
   integrity sha512-wMTHiiTiBAAPebqaPiPDLFA4LYPKr6Ph0Xq/6rq1Ur3v66HXyG+clfR9CNETkD7MQS8ZHvpQOtA53DLws5WAEQ==
@@ -2877,7 +2869,7 @@
   resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-5.0.3.tgz#e7b5aebbac150f8b5fdd4a46e7f0bd8e65e19109"
   integrity sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==
 
-"@types/prettier@*", "@types/prettier@^2.0.0":
+"@types/prettier@^2.0.0":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.1.5.tgz#b6ab3bba29e16b821d84e09ecfaded462b816b00"
   integrity sha512-UEyp8LwZ4Dg30kVU2Q3amHHyTn1jEdhCIE59ANed76GaT1Vp76DD3ZWSAxgCrw6wJ0TqeoBpqmfUHiUDPs//HQ==
@@ -4015,16 +4007,6 @@ babel-plugin-macros@2.8.0:
     "@babel/runtime" "^7.7.2"
     cosmiconfig "^6.0.0"
     resolve "^1.12.0"
-
-babel-plugin-tester@^9.2.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-tester/-/babel-plugin-tester-9.2.0.tgz#7169f99678419b9c6754bcc5e3a44eb4a11cdff3"
-  integrity sha512-HCbgmxOJXCcJ8hMk4ek6Ehfv0Ye7D7EpglNP8bh2gmRZnLPkKSJF+ufvypur/F38N3bEWWHYX4QfdnfLyql2DQ==
-  dependencies:
-    "@types/babel-plugin-tester" "^9.0.0"
-    lodash.mergewith "^4.6.2"
-    prettier "^2.0.1"
-    strip-indent "^3.0.0"
 
 babel-plugin-transform-react-remove-prop-types@0.4.24:
   version "0.4.24"
@@ -6372,7 +6354,7 @@ engine.io@~3.2.0:
     engine.io-parser "~2.1.0"
     ws "~3.3.1"
 
-enhanced-resolve@^4.1.1, enhanced-resolve@^4.3.0:
+enhanced-resolve@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz#3b806f3bfafc1ec7de69551ef93cca46c1704126"
   integrity sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==
@@ -9352,11 +9334,6 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
-lodash.mergewith@^4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
-  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
-
 lodash.set@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
@@ -11405,7 +11382,7 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^2.0.1, prettier@^2.0.5:
+prettier@^2.0.5:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
   integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==


### PR DESCRIPTION
## Changes

- Implements #1889 to improve bundler perf
- `__snowpack__/env.js` is now many explicit named exports instead of one default object export.
- `import.meta.env.X` references are now rewritten directly to `_SNOWPACK_ENV_.X`

## Testing

- Tests updated

## Docs

- N/A