### PR TITLE
[wip] Don't prefer built-in Node.js modules when running `esinstall`

### DIFF
--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -433,7 +433,7 @@ ${colors.dim(
         mainFields: ['browser:module', 'module', 'browser', 'main'],
         extensions: ['.mjs', '.cjs', '.js', '.json'], // Default: [ '.mjs', '.js', '.json', '.node' ]
         // whether to prefer built-in modules (e.g. `fs`, `path`) or local ones with the same names
-        preferBuiltins: true, // Default: true
+        preferBuiltins: false,
         dedupe: userDefinedRollup.dedupe || [],
         // @ts-ignore: Added in v11+ of this plugin
         exportConditions: packageExportLookupFields,


### PR DESCRIPTION
## Changes

If a module with the same name as a built-in Node.js module exists in `node_modules`, it should take precedence over the built-in module. For example, if the `buffer` module from npm is used by a package, `esinstall` should use this module instead of failing with an error message saying that Node.js polyfills are needed.

https://github.com/snowpackjs/snowpack/discussions/1848#discussioncomment-234614

## Testing

Tested manually by using the `bson` package with Snowpack.

## Docs

Bug fix only.