### PR TITLE
update polyfill node rollup plugin

### DIFF
--- a/esinstall/package.json
+++ b/esinstall/package.json
@@ -53,7 +53,7 @@
     "mkdirp": "^1.0.3",
     "rimraf": "^3.0.0",
     "rollup": "^2.34.0",
-    "rollup-plugin-node-polyfills": "^0.2.1",
+    "rollup-plugin-polyfill-node": "^0.4.1",
     "validate-npm-package-name": "^3.0.0",
     "vm2": "^3.9.2"
   }

--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -9,7 +9,7 @@ import mkdirp from 'mkdirp';
 import path from 'path';
 import rimraf from 'rimraf';
 import {InputOptions, OutputOptions, Plugin as RollupPlugin, rollup, RollupError} from 'rollup';
-import rollupPluginNodePolyfills from 'rollup-plugin-node-polyfills';
+import rollupPluginNodePolyfills from 'rollup-plugin-polyfill-node';
 import rollupPluginReplace from '@rollup/plugin-replace';
 import util from 'util';
 import validatePackageName from 'validate-npm-package-name';

--- a/snowpack/scripts/generate-bundle.js
+++ b/snowpack/scripts/generate-bundle.js
@@ -91,10 +91,6 @@ const config = {
         // vm2 & others
         {find: /^vm2$/, replacement: require.resolve('../vendor/vm2/index.js')},
         {find: /^htmlparser2$/, replacement: require.resolve('../vendor/generated/~htmlparser2.js')},
-        {
-          find: /^rollup-plugin-node-polyfills$/,
-          replacement: 'rollup-plugin-node-polyfills/dist/index.js'
-        },
       ],
     }),
     commonjs({

--- a/snowpack/scripts/generate-vendor.js
+++ b/snowpack/scripts/generate-vendor.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 
 fs.copyFileSync(require.resolve('source-map/lib/mappings.wasm'), path.join(__dirname, '../lib/mappings.wasm'));
 // fs.copyFileSync(path.join(require.resolve('rollup-plugin-node-polyfills/package.json'), '../polyfills'), path.join(__dirname, '../polyfills'));
-execa.commandSync(`cp -r ${path.join(require.resolve('rollup-plugin-node-polyfills/package.json'), '../polyfills')} ${path.join(__dirname, '../polyfills')}`);
+// execa.commandSync(`cp -r ${path.join(require.resolve('rollup-plugin-node-polyfills/package.json'), '../polyfills')} ${path.join(__dirname, '../polyfills')}`);
 
 /** 
  * Some packages just don't work with Rollup. As a workaround,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2424,7 +2424,7 @@
     magic-string "^0.25.7"
     resolve "^1.17.0"
 
-"@rollup/plugin-inject@^4.0.2":
+"@rollup/plugin-inject@^4.0.0", "@rollup/plugin-inject@^4.0.2":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-inject/-/plugin-inject-4.0.2.tgz#55b21bb244a07675f7fdde577db929c82fc17395"
   integrity sha512-TSLMA8waJ7Dmgmoc8JfPnwUwVZgLjjIAM6MqeIFqPO2ODK36JqE0Cf2F54UTgCUuW8da93Mvoj75a6KAVWgylw==
@@ -5776,7 +5776,7 @@ css-loader@^4.3.0:
 "css-package-a@file:./test/build/config-alias/packages/css-package-a":
   version "1.2.3"
 
-"css-package@file:./test/build/scan-imports/packages/css-package":
+"css-package@file:./test/build/scan-imports-html/packages/css-package":
   version "1.2.3"
 
 css-select-base-adapter@^0.1.1:
@@ -9695,7 +9695,7 @@ macos-release@^2.2.0:
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.4.1.tgz#64033d0ec6a5e6375155a74b1a1eba8e509820ac"
   integrity sha512-H/QHeBIN1fIGJX517pvK8IEK53yQOW7YcEI55oYtgjDdoCQQz7eJS94qt5kNrscReEyuD/JcdFCm2XBEcGOITg==
 
-magic-string@^0.25.3, magic-string@^0.25.5, magic-string@^0.25.7:
+magic-string@^0.25.5, magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
   integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
@@ -12578,21 +12578,12 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollup-plugin-inject@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz#e4233855bfba6c0c12a312fd6649dff9a13ee9f4"
-  integrity sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==
+rollup-plugin-polyfill-node@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-polyfill-node/-/rollup-plugin-polyfill-node-0.4.1.tgz#3a1207e725d4b30725b754875a34ee6b4e695f56"
+  integrity sha512-PxON/asmp3BuBaJPUToUQSq3RA6MpDma0zlK+NuQoBgxImMOPjVeelkdLYh0EWo9ZSJbCqDDkckAAM0wOwvysQ==
   dependencies:
-    estree-walker "^0.6.1"
-    magic-string "^0.25.3"
-    rollup-pluginutils "^2.8.1"
-
-rollup-plugin-node-polyfills@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz#53092a2744837164d5b8a28812ba5f3ff61109fd"
-  integrity sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==
-  dependencies:
-    rollup-plugin-inject "^3.0.0"
+    "@rollup/plugin-inject" "^4.0.0"
 
 rollup-plugin-svelte@^7.0.0:
   version "7.0.0"
@@ -12602,7 +12593,7 @@ rollup-plugin-svelte@^7.0.0:
     require-relative "^0.8.7"
     rollup-pluginutils "^2.8.2"
 
-rollup-pluginutils@^2.8.1, rollup-pluginutils@^2.8.2:
+rollup-pluginutils@^2.8.2:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
   integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==


### PR DESCRIPTION
## Changes

- We forked the old plugin which had been abandoned: https://github.com/rollup/plugins/pull/51#issuecomment-747489334
- Then we made some improvements to it: https://github.com/snowpackjs/rollup-plugin-polyfill-node
- Now we're good to update to it 👍 

## Testing

- Covered by existing tests (and the test suite in the plugin repo)

## Docs

- N/A