### PR TITLE
Handle HMR updates on svelte pre-processed file dependencies

### DIFF
--- a/plugins/plugin-svelte/plugin.js
+++ b/plugins/plugin-svelte/plugin.js
@@ -77,6 +77,8 @@ module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
     }
   }
 
+  console.log(pluginOptions.preprocess);
+
   if (preprocessOptions === undefined) {
     preprocessOptions = require('svelte-preprocess')();
   }
@@ -108,6 +110,8 @@ module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
       let codeToCompile = await fs.promises.readFile(filePath, 'utf-8');
       // PRE-PROCESS
       if (preprocessOptions !== false) {
+        console.log('boo!');
+
         ({code: codeToCompile, dependencies} = await svelte.preprocess(
           codeToCompile,
           preprocessOptions,
@@ -120,7 +124,7 @@ module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
       if (isDev && dependencies) {
         dependencies.forEach((depPath) => {
           console.log(depPath, filePath);
-          importedByMap(depPath, filePath);
+          importedByMap.set(depPath, filePath);
         });
       }
 

--- a/plugins/plugin-svelte/plugin.js
+++ b/plugins/plugin-svelte/plugin.js
@@ -77,8 +77,6 @@ module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
     }
   }
 
-  console.log(pluginOptions.preprocess);
-
   if (preprocessOptions === undefined) {
     preprocessOptions = require('svelte-preprocess')();
   }

--- a/plugins/plugin-svelte/plugin.js
+++ b/plugins/plugin-svelte/plugin.js
@@ -83,14 +83,12 @@ module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
     preprocessOptions = require('svelte-preprocess')();
   }
 
-  const importedByMap = new Map();
-
-  function addImportsToMap(filePath, sassImport) {
-    const importedBy = importedByMap.get(sassImport);
+  function addImportsToMap(filePath, imp) {
+    const importedBy = importedByMap.get(imp);
     if (importedBy) {
       importedBy.add(filePath);
     } else {
-      importedByMap.set(sassImport, new Set([filePath]));
+      importedByMap.set(imp, new Set([filePath]));
     }
   }
 

--- a/plugins/plugin-svelte/plugin.js
+++ b/plugins/plugin-svelte/plugin.js
@@ -139,7 +139,7 @@ module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
       }
 
       // in dev mode, track preprocess dependencies
-      if (isDev && dependencies) {
+      if (isDev && dependencies.length) {
         dependencies.forEach((imp) => addImportsToMap(filePath, imp));
       }
 

--- a/plugins/plugin-svelte/plugin.js
+++ b/plugins/plugin-svelte/plugin.js
@@ -139,7 +139,7 @@ module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
       }
 
       // in dev mode, track preprocess dependencies
-      if (isDev && dependencies.length) {
+      if (isDev && dependencies && dependencies.length) {
         dependencies.forEach((imp) => addImportsToMap(filePath, imp));
       }
 

--- a/plugins/plugin-svelte/test/plugin.test.js
+++ b/plugins/plugin-svelte/test/plugin.test.js
@@ -168,7 +168,7 @@ describe('@snowpack/plugin-svelte (preprocessor deps)', () => {
 
   afterAll(() => jest.resetModules());
 
-  it.only('marks a file as changed when a preprocess dependency changes', async () => {
+  it('marks a file as changed when a preprocess dependency changes', async () => {
     const preprocess = {__test: 'preprocess'};
     const p = plugin(DEFAULT_CONFIG, {preprocess});
     p.markChanged = jest.fn();

--- a/plugins/plugin-svelte/test/plugin.test.js
+++ b/plugins/plugin-svelte/test/plugin.test.js
@@ -2,9 +2,10 @@ const path = require('path');
 
 const mockCompiler = jest.fn().mockImplementation((code) => ({js: {code}}));
 const mockPreprocessor = jest.fn().mockImplementation((code) => code);
-const mockPreprocessorWithDeps = jest
-  .fn()
-  .mockImplementation((code) => ({code, dependencies: ['path/to/file.stylus']}));
+const mockPreprocessorWithDeps = jest.fn().mockImplementation((code) => ({
+  code,
+  dependencies: ['path/to/file.stylus', 'path/to/file2.stylus'],
+}));
 
 let DEFAULT_CONFIG;
 const mockComponent = path.join(__dirname, 'Button.svelte');
@@ -170,8 +171,13 @@ describe('@snowpack/plugin-svelte (preprocessor deps)', () => {
   it.only('marks a file as changed when a preprocess dependency changes', async () => {
     const preprocess = {__test: 'preprocess'};
     const p = plugin(DEFAULT_CONFIG, {preprocess});
+    p.markChanged = jest.fn();
     await p.load({filePath: mockComponent});
+    p.onChange({filePath: 'path/to/file.stylus'});
+    p.onChange({filePath: 'path/to/file2.stylus'});
 
-    expect(mockPreprocessorWithDeps).toHaveBeenCalled();
+    expect(p.markChanged).toHaveBeenCalledTimes(2);
+    expect(p.markChanged.mock.calls[0][0]).toBe(mockComponent);
+    expect(p.markChanged.mock.calls[1][0]).toBe(mockComponent);
   });
 });

--- a/plugins/plugin-svelte/test/plugin.test.js
+++ b/plugins/plugin-svelte/test/plugin.test.js
@@ -20,6 +20,12 @@ beforeEach(() => {
   };
 });
 
+afterEach(() => {
+  mockCompiler.mockClear();
+  mockPreprocessor.mockClear();
+  mockPreprocessorWithDeps.mockClear();
+});
+
 describe('@snowpack/plugin-svelte (mocked)', () => {
   jest.mock('svelte/compiler', () => ({compile: mockCompiler, preprocess: mockPreprocessor})); // important: mock before import
   const plugin = require('../plugin');


### PR DESCRIPTION
## Changes

Closes #2103.

When a preprocessed file imports other files, we need to let snowpack know about them and mark the importing file as changed when those dependencies change. 

Svelte preprocessors can already return an array of dependencies, we can use this to map importers to importees and mark the necessary files as changed.

I've tried to match the `plugin-sass` implementation as much as possible to keep plugins consistent. 

https://user-images.githubusercontent.com/12937446/103038119-8298d680-4565-11eb-968e-7120e23ab3bd.mov

## Testing

I had to refactor the tests slightly in order to provide a different set of mocks from those used for the other tests, mainly just mocking via hooks scoped to a specific `describe` block.

This functionality is tested in a similar way to the `plugin-sass` implementation. I have not added a non-dev mode tests, I can add that if you feel it is necessary.

I have also tested this locally (via linking) to ensure that it covers @jameswoodley's case, I used the described repro for local testing. The attached video is that local manual test.

## Docs

I think the previous behaviour _could_ be considered a bug. This is mostly behind the scenes magic that makes things 'just work' , however, there is no guarantee that a given preprocessor actually honours the contract (it might not return a dependency array). Additionally, this PR assumes the paths have already been resolved by the preprocessor (I'm assuming the 
 `onChange` filePaths are fully resolved paths too), if they haven't been there could be discrepancies that cause the paths not to match. I think these assumptions/ requirements are reasonable, but let me know if we need to do some additional path resolution here.

So to address the documentation issue, it may be valuable to have a note detailing why this _might not_ work but no documentation is required to enable it. `svelte-preprocess` resolves paths fully before returning the `dependencies` array and this will be by far the most common use-case.
