### PR TITLE
Replace the wrong link to types

### DIFF
--- a/www/_template/reference/javascript-interface.md
+++ b/www/_template/reference/javascript-interface.md
@@ -20,4 +20,4 @@ For example, [SvelteKit](https://svelte.dev/blog/whats-the-deal-with-sveltekit) 
 
 ### API Reference
 
-This documentation is still in progress as we prepare for Snowpack v3.0. For now, visit the TypeScript type declarations to see a full summary of the current JS API: https://github.com/snowpackjs/snowpack/blob/main/snowpack/src/types/snowpack.ts#L22-L65
+This documentation is still in progress as we prepare for Snowpack v3.0. For now, visit the TypeScript type declarations to see a full summary of the current JS API: https://github.com/snowpackjs/snowpack/blob/main/snowpack/src/types.ts#L21-L63

--- a/www/_template/reference/javascript-interface.md
+++ b/www/_template/reference/javascript-interface.md
@@ -20,4 +20,4 @@ For example, [SvelteKit](https://svelte.dev/blog/whats-the-deal-with-sveltekit) 
 
 ### API Reference
 
-This documentation is still in progress as we prepare for Snowpack v3.0. For now, visit the TypeScript type declarations to see a full summary of the current JS API: https://github.com/snowpackjs/snowpack/blob/main/snowpack/src/types.ts#L21-L63
+This documentation is still in progress as we prepare for Snowpack v3.0. For now, visit the TypeScript type declarations to see a full summary of the current JS API: https://github.com/snowpackjs/snowpack/blob/main/snowpack/src/types.ts#L197-L245


### PR DESCRIPTION
## Changes

## Testing


## Docs

The temporary link to JavaScript API types is wrong.
