### PR TITLE
Add `snowpack-react-typescript-tailwind` to CSA community templates

### DIFF
--- a/create-snowpack-app/cli/README.md
+++ b/create-snowpack-app/cli/README.md
@@ -28,6 +28,7 @@ npx create-snowpack-app new-dir --template @snowpack/app-template-NAME [--use-ya
 - [app-template-reason-react](https://github.com/jihchi/app-template-reason-react) (ReasonML (BuckleScript) & reason-react on top of [@snowpack/app-template-react](/templates/app-template-react))
 - [svelte-tailwind](https://github.com/agneym/svelte-tailwind-snowpack) (Adds PostCSS and TailwindCSS using [svelte-preprocess](https://github.com/sveltejs/svelte-preprocess))
 - [snowpack-react-tailwind](https://github.com/mrkldshv/snowpack-react-tailwind) (React + Snowpack + Tailwindcss)
+- [snowpack-react-typescript-tailwind](https://github.com/hgballesteros/snowpack-react-typescript-tailwind)
 - [hyperapp-snowpack](https://github.com/bmartel/hyperapp-snowpack) (Hyperapp + Snowpack + TailwindCSS)
 - [snowpack-vue-capacitor-2-demo](https://github.com/brodybits/snowpack-vue-capacitor-2-demo) Demo of Snowpack with Vue and [Capacitor mobile app framework](https://capacitorjs.com/) version 2, originally generated from `@snowpack/vue-template` template, see [discussion #905](https://github.com/snowpackjs/snowpack/discussions/905)
 - [snowpack-react-ssr](https://github.com/matthoffner/snowpack-react-ssr) (React + Server Side Rendering)

--- a/create-snowpack-app/cli/README.md
+++ b/create-snowpack-app/cli/README.md
@@ -22,19 +22,22 @@ npx create-snowpack-app new-dir --template @snowpack/app-template-NAME [--use-ya
 
 ### Featured Community Templates
 
-- [snowpack-template-preset-env](https://github.com/argyleink/snowpack-template-preset-env) (PostCSS + Babel)
-- [11st-Starter-Kit](https://github.com/stefanfrede/11st-starter-kit) (11ty +
-  Snowpack + tailwindcss)
-- [app-template-reason-react](https://github.com/jihchi/app-template-reason-react) (ReasonML (BuckleScript) & reason-react on top of [@snowpack/app-template-react](/templates/app-template-react))
-- [svelte-tailwind](https://github.com/agneym/svelte-tailwind-snowpack) (Adds PostCSS and TailwindCSS using [svelte-preprocess](https://github.com/sveltejs/svelte-preprocess))
-- [snowpack-react-tailwind](https://github.com/mrkldshv/snowpack-react-tailwind) (React + Snowpack + Tailwindcss)
-- [snowpack-react-typescript-tailwind](https://github.com/hgballesteros/snowpack-react-typescript-tailwind)
-- [hyperapp-snowpack](https://github.com/bmartel/hyperapp-snowpack) (Hyperapp + Snowpack + TailwindCSS)
-- [snowpack-vue-capacitor-2-demo](https://github.com/brodybits/snowpack-vue-capacitor-2-demo) Demo of Snowpack with Vue and [Capacitor mobile app framework](https://capacitorjs.com/) version 2, originally generated from `@snowpack/vue-template` template, see [discussion #905](https://github.com/snowpackjs/snowpack/discussions/905)
-- [snowpack-react-ssr](https://github.com/matthoffner/snowpack-react-ssr) (React + Server Side Rendering)
-- [snowpack-app-template-preact-hmr-tailwind](https://github.com/Mozart409/snowpack-app-template-preact-hmr-tailwind) (Snowpack + Preact + HMR + Tailwindcss)
-- [snowpack-mdx-chakra](https://github.com/molebox/snowpack-mdx)(An opinionated template setup with MDX, Chakra-ui for styling, theme and components, and React Router v6 for routing.)
-- [snowpack-svelte-ts-tw](https://github.com/GarrettCannon/snowpack-svelte-ts-tw) (Snowpack + Svelte + Typescript + TailwindCSS)
-- [snowpack-template-tailwind](https://github.com/jonalvarezz/snowpack-template-tailwind) (Snowpack + TailwindCSS + Autopublish to GitHub Pages)
-- [snowpack-app-template-glimmer](https://github.com/rajasegar/snowpack-app-template-glimmer) (Snowpack + [Glimmer.js](https://glimmerjs.com))
-- PRs that add a link to this list are welcome!
+| Template | Description |
+| -------- | ---------- |
+| [snowpack-template-preset-env](https://github.com/argyleink/snowpack-template-preset-env)                           | PostCSS + Babel|
+| [11st-Starter-Kit](https://github.com/stefanfrede/11st-starter-kit)                                                 | 11ty + Snowpack + tailwindcss|
+| [app-template-reason-react](https://github.com/jihchi/app-template-reason-react)                                    | ReasonML (BuckleScript) & reason-react on top of [@snowpack/app-template-react](/templates/app-template-react)
+| [svelte-tailwind](https://github.com/agneym/svelte-tailwind-snowpack)                                               | PostCSS and TailwindCSS using [svelte-preprocess](https://github.com/sveltejs/svelte-preprocess) |
+| [snowpack-react-tailwind](https://github.com/mrkldshv/snowpack-react-tailwind)                                      | React + Snowpack + Tailwindcss |
+| [snowpack-react-typescript-tailwind](https://github.com/hgballesteros/snowpack-react-typescript-tailwind)           |  |
+| [hyperapp-snowpack](https://github.com/bmartel/hyperapp-snowpack)                                                   | Hyperapp + Snowpack + TailwindCSS |
+| [snowpack-vue-capacitor-2-demo](https://github.com/brodybits/snowpack-vue-capacitor-2-demo)                         | Demo of Snowpack with Vue and [Capacitor mobile app framework](https://capacitorjs.com/) version 2, originally generated from `@snowpack/vue-template` template, see [discussion #905](https://github.com/snowpackjs/snowpack/discussions/905) |
+| [snowpack-react-ssr](https://github.com/matthoffner/snowpack-react-ssr)                                             | React + Server Side Rendering|
+| [snowpack-app-template-preact-hmr-tailwind](https://github.com/Mozart409/snowpack-app-template-preact-hmr-tailwind) | Snowpack + Preact + HMR + Tailwindcss |
+| [snowpack-mdx-chakra](https://github.com/molebox/snowpack-mdx)                                                      | An opinionated template setup with MDX, Chakra-ui for styling, theme and components, and React Router v6 for routing. |
+| [snowpack-svelte-ts-tw](https://github.com/GarrettCannon/snowpack-svelte-ts-tw)                                     | Snowpack + Svelte + Typescript + TailwindCSS |
+| [snowpack-template-tailwind](https://github.com/jonalvarezz/snowpack-template-tailwind)                             | Snowpack + TailwindCSS + Autopublish to GitHub Pages |
+| [snowpack-app-template-glimmer](https://github.com/rajasegar/snowpack-app-template-glimmer)                         | Snowpack + [Glimmer.js](https://glimmerjs.com) |
+
+PRs that add a link to this list are welcome!
+


### PR DESCRIPTION
## Changes

1. Add `snowpack-react-typescript-tailwind` template to CSA community templates
2. Change template formatting from list to table to reduce visual clutter

## Testing

No tests added/modified b/c no source code was changed.

## Docs

Only updates are to the markdown document containing community templates for the `create-snowpack-app` cli.
