### PR TITLE
Update doc links in error messages and comments

### DIFF
--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -471,7 +471,7 @@ ${colors.dim(
           const fileName = path.relative(cwd, warning.id).replace(/\\/g, '/');
           logger.error(`${fileName}\n   ${warning.message}`);
         } else {
-          logger.error(`${warning.message}. See https://www.snowpack.dev/#troubleshooting`);
+          logger.error(`${warning.message}. See https://www.snowpack.dev/reference/common-error-details`);
         }
         return;
       }

--- a/esinstall/src/util.ts
+++ b/esinstall/src/util.ts
@@ -86,9 +86,9 @@ export function resolveDependencyManifest(dep: string, cwd: string): [string | n
  */
 export const MISSING_PLUGIN_SUGGESTIONS: {[ext: string]: string} = {
   '.svelte':
-    'Try installing rollup-plugin-svelte and adding it to Snowpack (https://www.snowpack.dev/#custom-rollup-plugins)',
+    'Try installing rollup-plugin-svelte and adding it to Snowpack (https://www.snowpack.dev/tutorials/svelte)',
   '.vue':
-    'Try installing rollup-plugin-vue and adding it to Snowpack (https://www.snowpack.dev/#custom-rollup-plugins)',
+    'Try installing rollup-plugin-vue and adding it to Snowpack (https://www.snowpack.dev/guides/vue)',
 };
 
 /**

--- a/examples/https-ssl-certificates/snowpack.config.js
+++ b/examples/https-ssl-certificates/snowpack.config.js
@@ -1,5 +1,5 @@
 // Snowpack Configuration File
-// See all supported options: https://www.snowpack.dev/#configuration
+// See all supported options: https://www.snowpack.dev/reference/configuration
 
 /** @type {import("snowpack").SnowpackUserConfig } */
 module.exports = {

--- a/skypack/src/util.ts
+++ b/skypack/src/util.ts
@@ -126,9 +126,9 @@ export function resolveDependencyManifest(dep: string, cwd: string): [string | n
  */
 export const MISSING_PLUGIN_SUGGESTIONS: {[ext: string]: string} = {
   '.svelte':
-    'Try installing rollup-plugin-svelte and adding it to Snowpack (https://www.snowpack.dev/#custom-rollup-plugins)',
+    'Try installing rollup-plugin-svelte and adding it to Snowpack (https://www.snowpack.dev/tutorials/svelte)',
   '.vue':
-    'Try installing rollup-plugin-vue and adding it to Snowpack (https://www.snowpack.dev/#custom-rollup-plugins)',
+    'Try installing rollup-plugin-vue and adding it to Snowpack (https://www.snowpack.dev/guides/vue)',
 };
 
 export async function checkLockfileHash(dir: string) {

--- a/snowpack/assets/snowpack-init-file.js
+++ b/snowpack/assets/snowpack-init-file.js
@@ -1,5 +1,5 @@
 // Snowpack Configuration File
-// See all supported options: https://www.snowpack.dev/#configuration
+// See all supported options: https://www.snowpack.dev/reference/configuration
 
 /** @type {import("snowpack").SnowpackUserConfig } */
 module.exports = {

--- a/snowpack/src/index.ts
+++ b/snowpack/src/index.ts
@@ -28,7 +28,7 @@ ${colors.bold(`snowpack`)} - A faster build system for the modern web.
 
   Snowpack is best configured via config file.
   But, most configuration can also be passed via CLI flags.
-  📖 ${colors.dim('https://www.snowpack.dev/#configuration')}
+  📖 ${colors.dim('https://www.snowpack.dev/reference/configuration')}
 
 ${colors.bold('Commands:')}
   snowpack init          Create a new project config file.

--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -171,9 +171,9 @@ export function resolveDependencyManifest(dep: string, cwd: string): [string | n
  */
 export const MISSING_PLUGIN_SUGGESTIONS: {[ext: string]: string} = {
   '.svelte':
-    'Try installing rollup-plugin-svelte and adding it to Snowpack (https://www.snowpack.dev/#custom-rollup-plugins)',
+    'Try installing rollup-plugin-svelte and adding it to Snowpack (https://www.snowpack.dev/tutorials/svelte)',
   '.vue':
-    'Try installing rollup-plugin-vue and adding it to Snowpack (https://www.snowpack.dev/#custom-rollup-plugins)',
+    'Try installing rollup-plugin-vue and adding it to Snowpack (https://www.snowpack.dev/guides/vue)',
 };
 
 const appNames = {

--- a/test/esinstall/config-package-svelte/config-package-svelte.test.js
+++ b/test/esinstall/config-package-svelte/config-package-svelte.test.js
@@ -9,7 +9,7 @@ describe('config-package-svelte', () => {
     ).rejects.toThrowError(`Install failed.`);
     // TODO:
     // Assert the reason: Failed to load ../../../node_modules/simple-svelte-autocomplete/src/SimpleAutocomplete.svelte
-    // Try installing rollup-plugin-svelte and adding it to Snowpack (https://www.snowpack.dev/#custom-rollup-plugins)
+    // Try installing rollup-plugin-vue and adding it to Snowpack (https://www.snowpack.dev/guides/vue)
   });
 
   it('succeeds when svelte plugin is provided', async () => {


### PR DESCRIPTION
## Changes

While running `snowpack init`, I noticed that the link to the `snowpack.config.js` reference was broken, I found a few that also started by `https://www.snowpack.dev/#` that looked off

- https://www.snowpack.dev/#configuration' :arrow_right: https://www.snowpack.dev/reference/configuration
- https://www.snowpack.dev/#troubleshooting :arrow_right: https://www.snowpack.dev/reference/common-error-details
- (for svelte errors) https://www.snowpack.dev/#custom-rollup-plugins :arrow_right: https://www.snowpack.dev/tutorials/svelte
- (for vue errors) https://www.snowpack.dev/#custom-rollup-plugins :arrow_right: https://www.snowpack.dev/guides/vue

## Testing

I only modified error strings and comments so I think we should be good

## Docs

I don't think there's the need for that