### PR TITLE
typo: "three" => "two" SSR options

### DIFF
--- a/www/_template/guides/server-side-render.md
+++ b/www/_template/guides/server-side-render.md
@@ -11,7 +11,7 @@ Server-side rendering (SSR) refers to several similar developer stories:
 - Using Snowpack with a server-side frontend framework kit like Next.js or SvelteKit
 - Any site configuration where your HTML is generated at runtime, outside of your static build.
 
-This guide will walk you through three different options for setting up Snowpack with your own custom server:
+This guide will walk you through two options for setting up Snowpack with your own custom server:
 
 1. `snowpack build --watch` - Load files out of the static build directory
 2. `startDevServer({ ... })` - Load files on-demand via Snowpack's JavaScript API


### PR DESCRIPTION
## Changes

On the SSR docs page, the intro mentions three options, but then the page discusses only two options. This changes the intro to match what's covered.

## Testing

Docs change only, no tests should be affected.

## Docs

This is a docs change only.
