### PR TITLE
docs: add HMR state directive to Svelte example

### DIFF
--- a/www/_template/tutorials/svelte.md
+++ b/www/_template/tutorials/svelte.md
@@ -262,7 +262,7 @@ Svelte components include component specific scripts in a `<script>` tag. Add th
 
 <script>
   import { onMount } from 'svelte';
-  let count = 0;
+  let count = 0; // @hmr:keep
   onMount(() => {
     const interval = setInterval(() => count++, 1000);
     return () => {


### PR DESCRIPTION
HMR no longer automatically preserves state as described by the current documentation, but [this behavior can be opted into with a `// @hmr:keep` comment](https://github.com/snowpackjs/snowpack/discussions/1567#discussioncomment-130116). I’ve updated the example code to bring its behavior more into line with the surrounding documentation and avoid confusion for people following along with the tutorial by copy-pasting (as I was).

## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Minor edit to the “Getting Started with Svelte” tutorial.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

Docs change only.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

[/tutorials/svelte#adding-a-counter-to-your-svelte-component](https://snowpack-git-fork-davidjones418-patch-1.pikapkg.vercel.app/tutorials/svelte#adding-a-counter-to-your-svelte-component) (first code example)