### PR TITLE
Fix paths in contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,13 +83,13 @@ You can run your local snowpack by path
 ```bash
 yarn build
 cd path/to/some-other-project
-/path/to/snowpack/pkg/dist-node/index.bin.js dev --verbose --reload
+/path/to/snowpack-repository/snowpack/index.bin.js dev --verbose --reload
 ```
 
 Or by linking the global `snowpack` library to your local clone
 
 ```bash
-cd pkg
+cd snowpack
 npm link
 cd path/to/some-other-project
 snowpack dev --verbose --reload
@@ -98,7 +98,7 @@ snowpack dev --verbose --reload
 To test a local version of the CLI tool use
 
 ```bash
-node /path/to/snowpack/create-snowpack-app/cli [my-new-dir] --template @snowpack/app-template-vue
+node /path/to/snowpack-repository/create-snowpack-app/cli [my-new-dir] --template @snowpack/app-template-vue
 ```
 
 To test a local version of the `create-snowpack-app` templates use


### PR DESCRIPTION
## Changes

I tried to follow the instructions in `CONTRIBUTING.md` and noticed that the paths to `snowpack` aren't working. I removed the `pkg` and `dist-node` parts and changed the repository name to distinguish it from the `snowpack` directory inside the repository.

## Testing

I tested the three new paths manually.

## Docs

This PR only updates the contributing guidelines.
