### PR TITLE
Concise display - as few lines as possible, more muted colors. Let pl…

### DIFF
--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -110,6 +110,7 @@ const configSchema = {
         hmrDelay: {type: 'number'},
         hmrPort: {type: 'number'},
         hmrErrorOverlay: {type: 'boolean'},
+        concise: {type: 'boolean'},
       },
     },
     installOptions: {

--- a/snowpack/src/types/snowpack.ts
+++ b/snowpack/src/types/snowpack.ts
@@ -213,6 +213,7 @@ export interface SnowpackConfig {
     hmrDelay: number;
     hmrPort: number | undefined;
     hmrErrorOverlay: boolean;
+    concise: boolean;
   };
   installOptions: Omit<InstallOptions, 'alias'>;
   buildOptions: {

--- a/www/_template/reference/configuration.md
+++ b/www/_template/reference/configuration.md
@@ -144,6 +144,10 @@ module.exports = {
 - `"dashboard"` delivers an organized layout of console output and the logs of any connected tools. This is recommended for most users and results in the best logging experience.
 - `"stream"` is useful when Snowpack is run in parallel with other commands, where clearing the shell would clear important output of other commands running in the same shell.
 
+#### devOptions.concise | `boolean` | Default false
+
+`Concise` dashboard view will present the dashboard in as few lines as possible. This is useful if you have a lot of plugins producing output, and would like to see them without scrolling.
+
 #### devOptions.hostname | `string` | Default: `localhost`
 
 - The hostname where the browser tab will be open.


### PR DESCRIPTION
This is out of the blue, so feel free to take as much or as little as makes sense :)

## Background
The developer has many windows open - IDE, terminal, browser, StackOverflow. Sometimes they are plugged into an external monitor with plenty of pixels, other times just a laptop. Screen real-estate is limited, and rearranging them takes valuable time.

## Simple case
Developer uses Snowpack for hot-reloading with a simple config file. They minimize/cover the Terminal running Snowpack.

## Advanced: Snowpack as dashboard
A team has feedback tools for static analysis in snowpack -- linting, type checking, unit tests. The snowpack dashboard shows information without scrolling or a lot of screen flicker. Snowpack reacts and shows feedback quickly on change. Developers find the fast-feedback loop valuable, so keep it onscreen and notice flashing / bright colors if they have errors in code.

When errors fire, the Snowpack window explodes with feedback, scrolling vertically from the 3 concurrent checks. The developer may need to click over to the window and scroll through output.

## Proposal
I was thinking about Snowpack's dashboard in relation to Edward Tufte's data-to-ink ratio. Basically, make each pixel justify its existence (and intensity) by the value it provides.

Here are some screenshots--

## Before: Success - 23 lines
![image](https://user-images.githubusercontent.com/883896/102656817-80d4aa80-4142-11eb-9d6a-ebe834d3da7b.png)

Nicely formatted - underlines, bright colors, blank lines. 
  
 ## Before: Errors - 45 lines
![image](https://user-images.githubusercontent.com/883896/102656924-bb3e4780-4142-11eb-8761-8e0d5eeec55b.png)

Screen seems busy. Bright underlined task names compete with the tool output for attention.
  
 ## Proposal: Success - 9 lines
![image](https://user-images.githubusercontent.com/883896/102657196-43bce800-4143-11eb-8a99-27b388c3ee92.png)

 Non-essential information is dropped. Lower contrast, less blank space. Plugin output is brighter, pops out.

## Proposal: Errors - 27 lines
![image](https://user-images.githubusercontent.com/883896/102657290-6c44e200-4143-11eb-8d23-bedc154e85a6.png)

Errors stand out. Fewer lines, need to scroll.

The same information in 40% less vertical real estate!

## Tests
Don't have any -- there was no existing infra I could find to hit this code path.

## Docs
Updated.