### PR TITLE
fix babel plugin link

### DIFF
--- a/www/_template/guides/babel.md
+++ b/www/_template/guides/babel.md
@@ -12,7 +12,7 @@ description: How to use Babel in your Snowpack project.
 
 **You probably don't need Babel!** Snowpack has built-in support for JSX and TypeScript transpilation. Only use Babel if you need to customize how your JavaScript/TypeScript files are built using custom Babel plugins/presets.
 
-**To use Babel with Snowpack:** add the [@snowpack/plugin-babel](https://www.npmjs.com/package/@snowpack/plugin-babl) plugin to your project.
+**To use Babel with Snowpack:** add the [@snowpack/plugin-babel](https://www.npmjs.com/package/@snowpack/plugin-babel) plugin to your project.
 
 ```diff
 // snowpack.config.js


### PR DESCRIPTION
## Changes
Fix link URL in docs
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing
N/A
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs
Yes, it's a documentation typo
<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
