### PR TITLE
[v3] buildOptions.clean now defaults to true

### DIFF
--- a/plugins/plugin-babel/plugin.js
+++ b/plugins/plugin-babel/plugin.js
@@ -27,7 +27,7 @@ module.exports = function plugin(snowpackConfig, options = {}) {
       worker = worker || (await pool.proxy());
       let encodedResult = await worker.transformFileAsync(filePath, {
         caller: {
-          name: "@snowpack/plugin-babel",
+          name: '@snowpack/plugin-babel',
           supportsStaticESM: true,
           supportsDynamicImport: true,
           supportsTopLevelAwait: true,

--- a/snowpack/src/build/optimize.ts
+++ b/snowpack/src/build/optimize.ts
@@ -4,7 +4,6 @@ import {promises as fs, readFileSync, unlinkSync, writeFileSync} from 'fs';
 import {glob} from 'glob';
 import mkdirp from 'mkdirp';
 import path from 'path';
-import rimraf from 'rimraf';
 import {logger} from '../logger';
 import {OptimizeOptions, SnowpackConfig} from '../types';
 import {
@@ -16,6 +15,7 @@ import {
   PROJECT_CACHE_DIR,
   removeLeadingSlash,
   removeTrailingSlash,
+  deleteFromBuildSafe,
 } from '../util';
 import {getUrlForFile} from './file-urls';
 
@@ -531,8 +531,9 @@ export async function runBuiltInOptimize(config: SnowpackConfig) {
         await fs.unlink(path.resolve(buildDirectoryLoc, bundledInput));
       }
     }
-    rimraf.sync(
+    deleteFromBuildSafe(
       path.resolve(buildDirectoryLoc, removeLeadingSlash(config.buildOptions.webModulesUrl)),
+      config
     );
     await removeEmptyFolders(buildDirectoryLoc);
     for (const outputFile of outputFiles!) {

--- a/snowpack/src/commands/build.ts
+++ b/snowpack/src/commands/build.ts
@@ -6,7 +6,6 @@ import mkdirp from 'mkdirp';
 import PQueue from 'p-queue';
 import path from 'path';
 import {performance} from 'perf_hooks';
-import rimraf from 'rimraf';
 import url from 'url';
 import {
   generateEnvModule,
@@ -34,6 +33,7 @@ import {
 } from '../types';
 import {
   cssSourceMappingURL,
+  deleteFromBuildSafe,
   getExtensionMatch,
   getPackageSource,
   HMR_CLIENT_CODE,
@@ -352,7 +352,7 @@ export async function buildProject(commandOptions: CommandOptions): Promise<Snow
   const internalFilesBuildLoc = path.join(buildDirectoryLoc, config.buildOptions.metaDir);
 
   if (config.buildOptions.clean) {
-    rimraf.sync(buildDirectoryLoc);
+    deleteFromBuildSafe(buildDirectoryLoc, config);
   }
   mkdirp.sync(buildDirectoryLoc);
   mkdirp.sync(internalFilesBuildLoc);

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -52,7 +52,7 @@ const DEFAULT_CONFIG: SnowpackUserConfig = {
     out: 'build',
     baseUrl: '/',
     webModulesUrl: '/web_modules',
-    clean: false,
+    clean: true,
     metaDir: '__snowpack__',
     minify: false,
     sourceMaps: false,

--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -48,6 +48,23 @@ export const HTML_STYLE_REGEX = /(<style.*?>)(.*?)<\/style>/gims;
 export const CSS_REGEX = /@import\s*['"](.*?)['"];/gs;
 export const SVELTE_VUE_REGEX = /(<script[^>]*>)(.*?)<\/script>/gims;
 
+/**
+ * Like rimraf, but will fail if "dir" is outside of your configured build output directory.
+ */
+export function deleteFromBuildSafe(dir: string, config: SnowpackConfig) {
+  const {out} = config.buildOptions;
+  if (!path.isAbsolute(dir)) {
+    throw new Error(`rimrafSafe(): dir ${dir} must be a absolute path`);
+  }
+  if (!path.isAbsolute(out)) {
+    throw new Error(`rimrafSafe(): buildOptions.out ${out} must be a absolute path`);
+  }
+  if (!dir.startsWith(out)) {
+    throw new Error(`rimrafSafe(): ${dir} outside of buildOptions.out ${out}`);
+  }
+  return rimraf.sync(dir);
+}
+
 /** Read file from disk; return a string if it’s a code file */
 export async function readFile(filepath: URL): Promise<string | Buffer> {
   const data = await fs.promises.readFile(url.fileURLToPath(filepath));

--- a/test/build/config-out-flag/package.json
+++ b/test/build/config-out-flag/package.json
@@ -6,11 +6,6 @@
   "scripts": {
     "testbuild": "snowpack build --out TEST_BUILD_OUT"
   },
-  "snowpack": {
-    "buildOptions": {
-      "clean": true
-    }
-  },
   "devDependencies": {
     "cross-env": "^7.0.2",
     "snowpack": "^2.14.3"

--- a/test/build/plugin-hook-transform/snowpack.config.json
+++ b/test/build/plugin-hook-transform/snowpack.config.json
@@ -3,7 +3,6 @@
     "./src": "/_dist_"
   },
   "buildOptions": {
-    "clean": true,
     "sourceMaps": true
   },
   "plugins": ["./custom-transform-plugin.js"]

--- a/www/_template/reference/configuration.md
+++ b/www/_template/reference/configuration.md
@@ -175,9 +175,9 @@ module.exports = {
 
 - In your HTML, replace all instances of `%PUBLIC_URL%` with this (inspired by the same [Create React App](https://create-react-app.dev/docs/using-the-public-folder/) concept). This is useful if your app will be deployed to a subdirectory. _Note: if you have `homepage` in your `package.json`, Snowpack will actually pick up on that, too._
 
-#### buildOptions.clean | `boolean` | Default: `false`
+#### buildOptions.clean | `boolean` | Default: `true`
 
-- Set to `true` if Snowpack should erase the build folder before each build.
+- Set to `false` to prevent Snowpack from deleting the build output folder (`buildOptions.out`) between builds.
 
 #### buildOptions.metaDir | `string` | Default: `__snowpack__`
 


### PR DESCRIPTION
## Changes

- Changed this default behavior from "false" to "true"
- Reasoning: since the v2.0 release, our automatic build optimizations now work by scanning your build directory for files to build, bundle, etc. This creates undefined behavior when clean = false that's confusing as a default behavior, on top of the existing issue of undefined behavior where the build directory wasn't cleaned and unexpected files would exist.
- Added a safe, protected helper method to remove all current unprotected calls to rimraf.

## Testing

- Tests updated (also covered by existing tests)
- Improves our tests by fixing a class of issue where our tests didn't define this value, which gives false negatives (ignored) any "file not built" error when tests are run locally.

## Docs

- Docs updated.
