### PR TITLE
Fix #2088: unbreak automatic reinstall of linked dependencies on change

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -1121,7 +1121,7 @@ export async function startServer(commandOptions: CommandOptions): Promise<Snowp
     const quickETagCheck = req.headers['if-none-match'];
     const quickETagCheckUrl = reqUrl.replace(/\/$/, '/index.html');
     if (quickETagCheck && quickETagCheck === knownETags.get(quickETagCheckUrl)) {
-      logger.debug(`optimized etag! sending 304...`);
+      logger.debug(`optimized etag for ${quickETagCheckUrl}! sending 304...`);
       res.writeHead(304, {'Access-Control-Allow-Origin': '*'});
       res.end();
       return;
@@ -1346,6 +1346,7 @@ export async function startServer(commandOptions: CommandOptions): Promise<Snowp
 
   let working : Promise<any> | null = null; // only one installl at a time
   function onDepWatchEvent() {
+    knownETags.clear();
     if (!working)
       // FIXME: If one changes, reinstall _all_.  Inefficient?
       working = installDependencies(config)

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -1355,6 +1355,7 @@ export async function startServer(commandOptions: CommandOptions): Promise<Snowp
         });
   }
   const depWatcher = chokidar.watch([...symlinkedFileLocs], {
+    ignored: config.exclude,
     cwd: '/', // we’re using absolute paths, so watch from root
     persistent: true,
     ignoreInitial: true,

--- a/snowpack/src/sources/local-install.ts
+++ b/snowpack/src/sources/local-install.ts
@@ -18,7 +18,7 @@ interface InstallRunOptions {
   shouldPrintStats: boolean;
 }
 
-interface InstallRunResult {
+export interface InstallRunResult {
   importMap: ImportMap;
   newLockfile: ImportMap | null;
   stats: DependencyStatsOutput | null;

--- a/snowpack/src/sources/local.ts
+++ b/snowpack/src/sources/local.ts
@@ -6,7 +6,7 @@ import {ImportMap, InstallOptions as EsinstallOptions} from 'esinstall';
 import {existsSync, promises as fs} from 'fs';
 import * as colors from 'kleur/colors';
 import path from 'path';
-import {run as installRunner} from './local-install';
+import {InstallRunResult, run as installRunner} from './local-install';
 import {logger} from '../logger';
 import {getInstallTargets} from '../scan-imports';
 import {CommandOptions, PackageSource, PackageSourceLocal, SnowpackConfig} from '../types';
@@ -26,14 +26,15 @@ const DEV_DEPENDENCIES_DIR = path.join(PROJECT_CACHE_DIR, process.env.NODE_ENV |
  * your entire source app for dependency install targets, installs them,
  * and then updates the "hash" file used to check node_modules freshness.
  */
-async function installDependencies(config: SnowpackConfig) {
+export async function installDependencies(config: SnowpackConfig)
+: Promise <InstallRunResult | null> {
   const installTargets = await getInstallTargets(
     config,
     config.packageOptions.source === 'local' ? config.packageOptions.knownEntrypoints : [],
   );
   if (installTargets.length === 0) {
     logger.info('Nothing to install.');
-    return;
+    return null;
   }
   // 2. Install dependencies, based on the scan of your final build.
   const installResult = await installRunner({


### PR DESCRIPTION
* snowpack/src/commands/dev.ts (installDependencies): import it.
(onDepWatchEvent): Use it.

* snowpack/src/commands/install.ts (InstallRunResult): export it.

* snowpack/src/sources/local.ts (InstallRunResult): import it.
(installDependencies): export it.

## Changes

<!-- What does this change, in plain language? -->

This fix bug #2088, a regression.  It unbreaks the automatic reinstall of linked dependencies on change, which was lost after commit 610fb9d28452bf24758387a00fe81a4ed103e503.

<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- How was this change tested? -->

Not extensively tested I must say.  I manually tested by changing the file of a single linked dependency. Anyway,  the change to the code is small so it should be easy to understand what it does.

I also ran `yarn test` from the console.  i got a single failure related to something react/svelte.  I don't think i introduced that.  Maybe I need some package installed or something.

<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

bug fix only. Presumably this is already documented.  But if it's not, tell me and I'll see to it.  I write decent documentation.
