### PR TITLE
plugin-typescript: Support custom tsc command (e.g. TTypeScript)

### DIFF
--- a/plugins/plugin-typescript/README.md
+++ b/plugins/plugin-typescript/README.md
@@ -24,4 +24,5 @@ module.exports = {
 
 | Name   |   Type   | Description                                                                                                                                                                               |
 | :----- | :------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tsc`  | `string` | Optional custom tsc command. For example, you can use TTypeScript compiler by specifying: `tsc: "ttsc"`. |
 | `args` | `string` | Optional arguments to pass to the `tsc` CLI. For example, you can configure a custom project directory (with a custom `tsconfig.json` file) using `args: "--project ./your/custom/path"`. |

--- a/plugins/plugin-typescript/plugin.js
+++ b/plugins/plugin-typescript/plugin.js
@@ -1,12 +1,12 @@
 const execa = require('execa');
 const npmRunPath = require('npm-run-path');
 
-function typescriptPlugin(snowpackConfig, {args} = {}) {
+function typescriptPlugin(snowpackConfig, {tsc, args} = {}) {
   return {
     name: '@snowpack/plugin-typescript',
     async run({isDev, log}) {
       const workerPromise = execa.command(
-        `tsc --noEmit ${isDev ? '--watch' : ''} ${args ? args : ''}`,
+        `${tsc ? tsc : "tsc"} --noEmit ${isDev ? '--watch' : ''} ${args ? args : ''}`,
         {
           env: npmRunPath.env(),
           extendEnv: true,

--- a/plugins/plugin-typescript/test/plugin.test.js
+++ b/plugins/plugin-typescript/test/plugin.test.js
@@ -36,6 +36,11 @@ describe('plugin-typescript', () => {
     await p.run({isDev: false, log: jest.fn});
     expect(execaFn.mock.calls[0][0]).toContain('--foo bar');
   });
+  test('calls custom tsc command correctly with args', async () => {
+    const p = plugin({}, {tsc: 'echo', args: 'Echo message'});
+    await p.run({isDev: false, log: jest.fn});
+    expect(execaFn.mock.calls[0][0]).toContain('Echo message');
+  });
   test('handles tsc output', async () => {
     const logFn = jest.fn();
     const p = plugin({});


### PR DESCRIPTION
## Changes

Adds support for specifying a custom TypeScript compiler command. This is useful, for example, to use "ttsc" instead of "tsc".

See also, discussion https://github.com/snowpackjs/snowpack/discussions/1601

## Testing

* I made sure that existing tests pass without modification i.e. the default command is `tsc`
* I added a test that verifies the custom command is used instead of the default `tsc` command

## Docs

I have added the `tsc` option to the README.