### PR TITLE
Concise view for dashboard

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -296,6 +296,7 @@ export async function startDevServer(commandOptions: CommandOptions): Promise<Sn
     paintDashboard(
       messageBus,
       config.plugins.map((p) => p.name),
+      config.devOptions.concise
     );
     logger.debug(`dashboard started`);
   } else {

--- a/snowpack/src/commands/paint.ts
+++ b/snowpack/src/commands/paint.ts
@@ -3,6 +3,7 @@ import {EventEmitter} from 'events';
 import * as colors from 'kleur/colors';
 import path from 'path';
 import readline from 'readline';
+import stripAnsi from 'strip-ansi';
 import {logger, LogRecord} from '../logger';
 
 const cwd = process.cwd();
@@ -116,7 +117,7 @@ interface WorkerState {
 }
 const WORKER_BASE_STATE: WorkerState = {done: false, error: null, output: ''};
 
-export function paintDashboard(bus: EventEmitter, plugins: string[]) {
+export function paintDashboard(bus: EventEmitter, plugins: string[], concise: boolean) {
   let serverInfo: ServerInfo;
   const allWorkerStates: Record<string, WorkerState> = {};
   const allFileBuilds = new Set<string>();
@@ -132,18 +133,21 @@ export function paintDashboard(bus: EventEmitter, plugins: string[]) {
   }
 
   function repaint() {
+    const formatHeader = concise ? colors.dim : colors.bold;
+    const formatWorker = concise ? (str) => str : colors.underline;
+    const EOL = concise ? '\n' : '\n\n';
     // Clear Page
     process.stdout.write(process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H');
     // Header
-    process.stdout.write(`${colors.bold(`snowpack`)}\n\n`);
+    process.stdout.write(`${colors.bold(formatHeader(`snowpack`))}${EOL}`);
     // Server Stats
-    serverInfo && process.stdout.write(getServerInfoMessage(serverInfo, allFileBuilds.size > 0));
+    serverInfo && !concise && process.stdout.write(getServerInfoMessage(serverInfo, allFileBuilds.size > 0));
     // Console Output
     const history = logger.getHistory();
     if (history.length) {
-      process.stdout.write(`${colors.underline(colors.bold('▼ Console'))}\n`);
+      process.stdout.write(`${formatWorker(formatHeader('▼ Console'))}\n`);
       process.stdout.write(summarizeHistory(history));
-      process.stdout.write('\n\n');
+      process.stdout.write(EOL);
     }
     // Worker Dashboards
     for (const [script, workerState] of Object.entries(allWorkerStates)) {
@@ -151,9 +155,19 @@ export function paintDashboard(bus: EventEmitter, plugins: string[]) {
         continue;
       }
       const colorsFn = Array.isArray(workerState.error) ? colors.red : colors.reset;
-      process.stdout.write(`${colorsFn(colors.underline(colors.bold('▼ ' + script)))}\n\n`);
-      process.stdout.write('  ' + workerState.output.trim().replace(/\n/gm, '\n  '));
-      process.stdout.write('\n\n');
+      process.stdout.write(`${colorsFn(formatWorker(formatHeader('▼ ' + script)))}${EOL}`);
+      var output = workerState.output.trim();
+      if (concise) {
+        // Strip blank lines
+        output = output
+            .split('\n')
+            .filter((line) => stripAnsi(line).length > 0)
+            .join('\n');
+      }
+      if (output.length > 0) {
+        process.stdout.write('  ' + output.replace(/\n/gm, '\n  '));
+      }
+      !concise && process.stdout.write(EOL);
     }
   }
 

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -123,6 +123,7 @@ const configSchema = {
         hmrDelay: {type: 'number'},
         hmrPort: {type: 'number'},
         hmrErrorOverlay: {type: 'boolean'},
+        config: {type: 'boolean'},
         // DEPRECATED
         out: {type: 'string'},
       },

--- a/snowpack/src/types/snowpack.ts
+++ b/snowpack/src/types/snowpack.ts
@@ -232,6 +232,7 @@ export interface SnowpackConfig {
     hmrDelay: number;
     hmrPort: number | undefined;
     hmrErrorOverlay: boolean;
+    concise: boolean;
   };
   installOptions: Omit<InstallOptions, 'alias'>;
   buildOptions: {


### PR DESCRIPTION
This is out of the blue, so feel free to take as much or as little as makes sense :)

## Background
The developer has many windows open - IDE, terminal, browser, StackOverflow. Sometimes they are plugged into an external monitor with plenty of pixels, other times just a laptop. Screen real-estate is limited, and rearranging them takes valuable time.

## Simple case
Developer uses Snowpack for hot-reloading with a simple config file. They minimize/cover the Terminal running Snowpack.

## Advanced: Snowpack as dashboard
A team has feedback tools for static analysis in snowpack -- linting, type checking, unit tests. The snowpack dashboard shows information without scrolling or a lot of screen flicker. Snowpack reacts and shows feedback quickly on change. Developers find the fast-feedback loop valuable, so keep it onscreen and notice flashing / bright colors if they have errors in code.

When errors fire, the Snowpack window explodes with feedback, scrolling vertically from the 3 concurrent checks. The developer may need to click over to the window and scroll through output.

## Proposal
I was thinking about Snowpack's dashboard in relation to Edward Tufte's data-to-ink ratio. Basically, make each pixel justify its existence (and intensity) by the value it provides.

Here are some screenshots--

## Before: Success - 23 lines
![image](https://user-images.githubusercontent.com/883896/102656817-80d4aa80-4142-11eb-9d6a-ebe834d3da7b.png)

Nicely formatted - underlines, bright colors, blank lines. 
  
 ## Before: Errors - 45 lines
![image](https://user-images.githubusercontent.com/883896/102656924-bb3e4780-4142-11eb-8761-8e0d5eeec55b.png)

Screen seems busy. Bright underlined task names compete with the tool output for attention.
  
 ## Proposal: Success - 9 lines
![image](https://user-images.githubusercontent.com/883896/102657196-43bce800-4143-11eb-8a99-27b388c3ee92.png)

 Non-essential information is dropped. Lower contrast, less blank space. Plugin output is brighter, pops out.

## Proposal: Errors - 27 lines
![image](https://user-images.githubusercontent.com/883896/102657290-6c44e200-4143-11eb-8d23-bedc154e85a6.png)

Errors stand out. Fewer lines, need to scroll.

## Objections
Does not look as nice as before. True: the priority here is to convey information with as **little screen real estate as possible** for the dashboard scenario. It's opt-in.

## Tests
Don't have any -- there was no existing infra I could find to hit this code path.
