### PR TITLE
[plugin-svelte] disable svelte-hmr conflicting overlay

### DIFF
--- a/plugins/plugin-svelte/package.json
+++ b/plugins/plugin-svelte/package.json
@@ -18,7 +18,7 @@
   "gitHead": "a01616bb0787d56cd782f94cecf2daa12c7594e4",
   "dependencies": {
     "rollup-plugin-svelte": "^7.0.0",
-    "svelte-hmr": "^0.12.0",
+    "svelte-hmr": "^0.12.1",
     "svelte-preprocess": "^4.6.0"
   },
   "devDependencies": {

--- a/plugins/plugin-svelte/plugin.js
+++ b/plugins/plugin-svelte/plugin.js
@@ -128,6 +128,7 @@ module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
             ...hmrOptions,
             absoluteImports: false,
             injectCss: true,
+            noOverlay: true,
           },
           compiled,
           originalCode: codeToCompile,


### PR DESCRIPTION
## Changes

`svelte-hmr` implements its own error overlay, and it can conflict (be displayed at the same time) as Snowpack's one. Also, both overlays don't have the same design, so this seems pretty weird to keep both.

This PR opts out of `svelte-hmr` overlay to only keep Snowpack's one.

## Testing

Manual testing: errors that triggered `svelte-hmr` overlay before the change don't trigger it anymore after the change.

## Docs

I think the current double-overlay situation should be considered a bug that this change is fixing.