### PR TITLE
Add entry point APIs

### DIFF
--- a/esinstall/package.json
+++ b/esinstall/package.json
@@ -51,6 +51,7 @@
     "is-valid-identifier": "^2.0.2",
     "kleur": "^4.1.1",
     "mkdirp": "^1.0.3",
+    "picomatch": "^2.2.2",
     "rimraf": "^3.0.0",
     "rollup": "^2.34.0",
     "rollup-plugin-polyfill-node": "^0.4.1",

--- a/esinstall/src/entrypoints.ts
+++ b/esinstall/src/entrypoints.ts
@@ -204,7 +204,6 @@ export function resolveEntrypoint(
       `React workaround packages no longer needed! Revert back to the official React & React-DOM packages.`,
     );
   }
-  let plf = packageLookupFields;
   let foundEntrypoint = resolveManifestEntry(depManifest, dep, {
     packageName,
     packageLookupFields,

--- a/esinstall/src/entrypoints.ts
+++ b/esinstall/src/entrypoints.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import validatePackageName from 'validate-npm-package-name';
-import {ExportMap, ExportMapEntry, PackageManifestWithExports, PackageManifest} from './types';
+import {ExportField, ExportMapEntry, PackageManifestWithExports, PackageManifest} from './types';
 import {parsePackageImportSpecifier, resolveDependencyManifest} from './util';
 
 // Rarely, a package will ship a broken "browser" package.json entrypoint.
@@ -230,18 +230,18 @@ export function resolveEntrypoint(
 /**
  * Given an export map and all of the crazy variations, condense down to a key/value map of string keys to string values.
  */
-export function normalizeExportMap(exportMap?: ExportMap): Record<string, string> | undefined {
-  if (!exportMap) {
+export function normalizeExportMap(exportField?: ExportField): Record<string, string> | undefined {
+  if (!exportField) {
     return;
   }
   const cleanExportMap: Record<string, string> = {};
 
-  const simpleExportMap = resolveExportMapEntry(exportMap); // handle case where export map is a string, or if there‘s only one file in the entire export map
+  const simpleExportMap = resolveExportMapEntry(exportField); // handle case where export map is a string, or if there‘s only one file in the entire export map
   if (simpleExportMap) {
     return {'.': simpleExportMap} as Record<string, string>;
   }
 
-  for (const [key, val] of Object.entries(exportMap)) {
+  for (const [key, val] of Object.entries(exportField)) {
     // skip invalid entries
     if (!key.startsWith('.')) {
       continue;

--- a/esinstall/src/entrypoints.ts
+++ b/esinstall/src/entrypoints.ts
@@ -1,0 +1,254 @@
+import fs from 'fs';
+import path from 'path';
+import validatePackageName from 'validate-npm-package-name';
+import {
+  ExportMap,
+  ExportMapEntry,
+  PackageManifestWithExports,
+  PackageManifest,
+} from './types';
+import {
+  parsePackageImportSpecifier,
+  resolveDependencyManifest
+} from './util';
+
+// Rarely, a package will ship a broken "browser" package.json entrypoint.
+// Ignore the "browser" entrypoint in those packages.
+const BROKEN_BROWSER_ENTRYPOINT = ['@sheerun/mutationobserver-shim'];
+
+function hasBrokenBrowserEntrypoint(packageName?) {
+  return !!(packageName && BROKEN_BROWSER_ENTRYPOINT.includes(packageName));
+}
+
+function manifestHasTypes(manifest: PackageManifest): boolean {
+  return !!(manifest.types || manifest.typings);
+}
+
+type ResolveManifestEntryOptions = {
+  packageLookupFields?: string[];
+  packageName?: string;
+}
+
+function resolveManifestEntry(manifest: PackageManifest, entry?: string, {
+  packageLookupFields = [],
+  packageName
+}: ResolveManifestEntryOptions = {}): string | undefined {
+  let foundEntrypoint: string | undefined;
+
+  if(manifest.exports) {
+    foundEntrypoint = typeof manifest.exports === 'string' ?
+      manifest.exports :
+      resolveExportMapEntry(manifest.exports['.']);
+
+    if(typeof foundEntrypoint === 'string') {
+      return foundEntrypoint;
+    }
+  }
+
+  foundEntrypoint = [
+    ...packageLookupFields,
+    'browser:module',
+    'module',
+    'main:esnext',
+    'jsnext:main',
+  ]
+    .map((e) => manifest[e])
+    .find(Boolean);
+
+  if (!foundEntrypoint && !hasBrokenBrowserEntrypoint(packageName)) {
+    // Some packages define "browser" as an object. We'll do our best to find the
+    // right entrypoint in an entrypoint object, or fail otherwise.
+    // See: https://github.com/defunctzombie/package-browser-field-spec
+    let browserField = manifest.browser;
+
+    if(typeof browserField === 'string') {
+      foundEntrypoint = browserField;
+    } else if (typeof browserField === 'object') {
+      let browserEntrypoint =
+        (entry && browserField[entry]) ||
+        browserField['./index.js'] ||
+        browserField['./index'] ||
+        browserField['index.js'] ||
+        browserField['index'] ||
+        browserField['./'] ||
+        browserField['.'];
+
+      if(typeof browserEntrypoint === 'string') {
+        foundEntrypoint = browserEntrypoint;
+      }
+    }
+  }
+
+  // If browser object is set but no relevant entrypoint is found, fall back to "main".
+  if (!foundEntrypoint) {
+    foundEntrypoint = manifest.main;
+  }
+
+  return foundEntrypoint;
+}
+
+export function resolveMainEntrypoint(manifest: PackageManifest) {
+  return resolveManifestEntry(manifest);
+}
+
+/**
+ * Given an ExportMapEntry find the entry point, resolving recursively.
+ */
+export function resolveExportMapEntry(exportMapEntry?: ExportMapEntry): string | undefined {
+  // If this is a string or undefined we can skip checking for conditions
+  switch (typeof exportMapEntry) {
+    case 'string':
+      return exportMapEntry;
+    case 'undefined':
+      return exportMapEntry;
+  }
+
+  return (
+    resolveExportMapEntry(exportMapEntry?.browser) ||
+    resolveExportMapEntry(exportMapEntry?.import) ||
+    resolveExportMapEntry(exportMapEntry?.default) ||
+    resolveExportMapEntry(exportMapEntry?.require) ||
+    undefined
+  );
+}
+
+function resolveExportsMap(
+  packageManifest: PackageManifestWithExports,
+  exportsProp: string,
+): string | undefined {
+  const exportMapEntry = packageManifest.exports[exportsProp];
+  return resolveExportMapEntry(exportMapEntry);
+}
+
+type ResolveManifestFn = (dep: string, cwd: string) => [string | null, any];
+
+type ResolveEntrypointOptions = {
+  cwd: string;
+  packageLookupFields: string[];
+  resolveManifest?: ResolveManifestFn | undefined
+};
+
+/**
+ * Resolve a "webDependencies" input value to the correct absolute file location.
+ * Supports both npm package names, and file paths relative to the node_modules directory.
+ * Follows logic similar to Node's resolution logic, but using a package.json's ESM "module"
+ * field instead of the CJS "main" field.
+ */
+export function resolveEntrypoint(
+  dep: string,
+  {
+    cwd,
+    packageLookupFields,
+  }: ResolveEntrypointOptions,
+): string {
+  // We first need to check for an export map in the package.json. If one exists, resolve to it.
+  const [packageName, packageEntrypoint] = parsePackageImportSpecifier(dep);
+  const [packageManifestLoc, packageManifest] = resolveDependencyManifest(packageName, cwd);
+
+  if (packageManifestLoc && packageManifest && typeof packageManifest.exports !== 'undefined') {
+    // If this is a non-main entry point
+    if (packageEntrypoint) {
+      const exportMapValue = resolveExportsMap(packageManifest as PackageManifestWithExports, './' + packageEntrypoint);
+
+      if (typeof exportMapValue !== 'string') {
+        throw new Error(
+          `Package "${packageName}" exists but package.json "exports" does not include entry for "./${packageEntrypoint}".`,
+        );
+      }
+      return path.join(packageManifestLoc, '..', exportMapValue);
+    } else {
+      const exportMapValue = resolveExportsMap(packageManifest as PackageManifestWithExports, '.');
+
+      if (exportMapValue) {
+        return path.join(packageManifestLoc, '..', exportMapValue);
+      }
+    }
+  }
+
+  // if, no export map and dep points directly to a file within a package, return that reference.
+  if (path.extname(dep) && !validatePackageName(dep).validForNewPackages) {
+    return fs.realpathSync.native(require.resolve(dep, {paths: [cwd]}));
+  }
+
+  // Otherwise, resolve directly to the dep specifier. Note that this supports both
+  // "package-name" & "package-name/some/path" where "package-name/some/path/package.json"
+  // exists at that lower path, that must be used to resolve. In that case, export
+  // maps should not be supported.
+  const [depManifestLoc, depManifest] = resolveDependencyManifest(dep, cwd);
+
+  if (!depManifestLoc || !depManifest) {
+    throw new Error(
+      `Package "${dep}" not found. Have you installed it? ${depManifestLoc ? depManifestLoc : ''}`,
+    );
+  }
+  if (
+    depManifest.name &&
+    (depManifest.name.startsWith('@reactesm') || depManifest.name.startsWith('@pika/react'))
+  ) {
+    throw new Error(
+      `React workaround packages no longer needed! Revert back to the official React & React-DOM packages.`,
+    );
+  }
+  let plf = packageLookupFields;
+  let foundEntrypoint = resolveManifestEntry(depManifest, dep, {
+    packageName,
+    packageLookupFields
+  })
+
+  // Some packages are types-only. If this is one of those packages, resolve with that.
+  if (!foundEntrypoint && manifestHasTypes(depManifest)) {
+    const typesLoc = (depManifest.types || depManifest.typings) as string;
+    return path.join(depManifestLoc, '..', typesLoc)
+  }
+  // Sometimes packages don't give an entrypoint, assuming you'll fall back to "index.js".
+  if (!foundEntrypoint) {
+    foundEntrypoint = 'index.js';
+  }
+  if (typeof foundEntrypoint !== 'string') {
+    throw new Error(`"${dep}" has unexpected entrypoint: ${JSON.stringify(foundEntrypoint)}.`);
+  }
+
+  return fs.realpathSync.native(
+    require.resolve(path.join(depManifestLoc || '', '..', foundEntrypoint)),
+  );
+}
+
+/**
+ * Given an export map and all of the crazy variations, condense down to a key/value map of string keys to string values.
+ */
+export function normalizeExportMap(exportMap?: ExportMap): Record<string, string> | undefined {
+  if (!exportMap) {
+    return;
+  }
+  const cleanExportMap: Record<string, string> = {};
+
+  const simpleExportMap = resolveExportMapEntry(exportMap); // handle case where export map is a string, or if there‘s only one file in the entire export map
+  if (simpleExportMap) {
+    return {'.': simpleExportMap} as Record<string, string>;
+  }
+
+  for (const [key, val] of Object.entries(exportMap)) {
+    // skip invalid entries
+    if (!key.startsWith('.')) {
+      continue;
+    }
+    // skip wildcards for now (https://nodejs.org/api/packages.html#packages_subpath_folder_mappings)
+    if (key.endsWith('/') || key.includes('*')) {
+      continue;
+    }
+
+    // If entry is an array, assume that we can always support the first value
+    const firstVal = Array.isArray(val) ? val[0] : val;
+    // Support these entries, in this order.
+    const cleanValue = resolveExportMapEntry(firstVal);
+    if (typeof cleanValue !== 'string') {
+      continue;
+    }
+    cleanExportMap[key] = cleanValue;
+  }
+
+  if (Object.keys(cleanExportMap).length === 0) {
+    return;
+  }
+  return cleanExportMap;
+}

--- a/esinstall/src/entrypoints.ts
+++ b/esinstall/src/entrypoints.ts
@@ -32,7 +32,7 @@ export function findManifestEntry(
     foundEntrypoint =
       typeof manifest.exports === 'string'
         ? manifest.exports
-        : findExportMapEntry(manifest.exports['.']);
+        : findExportMapEntry(manifest.exports['.'] || manifest.exports);
 
     if (typeof foundEntrypoint === 'string') {
       return foundEntrypoint;
@@ -147,7 +147,7 @@ export function resolveEntrypoint(
       }
       return path.join(packageManifestLoc, '..', mapValue);
     } else {
-      const exportMapEntry = exportField['.'];
+      const exportMapEntry = exportField['.'] || exportField;
       const mapValue = findExportMapEntry(exportMapEntry);
 
       if (mapValue) {

--- a/esinstall/src/entrypoints.ts
+++ b/esinstall/src/entrypoints.ts
@@ -94,7 +94,7 @@ export function resolveMainEntrypoint(manifest: PackageManifest) {
 /**
  * Given an ExportMapEntry find the entry point, resolving recursively.
  */
-export function resolveExportMapEntry(exportMapEntry?: ExportMapEntry): string | undefined {
+export function resolveExportMapEntry(exportMapEntry?: ExportMapEntry, conditions?: string[]): string | undefined {
   // If this is a string or undefined we can skip checking for conditions
   switch (typeof exportMapEntry) {
     case 'string':
@@ -103,11 +103,20 @@ export function resolveExportMapEntry(exportMapEntry?: ExportMapEntry): string |
       return exportMapEntry;
   }
 
+  let entry = exportMapEntry;
+  for(let i = 0, len = conditions?.length || 0; i < len; i++) {
+    let condition = conditions![i];
+
+    if(entry[condition]) {
+      entry = entry[condition];
+    }
+  }
+
   return (
-    resolveExportMapEntry(exportMapEntry?.browser) ||
-    resolveExportMapEntry(exportMapEntry?.import) ||
-    resolveExportMapEntry(exportMapEntry?.default) ||
-    resolveExportMapEntry(exportMapEntry?.require) ||
+    resolveExportMapEntry(entry?.browser) ||
+    resolveExportMapEntry(entry?.import) ||
+    resolveExportMapEntry(entry?.default) ||
+    resolveExportMapEntry(entry?.require) ||
     undefined
   );
 }

--- a/esinstall/src/entrypoints.ts
+++ b/esinstall/src/entrypoints.ts
@@ -3,28 +3,28 @@ import path from 'path';
 import validatePackageName from 'validate-npm-package-name';
 import {ExportField, ExportMapEntry, PackageManifestWithExports, PackageManifest} from './types';
 import {parsePackageImportSpecifier, resolveDependencyManifest} from './util';
+import pm from 'picomatch';
 
 // Rarely, a package will ship a broken "browser" package.json entrypoint.
 // Ignore the "browser" entrypoint in those packages.
 const BROKEN_BROWSER_ENTRYPOINT = ['@sheerun/mutationobserver-shim'];
 
-function hasBrokenBrowserEntrypoint(packageName?) {
-  return !!(packageName && BROKEN_BROWSER_ENTRYPOINT.includes(packageName));
-}
-
-function manifestHasTypes(manifest: PackageManifest): boolean {
+function hasTypes(manifest: PackageManifest): boolean {
   return !!(manifest.types || manifest.typings);
 }
 
-type ResolveManifestEntryOptions = {
+type FindManifestEntryOptions = {
   packageLookupFields?: string[];
   packageName?: string;
 };
 
-function resolveManifestEntry(
+/**
+ *
+ */
+export function findManifestEntry(
   manifest: PackageManifest,
   entry?: string,
-  {packageLookupFields = [], packageName}: ResolveManifestEntryOptions = {},
+  {packageLookupFields = [], packageName}: FindManifestEntryOptions = {},
 ): string | undefined {
   let foundEntrypoint: string | undefined;
 
@@ -32,7 +32,7 @@ function resolveManifestEntry(
     foundEntrypoint =
       typeof manifest.exports === 'string'
         ? manifest.exports
-        : resolveExportMapEntry(manifest.exports['.']);
+        : findExportMapEntry(manifest.exports['.']);
 
     if (typeof foundEntrypoint === 'string') {
       return foundEntrypoint;
@@ -49,14 +49,18 @@ function resolveManifestEntry(
     .map((e) => manifest[e])
     .find(Boolean);
 
-  if (!foundEntrypoint && !hasBrokenBrowserEntrypoint(packageName)) {
+  if (foundEntrypoint) {
+    return foundEntrypoint;
+  }
+
+  if (!(packageName && BROKEN_BROWSER_ENTRYPOINT.includes(packageName))) {
     // Some packages define "browser" as an object. We'll do our best to find the
     // right entrypoint in an entrypoint object, or fail otherwise.
     // See: https://github.com/defunctzombie/package-browser-field-spec
     let browserField = manifest.browser;
 
     if (typeof browserField === 'string') {
-      foundEntrypoint = browserField;
+      return browserField;
     } else if (typeof browserField === 'object') {
       let browserEntrypoint =
         (entry && browserField[entry]) ||
@@ -68,70 +72,48 @@ function resolveManifestEntry(
         browserField['.'];
 
       if (typeof browserEntrypoint === 'string') {
-        foundEntrypoint = browserEntrypoint;
+        return browserEntrypoint;
       }
     }
   }
 
   // If browser object is set but no relevant entrypoint is found, fall back to "main".
-  if (!foundEntrypoint) {
-    foundEntrypoint = manifest.main;
-  }
-
-  return foundEntrypoint;
-}
-
-export function resolveMainEntrypoint(manifest: PackageManifest) {
-  return resolveManifestEntry(manifest);
+  return manifest.main;
 }
 
 /**
  * Given an ExportMapEntry find the entry point, resolving recursively.
  */
-export function resolveExportMapEntry(
+export function findExportMapEntry(
   exportMapEntry?: ExportMapEntry,
   conditions?: string[],
 ): string | undefined {
   // If this is a string or undefined we can skip checking for conditions
-  switch (typeof exportMapEntry) {
-    case 'string':
-      return exportMapEntry;
-    case 'undefined':
-      return exportMapEntry;
+  if (typeof exportMapEntry === 'string' || typeof exportMapEntry === 'undefined') {
+    return exportMapEntry;
   }
 
   let entry = exportMapEntry;
-  for (let i = 0, len = conditions?.length || 0; i < len; i++) {
-    let condition = conditions![i];
-
-    if (entry[condition]) {
-      entry = entry[condition];
+  if (conditions) {
+    for (let condition of conditions) {
+      if (entry[condition]) {
+        entry = entry[condition];
+      }
     }
   }
 
   return (
-    resolveExportMapEntry(entry?.browser) ||
-    resolveExportMapEntry(entry?.import) ||
-    resolveExportMapEntry(entry?.default) ||
-    resolveExportMapEntry(entry?.require) ||
+    findExportMapEntry(entry?.browser) ||
+    findExportMapEntry(entry?.import) ||
+    findExportMapEntry(entry?.default) ||
+    findExportMapEntry(entry?.require) ||
     undefined
   );
 }
 
-function resolveExportsMap(
-  packageManifest: PackageManifestWithExports,
-  exportsProp: string,
-): string | undefined {
-  const exportMapEntry = packageManifest.exports[exportsProp];
-  return resolveExportMapEntry(exportMapEntry);
-}
-
-type ResolveManifestFn = (dep: string, cwd: string) => [string | null, any];
-
 type ResolveEntrypointOptions = {
   cwd: string;
   packageLookupFields: string[];
-  resolveManifest?: ResolveManifestFn | undefined;
 };
 
 /**
@@ -149,24 +131,27 @@ export function resolveEntrypoint(
   const [packageManifestLoc, packageManifest] = resolveDependencyManifest(packageName, cwd);
 
   if (packageManifestLoc && packageManifest && typeof packageManifest.exports !== 'undefined') {
+    const exportField = (packageManifest as PackageManifestWithExports).exports;
+
     // If this is a non-main entry point
     if (packageEntrypoint) {
-      const exportMapValue = resolveExportsMap(
-        packageManifest as PackageManifestWithExports,
-        './' + packageEntrypoint,
-      );
+      const normalizedMap = explodeExportMap(exportField, {
+        cwd: path.dirname(packageManifestLoc),
+      });
+      const mapValue = normalizedMap && Reflect.get(normalizedMap, './' + packageEntrypoint);
 
-      if (typeof exportMapValue !== 'string') {
+      if (typeof mapValue !== 'string') {
         throw new Error(
           `Package "${packageName}" exists but package.json "exports" does not include entry for "./${packageEntrypoint}".`,
         );
       }
-      return path.join(packageManifestLoc, '..', exportMapValue);
+      return path.join(packageManifestLoc, '..', mapValue);
     } else {
-      const exportMapValue = resolveExportsMap(packageManifest as PackageManifestWithExports, '.');
+      const exportMapEntry = exportField['.'];
+      const mapValue = findExportMapEntry(exportMapEntry);
 
-      if (exportMapValue) {
-        return path.join(packageManifestLoc, '..', exportMapValue);
+      if (mapValue) {
+        return path.join(packageManifestLoc, '..', mapValue);
       }
     }
   }
@@ -186,7 +171,7 @@ export function resolveEntrypoint(
     try {
       const maybeLoc = fs.realpathSync.native(require.resolve(dep, {paths: [cwd]}));
       return maybeLoc;
-    } catch (err) {
+    } catch {
       // Oh well, was worth a try
     }
   }
@@ -196,21 +181,14 @@ export function resolveEntrypoint(
       `Package "${dep}" not found. Have you installed it? ${depManifestLoc ? depManifestLoc : ''}`,
     );
   }
-  if (
-    depManifest.name &&
-    (depManifest.name.startsWith('@reactesm') || depManifest.name.startsWith('@pika/react'))
-  ) {
-    throw new Error(
-      `React workaround packages no longer needed! Revert back to the official React & React-DOM packages.`,
-    );
-  }
-  let foundEntrypoint = resolveManifestEntry(depManifest, dep, {
+
+  let foundEntrypoint = findManifestEntry(depManifest, dep, {
     packageName,
     packageLookupFields,
   });
 
   // Some packages are types-only. If this is one of those packages, resolve with that.
-  if (!foundEntrypoint && manifestHasTypes(depManifest)) {
+  if (!foundEntrypoint && hasTypes(depManifest)) {
     const typesLoc = (depManifest.types || depManifest.typings) as string;
     return path.join(depManifestLoc, '..', typesLoc);
   }
@@ -227,18 +205,21 @@ export function resolveEntrypoint(
   );
 }
 
-/**
- * Given an export map and all of the crazy variations, condense down to a key/value map of string keys to string values.
- */
-export function normalizeExportMap(exportField?: ExportField): Record<string, string> | undefined {
-  if (!exportField) {
-    return;
-  }
-  const cleanExportMap: Record<string, string> = {};
+const picoMatchGlobalOptions = Object.freeze({
+  capture: true,
+  noglobstar: true,
+});
 
-  const simpleExportMap = resolveExportMapEntry(exportField); // handle case where export map is a string, or if there‘s only one file in the entire export map
+function* forEachExportEntry(
+  exportField: ExportField,
+): Generator<[string, unknown], any, undefined> {
+  const simpleExportMap = findExportMapEntry(exportField);
+
+  // Handle case where export map is a string, or if there‘s only one file in the entire export map
   if (simpleExportMap) {
-    return {'.': simpleExportMap} as Record<string, string>;
+    yield ['.', simpleExportMap];
+
+    return;
   }
 
   for (const [key, val] of Object.entries(exportField)) {
@@ -246,15 +227,90 @@ export function normalizeExportMap(exportField?: ExportField): Record<string, st
     if (!key.startsWith('.')) {
       continue;
     }
-    // skip wildcards for now (https://nodejs.org/api/packages.html#packages_subpath_folder_mappings)
-    if (key.endsWith('/') || key.includes('*')) {
+
+    yield [key, val];
+  }
+}
+
+function* forEachWildcardEntry(
+  key: string,
+  value: string,
+  cwd: string,
+): Generator<[string, string], any, undefined> {
+  try {
+    let expr = pm.makeRe(value, picoMatchGlobalOptions);
+    let reldirnm = path.dirname(value);
+    let dirpth = path.join(cwd, reldirnm);
+    let files = fs.readdirSync(dirpth);
+
+    for (let file of files) {
+      let relfile = path.join(reldirnm, file);
+      let match = expr.exec(relfile);
+
+      if (match && match[1]) {
+        let [pth, repl] = match;
+        let k = key.replace('*', repl);
+        yield [k, './' + pth];
+      }
+    }
+  } catch {
+    // Should we just pretend this didn't happen?
+  }
+}
+
+function* forEachExportEntryExploded(
+  exportField: ExportField,
+  cwd: string,
+): Generator<[string, unknown], any, undefined> {
+  for (const [key, val] of forEachExportEntry(exportField)) {
+    // Deprecated but we still want to support this.
+    // https://nodejs.org/api/packages.html#packages_subpath_folder_mappings
+    if (key.endsWith('/')) {
+      if (typeof val !== 'string') {
+        continue;
+      }
+
+      // There isn't a clear use-case for this, so we are assuming it's not needed for now.
+      if (key === './') {
+        continue;
+      }
+
+      yield* forEachWildcardEntry(key + '*', val + '*', cwd);
+
       continue;
     }
 
+    // Wildcards https://nodejs.org/api/packages.html#packages_subpath_patterns
+    if (key.includes('*')) {
+      if (typeof val !== 'string') {
+        continue;
+      }
+      yield* forEachWildcardEntry(key, val, cwd);
+
+      continue;
+    }
+
+    yield [key, val];
+  }
+}
+
+/**
+ * Given an export map and all of the crazy variations, condense down to a key/value map of string keys to string values.
+ */
+export function explodeExportMap(
+  exportField: ExportField | undefined,
+  {cwd}: {cwd: string},
+): Record<string, string> | undefined {
+  if (!exportField) {
+    return;
+  }
+  const cleanExportMap: Record<string, string> = {};
+
+  for (const [key, val] of forEachExportEntryExploded(exportField, cwd)) {
     // If entry is an array, assume that we can always support the first value
     const firstVal = Array.isArray(val) ? val[0] : val;
     // Support these entries, in this order.
-    const cleanValue = resolveExportMapEntry(firstVal);
+    const cleanValue = findExportMapEntry(firstVal);
     if (typeof cleanValue !== 'string') {
       continue;
     }
@@ -264,5 +320,6 @@ export function normalizeExportMap(exportField?: ExportField): Record<string, st
   if (Object.keys(cleanExportMap).length === 0) {
     return;
   }
+
   return cleanExportMap;
 }

--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -40,10 +40,10 @@ import {resolveEntrypoint} from './entrypoints';
 
 export * from './types';
 export {
-  resolveExportMapEntry,
-  resolveMainEntrypoint,
+  findExportMapEntry,
+  findManifestEntry,
   resolveEntrypoint,
-  normalizeExportMap,
+  explodeExportMap,
 } from './entrypoints';
 export {printStats} from './stats';
 

--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -24,7 +24,7 @@ import {
   DependencyStatsOutput,
   EnvVarReplacements,
   ImportMap,
-  InstallTarget
+  InstallTarget,
 } from './types';
 import {
   createInstallTarget,
@@ -36,14 +36,14 @@ import {
   sanitizePackageName,
   writeLockfile,
 } from './util';
-import { resolveEntrypoint } from './entrypoints';
+import {resolveEntrypoint} from './entrypoints';
 
 export * from './types';
 export {
   resolveExportMapEntry,
   resolveMainEntrypoint,
   resolveEntrypoint,
-  normalizeExportMap
+  normalizeExportMap,
 } from './entrypoints';
 export {printStats} from './stats';
 
@@ -89,7 +89,7 @@ function resolveWebDependency(
 
   return {
     loc,
-    type: getWebDependencyType(loc)
+    type: getWebDependencyType(loc),
   };
 }
 

--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -12,7 +12,6 @@ import {InputOptions, OutputOptions, Plugin as RollupPlugin, rollup, RollupError
 import rollupPluginNodePolyfills from 'rollup-plugin-polyfill-node';
 import rollupPluginReplace from '@rollup/plugin-replace';
 import util from 'util';
-import validatePackageName from 'validate-npm-package-name';
 import {rollupPluginCatchFetch} from './rollup-plugins/rollup-plugin-catch-fetch';
 import {rollupPluginCatchUnresolved} from './rollup-plugins/rollup-plugin-catch-unresolved';
 import {rollupPluginCss} from './rollup-plugins/rollup-plugin-css';
@@ -25,8 +24,7 @@ import {
   DependencyStatsOutput,
   EnvVarReplacements,
   ImportMap,
-  InstallTarget,
-  ExportMapEntry,
+  InstallTarget
 } from './types';
 import {
   createInstallTarget,
@@ -35,28 +33,24 @@ import {
   getWebDependencyType,
   isPackageAliasEntry,
   MISSING_PLUGIN_SUGGESTIONS,
-  parsePackageImportSpecifier,
-  resolveDependencyManifest,
   sanitizePackageName,
   writeLockfile,
 } from './util';
+import { resolveEntrypoint } from './entrypoints';
 
 export * from './types';
+export {
+  resolveExportMapEntry,
+  resolveMainEntrypoint,
+  resolveEntrypoint,
+  normalizeExportMap
+} from './entrypoints';
 export {printStats} from './stats';
 
-type DependencyLoc =
-  | {
-      type: 'BUNDLE';
-      loc: string;
-    }
-  | {
-      type: 'ASSET';
-      loc: string;
-    }
-  | {
-      type: 'DTS';
-      loc: undefined;
-    };
+type DependencyLoc = {
+  type: 'BUNDLE' | 'ASSET' | 'DTS';
+  loc: string;
+};
 
 // Add popular CJS packages here that use "synthetic" named imports in their documentation.
 // CJS packages should really only be imported via the default export:
@@ -77,38 +71,8 @@ const CJS_PACKAGES_TO_AUTO_DETECT = [
   'chai/index.js',
 ];
 
-// Rarely, a package will ship a broken "browser" package.json entrypoint.
-// Ignore the "browser" entrypoint in those packages.
-const BROKEN_BROWSER_ENTRYPOINT = ['@sheerun/mutationobserver-shim'];
-
 function isImportOfPackage(importUrl: string, packageName: string) {
   return packageName === importUrl || importUrl.startsWith(packageName + '/');
-}
-
-function resolveNestedCondition(exportMapEntry: ExportMapEntry | undefined): string | undefined {
-  // If this is a string or undefined we can skip checking for conditions
-  switch (typeof exportMapEntry) {
-    case 'string':
-      return exportMapEntry;
-    case 'undefined':
-      return exportMapEntry;
-  }
-
-  return (
-    resolveNestedCondition(exportMapEntry?.browser) ||
-    resolveNestedCondition(exportMapEntry?.import) ||
-    resolveNestedCondition(exportMapEntry?.default) ||
-    resolveNestedCondition(exportMapEntry?.require) ||
-    undefined
-  );
-}
-
-function resolveExportsMap(
-  packageManifest: {exports: {}},
-  exportsProp: string,
-): string | undefined {
-  const exportMapEntry = packageManifest.exports[exportsProp];
-  return resolveNestedCondition(exportMapEntry);
 }
 
 /**
@@ -119,127 +83,13 @@ function resolveExportsMap(
  */
 function resolveWebDependency(
   dep: string,
-  {cwd, packageLookupFields}: {cwd: string; packageLookupFields: string[]},
+  resolveOptions: {cwd: string; packageLookupFields: string[]},
 ): DependencyLoc {
-  // We first need to check for an export map in the package.json. If one exists, resolve to it.
-  const [packageName, packageEntrypoint] = parsePackageImportSpecifier(dep);
-  const [packageManifestLoc, packageManifest] = resolveDependencyManifest(packageName, cwd);
+  const loc = resolveEntrypoint(dep, resolveOptions);
 
-  if (packageManifestLoc && packageManifest && packageManifest.exports) {
-    // If this is a non-main entry point
-    if (packageEntrypoint) {
-      const exportMapValue = resolveExportsMap(packageManifest, './' + packageEntrypoint);
-
-      if (typeof exportMapValue !== 'string') {
-        throw new Error(
-          `Package "${packageName}" exists but package.json "exports" does not include entry for "./${packageEntrypoint}".`,
-        );
-      }
-      const loc = path.join(packageManifestLoc, '..', exportMapValue);
-      return {
-        type: getWebDependencyType(loc),
-        loc,
-      };
-    } else {
-      const exportMapValue = resolveExportsMap(packageManifest, '.');
-
-      if (exportMapValue) {
-        const loc = path.join(packageManifestLoc, '..', exportMapValue);
-        return {
-          type: getWebDependencyType(loc),
-          loc,
-        };
-      }
-    }
-  }
-
-  // if, no export map and dep points directly to a file within a package, return that reference.
-  if (path.extname(dep) && !validatePackageName(dep).validForNewPackages) {
-    // For details on why we need to call fs.realpathSync.native here and other places, see
-    // https://github.com/snowpackjs/snowpack/pull/999.
-    const loc = fs.realpathSync.native(require.resolve(dep, {paths: [cwd]}));
-    return {
-      type: getWebDependencyType(loc),
-      loc,
-    };
-  }
-
-  // Otherwise, resolve directly to the dep specifier. Note that this supports both
-  // "package-name" & "package-name/some/path" where "package-name/some/path/package.json"
-  // exists at that lower path, that must be used to resolve. In that case, export
-  // maps should not be supported.
-  const [depManifestLoc, depManifest] = resolveDependencyManifest(dep, cwd);
-  if (!depManifest) {
-    try {
-      const maybeLoc = fs.realpathSync.native(require.resolve(dep, {paths: [cwd]}));
-      return {
-        type: getWebDependencyType(maybeLoc),
-        loc: maybeLoc,
-      };
-    } catch (err) {
-      // Oh well, was worth a try
-    }
-  }
-  if (!depManifestLoc || !depManifest) {
-    throw new Error(
-      `Package "${dep}" not found. Have you installed it? ${depManifestLoc ? depManifestLoc : ''}`,
-    );
-  }
-  if (
-    depManifest.name &&
-    (depManifest.name.startsWith('@reactesm') || depManifest.name.startsWith('@pika/react'))
-  ) {
-    throw new Error(
-      `React workaround packages no longer needed! Revert back to the official React & React-DOM packages.`,
-    );
-  }
-  let foundEntrypoint: any = [
-    ...packageLookupFields,
-    'browser:module',
-    'module',
-    'main:esnext',
-    'jsnext:main',
-  ]
-    .map((e) => depManifest[e])
-    .find(Boolean);
-  if (!foundEntrypoint && !BROKEN_BROWSER_ENTRYPOINT.includes(packageName)) {
-    foundEntrypoint = depManifest.browser;
-  }
-
-  // Some packages define "browser" as an object. We'll do our best to find the
-  // right entrypoint in an entrypoint object, or fail otherwise.
-  // See: https://github.com/defunctzombie/package-browser-field-spec
-  if (typeof foundEntrypoint === 'object') {
-    foundEntrypoint =
-      foundEntrypoint[dep] ||
-      foundEntrypoint['./index.js'] ||
-      foundEntrypoint['./index'] ||
-      foundEntrypoint['index.js'] ||
-      foundEntrypoint['index'] ||
-      foundEntrypoint['./'] ||
-      foundEntrypoint['.'];
-  }
-  // If browser object is set but no relevant entrypoint is found, fall back to "main".
-  if (!foundEntrypoint) {
-    foundEntrypoint = depManifest.main;
-  }
-  // Sometimes packages don't give an entrypoint, assuming you'll fall back to "index.js".
-  if (!foundEntrypoint && fs.existsSync(path.join(depManifestLoc, '../index.js'))) {
-    foundEntrypoint = 'index.js';
-  }
-  // Some packages are types-only. If this is one of those packages, resolve with that.
-  if (!foundEntrypoint && (depManifest.types || depManifest.typings)) {
-    return {type: 'DTS', loc: undefined};
-  }
-  if (typeof foundEntrypoint !== 'string') {
-    throw new Error(`"${dep}" has unexpected entrypoint: ${JSON.stringify(foundEntrypoint)}.`);
-  }
-  const loc = fs.realpathSync.native(
-    require.resolve(path.join(depManifestLoc || '', '..', foundEntrypoint)),
-  );
   return {
-    type: getWebDependencyType(loc),
     loc,
+    type: getWebDependencyType(loc)
   };
 }
 

--- a/esinstall/src/types.ts
+++ b/esinstall/src/types.ts
@@ -1,5 +1,3 @@
-import {resolveExportMapEntry} from './entrypoints';
-
 export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends Array<infer U>
     ? Array<DeepPartial<U>>

--- a/esinstall/src/types.ts
+++ b/esinstall/src/types.ts
@@ -1,4 +1,4 @@
-import { resolveExportMapEntry } from "./entrypoints";
+import {resolveExportMapEntry} from './entrypoints';
 
 export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends Array<infer U>
@@ -69,7 +69,7 @@ export type ExportMapEntry =
 
 export type ExportMap = Record<string, ExportMapEntry>;
 
-// 
+//
 /**
  * https://github.com/defunctzombie/package-browser-field-spec
  * "browser": "main.js",
@@ -92,4 +92,4 @@ export type PackageManifest = {
 
 export type PackageManifestWithExports = PackageManifest & {
   exports: ExportMap;
-}
+};

--- a/esinstall/src/types.ts
+++ b/esinstall/src/types.ts
@@ -66,6 +66,7 @@ export type ExportMapEntry =
     };
 
 export type ExportMap = Record<string, ExportMapEntry>;
+export type ExportField = string | ExportMap;
 
 //
 /**
@@ -82,7 +83,7 @@ export type PackageManifest = {
   version: string;
   main?: string; // This is optional, actually
   module?: string;
-  exports?: string | ExportMap;
+  exports?: ExportField;
   browser?: BrowserField;
   types?: string;
   typings?: string;

--- a/esinstall/src/types.ts
+++ b/esinstall/src/types.ts
@@ -1,3 +1,5 @@
+import { resolveExportMapEntry } from "./entrypoints";
+
 export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends Array<infer U>
     ? Array<DeepPartial<U>>
@@ -55,6 +57,7 @@ export interface LoggerOptions {
   name?: string;
 }
 
+// TODO this is incomplete and could be an array.
 export type ExportMapEntry =
   | string
   | {
@@ -63,3 +66,30 @@ export type ExportMapEntry =
       default?: ExportMapEntry;
       require?: ExportMapEntry;
     };
+
+export type ExportMap = Record<string, ExportMapEntry>;
+
+// 
+/**
+ * https://github.com/defunctzombie/package-browser-field-spec
+ * "browser": "main.js",
+ * "browser": { "./": "main.js" }
+ * "browser": { "./foo": false } // don't include in bundle
+ */
+export type BrowserField = string | Record<string, string | boolean>;
+
+// This is the package.json, with fields we care about
+export type PackageManifest = {
+  name: string;
+  version: string;
+  main?: string; // This is optional, actually
+  module?: string;
+  exports?: string | ExportMap;
+  browser?: BrowserField;
+  types?: string;
+  typings?: string;
+};
+
+export type PackageManifestWithExports = PackageManifest & {
+  exports: ExportMap;
+}

--- a/esinstall/src/util.ts
+++ b/esinstall/src/util.ts
@@ -42,7 +42,10 @@ export function parsePackageImportSpecifier(imp: string): [string, string | null
  * NOTE: You used to be able to require() a package.json file directly,
  * but now with export map support in Node v13 that's no longer possible.
  */
-export function resolveDependencyManifest(dep: string, cwd: string): [string | null, PackageManifest | null] {
+export function resolveDependencyManifest(
+  dep: string,
+  cwd: string,
+): [string | null, PackageManifest | null] {
   // Attempt #1: Resolve the dependency manifest normally. This works for most
   // packages, but fails when the package defines an export map that doesn't
   // include a package.json. If we detect that to be the reason for failure,

--- a/esinstall/src/util.ts
+++ b/esinstall/src/util.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import url from 'url';
 import validatePackageName from 'validate-npm-package-name';
-import {InstallTarget, ImportMap} from './types';
+import {InstallTarget, ImportMap, PackageManifest} from './types';
 
 // We need to use eval here to prevent Rollup from detecting this use of `require()`
 export const NATIVE_REQUIRE = eval('require');
@@ -42,7 +42,7 @@ export function parsePackageImportSpecifier(imp: string): [string, string | null
  * NOTE: You used to be able to require() a package.json file directly,
  * but now with export map support in Node v13 that's no longer possible.
  */
-export function resolveDependencyManifest(dep: string, cwd: string): [string | null, any | null] {
+export function resolveDependencyManifest(dep: string, cwd: string): [string | null, PackageManifest | null] {
   // Attempt #1: Resolve the dependency manifest normally. This works for most
   // packages, but fails when the package defines an export map that doesn't
   // include a package.json. If we detect that to be the reason for failure,
@@ -203,7 +203,7 @@ export function isJavaScript(pathname: string): boolean {
  *   - BUNDLE: Install and bundle this file with Rollup engine.
  *   - ASSET: Copy this file directly.
  */
-export function getWebDependencyType(pathname: string): 'ASSET' | 'BUNDLE' {
+export function getWebDependencyType(pathname: string): 'ASSET' | 'BUNDLE' | 'DTS' {
   const ext = path.extname(pathname).toLowerCase();
   // JavaScript should always be bundled.
   if (isJavaScript(pathname)) {
@@ -215,6 +215,12 @@ export function getWebDependencyType(pathname: string): 'ASSET' | 'BUNDLE' {
   if (ext === '.svelte' || ext === '.vue') {
     return 'BUNDLE';
   }
+
+  // TypeScript typings
+  if (pathname.endsWith('.d.ts')) {
+    return 'DTS';
+  }
+
   // All other files should be treated as assets (copied over directly).
   return 'ASSET';
 }

--- a/test/esinstall.api.test.js
+++ b/test/esinstall.api.test.js
@@ -1,0 +1,170 @@
+const {
+  normalizeExportMap,
+  resolveExportMapEntry,
+  resolveMainEntrypoint
+} = require('../esinstall/lib');
+
+describe('ESInstall API', () => {
+  describe('resolveExportMapEntry', () => {
+    it('returns a string value', () => {
+      expect(resolveExportMapEntry('foo.js')).toBe('foo.js');
+    })
+
+    it('prefers browser', () => {
+      expect(resolveExportMapEntry({ 
+        browser: 'browser.js',
+        import: 'import.js',
+        default: 'default.js',
+        require: 'require.js'
+      })).toBe('browser.js');
+    });
+
+    it('picks import', () => {
+      expect(resolveExportMapEntry({ 
+        import: 'import.js',
+        default: 'default.js',
+        require: 'require.js'
+      })).toBe('import.js');
+    });
+
+    it('picks default', () => {
+      expect(resolveExportMapEntry({ 
+        default: 'default.js',
+        require: 'require.js'
+      })).toBe('default.js');
+    });
+
+    it('picks require', () => {
+      expect(resolveExportMapEntry({ 
+        require: 'require.js',
+        other: 'other.js'
+      })).toBe('require.js');
+    });
+  })
+
+  describe('normalizeExportMap', () => {
+    it('when export map is a string, returns an object with a .', () => {
+      let map = normalizeExportMap('./main.js');
+
+      expect(map).toStrictEqual({
+        '.': './main.js'
+      });
+    });
+
+    it('resolves keys to the entry', () => {
+      let map = normalizeExportMap({
+        '.': {
+          browser: './entrypoint.js'
+        },
+        './other': {
+          import: './other.js'
+        }
+      });
+      expect(map).toStrictEqual({
+        '.': './entrypoint.js',
+        './other': './other.js'
+      });
+    });
+
+    it('ignores keys that don\'t start with .', () => {
+      let map = normalizeExportMap({
+        '.': './entrypoint.js',
+        'bad': './error.js'
+      });
+
+      expect(map).toStrictEqual({
+        '.': './entrypoint.js'
+      });
+    });
+
+    it('ignores wildcards', () => {
+      let map = normalizeExportMap({
+        '.': './entrypoint.js',
+        '/lib/*': './lib/*.js'
+      });
+
+      expect(map).toStrictEqual({
+        '.': './entrypoint.js'
+      });
+    });
+
+    it('resolves arrays the first value', () => {
+      let map = normalizeExportMap({
+        '.': [
+          './entrypoint.js',
+          './fallback.js'
+        ]
+      });
+
+      expect(map).toStrictEqual({
+        '.': './entrypoint.js'
+      });
+    });
+
+    it('returns undefined if there are no valid entries', () => {
+      let map = normalizeExportMap({
+        'bad': './error.js'
+      });
+      expect(map).toBe(undefined);
+    })
+  });
+
+  describe('resolveMainEntrypoint', () => {
+    it('gets "exports"', () => {
+      let entry = resolveMainEntrypoint({ exports: 'esm.js', main: 'main.js' });
+      expect(entry).toBe('esm.js');
+    });
+
+    it('gets "exports[.]"', () => {
+      debugger;
+      let entry = resolveMainEntrypoint({
+        exports: {
+          '.': 'esm.js'
+        },
+        main: 'main.js'
+      });
+      expect(entry).toBe('esm.js');
+    });
+
+    it('gets "main"', () => {
+      let entry = resolveMainEntrypoint({ main: 'foo.js' });
+      expect(entry).toBe('foo.js');
+    });
+
+    it('gets "module"', () => {
+      let entry = resolveMainEntrypoint({ main: 'error.js', module: 'foo.js' });
+      expect(entry).toBe('foo.js');
+    });
+
+    it('gets "browser:module"', () => {
+      let entry = resolveMainEntrypoint({ main: 'error.js', 'browser:module': 'mod.js' });
+      expect(entry).toBe('mod.js');
+    });
+
+    it('gets "main:esnext"', () => {
+      let entry = resolveMainEntrypoint({ main: 'error.js', 'main:esnext': 'main.js' });
+      expect(entry).toBe('main.js');
+    });
+
+    it('gets "jsnext:main"', () => {
+      let entry = resolveMainEntrypoint({ main: 'error.js', 'jsnext:main': 'jsnext.js' });
+      expect(entry).toBe('jsnext.js');
+    });
+
+    it('gets "browser"', () => {
+      let entry = resolveMainEntrypoint({
+        main: 'error.js',
+        browser: 'browser.js'
+      });
+      expect(entry).toBe('browser.js');
+
+      entry = resolveMainEntrypoint({
+        main: 'error.js',
+        browser: {
+          './': 'browser.js'
+        }
+      });
+      expect(entry).toBe('browser.js');
+    });
+  });
+});

--- a/test/esinstall.api.test.js
+++ b/test/esinstall.api.test.js
@@ -1,18 +1,14 @@
-const {
-  normalizeExportMap,
-  resolveExportMapEntry,
-  resolveMainEntrypoint,
-} = require('../esinstall/lib');
+const {findExportMapEntry, findManifestEntry, explodeExportMap} = require('../esinstall/lib');
 
 describe('ESInstall API', () => {
-  describe('resolveExportMapEntry', () => {
+  describe('findExportMapEntry', () => {
     it('returns a string value', () => {
-      expect(resolveExportMapEntry('foo.js')).toBe('foo.js');
+      expect(findExportMapEntry('foo.js')).toBe('foo.js');
     });
 
     it('prefers browser', () => {
       expect(
-        resolveExportMapEntry({
+        findExportMapEntry({
           browser: 'browser.js',
           import: 'import.js',
           default: 'default.js',
@@ -23,7 +19,7 @@ describe('ESInstall API', () => {
 
     it('picks import', () => {
       expect(
-        resolveExportMapEntry({
+        findExportMapEntry({
           import: 'import.js',
           default: 'default.js',
           require: 'require.js',
@@ -33,7 +29,7 @@ describe('ESInstall API', () => {
 
     it('picks default', () => {
       expect(
-        resolveExportMapEntry({
+        findExportMapEntry({
           default: 'default.js',
           require: 'require.js',
         }),
@@ -42,7 +38,7 @@ describe('ESInstall API', () => {
 
     it('picks require', () => {
       expect(
-        resolveExportMapEntry({
+        findExportMapEntry({
           require: 'require.js',
           other: 'other.js',
         }),
@@ -51,7 +47,7 @@ describe('ESInstall API', () => {
 
     it('takes conditions', () => {
       expect(
-        resolveExportMapEntry(
+        findExportMapEntry(
           {
             development: {
               browser: 'error.js',
@@ -66,79 +62,14 @@ describe('ESInstall API', () => {
     });
   });
 
-  describe('normalizeExportMap', () => {
-    it('when export map is a string, returns an object with a .', () => {
-      let map = normalizeExportMap('./main.js');
-
-      expect(map).toStrictEqual({
-        '.': './main.js',
-      });
-    });
-
-    it('resolves keys to the entry', () => {
-      let map = normalizeExportMap({
-        '.': {
-          browser: './entrypoint.js',
-        },
-        './other': {
-          import: './other.js',
-        },
-      });
-      expect(map).toStrictEqual({
-        '.': './entrypoint.js',
-        './other': './other.js',
-      });
-    });
-
-    it("ignores keys that don't start with .", () => {
-      let map = normalizeExportMap({
-        '.': './entrypoint.js',
-        bad: './error.js',
-      });
-
-      expect(map).toStrictEqual({
-        '.': './entrypoint.js',
-      });
-    });
-
-    it('ignores wildcards', () => {
-      let map = normalizeExportMap({
-        '.': './entrypoint.js',
-        '/lib/*': './lib/*.js',
-      });
-
-      expect(map).toStrictEqual({
-        '.': './entrypoint.js',
-      });
-    });
-
-    it('resolves arrays the first value', () => {
-      let map = normalizeExportMap({
-        '.': ['./entrypoint.js', './fallback.js'],
-      });
-
-      expect(map).toStrictEqual({
-        '.': './entrypoint.js',
-      });
-    });
-
-    it('returns undefined if there are no valid entries', () => {
-      let map = normalizeExportMap({
-        bad: './error.js',
-      });
-      expect(map).toBe(undefined);
-    });
-  });
-
-  describe('resolveMainEntrypoint', () => {
+  describe('findManifestEntry', () => {
     it('gets "exports"', () => {
-      let entry = resolveMainEntrypoint({exports: 'esm.js', main: 'main.js'});
+      let entry = findManifestEntry({exports: 'esm.js', main: 'main.js'});
       expect(entry).toBe('esm.js');
     });
 
     it('gets "exports[.]"', () => {
-      debugger;
-      let entry = resolveMainEntrypoint({
+      let entry = findManifestEntry({
         exports: {
           '.': 'esm.js',
         },
@@ -148,44 +79,143 @@ describe('ESInstall API', () => {
     });
 
     it('gets "main"', () => {
-      let entry = resolveMainEntrypoint({main: 'foo.js'});
+      let entry = findManifestEntry({main: 'foo.js'});
       expect(entry).toBe('foo.js');
     });
 
     it('gets "module"', () => {
-      let entry = resolveMainEntrypoint({main: 'error.js', module: 'foo.js'});
+      let entry = findManifestEntry({main: 'error.js', module: 'foo.js'});
       expect(entry).toBe('foo.js');
     });
 
     it('gets "browser:module"', () => {
-      let entry = resolveMainEntrypoint({main: 'error.js', 'browser:module': 'mod.js'});
+      let entry = findManifestEntry({main: 'error.js', 'browser:module': 'mod.js'});
       expect(entry).toBe('mod.js');
     });
 
     it('gets "main:esnext"', () => {
-      let entry = resolveMainEntrypoint({main: 'error.js', 'main:esnext': 'main.js'});
+      let entry = findManifestEntry({main: 'error.js', 'main:esnext': 'main.js'});
       expect(entry).toBe('main.js');
     });
 
     it('gets "jsnext:main"', () => {
-      let entry = resolveMainEntrypoint({main: 'error.js', 'jsnext:main': 'jsnext.js'});
+      let entry = findManifestEntry({main: 'error.js', 'jsnext:main': 'jsnext.js'});
       expect(entry).toBe('jsnext.js');
     });
 
     it('gets "browser"', () => {
-      let entry = resolveMainEntrypoint({
+      let entry = findManifestEntry({
         main: 'error.js',
         browser: 'browser.js',
       });
       expect(entry).toBe('browser.js');
 
-      entry = resolveMainEntrypoint({
+      entry = findManifestEntry({
         main: 'error.js',
         browser: {
           './': 'browser.js',
         },
       });
       expect(entry).toBe('browser.js');
+    });
+  });
+
+  describe('explodeExportMap', () => {
+    const cwd = __dirname;
+
+    it('when export map is a string, returns an object with a .', () => {
+      let map = explodeExportMap('./main.js', {cwd});
+
+      expect(map).toStrictEqual({
+        '.': './main.js',
+      });
+    });
+
+    it('resolves keys to the entry', () => {
+      let map = explodeExportMap(
+        {
+          '.': {
+            browser: './entrypoint.js',
+          },
+          './other': {
+            import: './other.js',
+          },
+        },
+        {cwd},
+      );
+
+      expect(map).toStrictEqual({
+        '.': './entrypoint.js',
+        './other': './other.js',
+      });
+    });
+
+    it("ignores keys that don't start with .", () => {
+      let map = explodeExportMap(
+        {
+          '.': './entrypoint.js',
+          bad: './error.js',
+        },
+        {cwd},
+      );
+
+      expect(map).toStrictEqual({
+        '.': './entrypoint.js',
+      });
+    });
+
+    it('ignores wildcards', () => {
+      let map = explodeExportMap(
+        {
+          './other': './other.js',
+          './': './',
+        },
+        {cwd},
+      );
+
+      expect(map).toStrictEqual({
+        './other': './other.js',
+      });
+    });
+
+    it('resolves arrays the first value', () => {
+      let map = explodeExportMap(
+        {
+          '.': ['./entrypoint.js', './fallback.js'],
+        },
+        {cwd},
+      );
+
+      expect(map).toStrictEqual({
+        '.': './entrypoint.js',
+      });
+    });
+
+    it('returns undefined if there are no valid entries', () => {
+      let map = explodeExportMap(
+        {
+          bad: './error.js',
+        },
+        {cwd},
+      );
+      expect(map).toBe(undefined);
+    });
+
+    it('explodes wildcard exports', () => {
+      let map = explodeExportMap(
+        {
+          '.': './entrypoint.js',
+          './extras/*': './src/extras/*.js',
+        },
+        {cwd: __dirname + '/esinstall/package-entrypoints/export-map-star'},
+      );
+
+      expect(map).toStrictEqual({
+        '.': './entrypoint.js',
+        './extras/one': './src/extras/one.js',
+        './extras/two': './src/extras/two.js',
+        './extras/three': './src/extras/three.js',
+      });
     });
   });
 });

--- a/test/esinstall.api.test.js
+++ b/test/esinstall.api.test.js
@@ -1,128 +1,138 @@
 const {
   normalizeExportMap,
   resolveExportMapEntry,
-  resolveMainEntrypoint
+  resolveMainEntrypoint,
 } = require('../esinstall/lib');
 
 describe('ESInstall API', () => {
   describe('resolveExportMapEntry', () => {
     it('returns a string value', () => {
       expect(resolveExportMapEntry('foo.js')).toBe('foo.js');
-    })
+    });
 
     it('prefers browser', () => {
-      expect(resolveExportMapEntry({ 
-        browser: 'browser.js',
-        import: 'import.js',
-        default: 'default.js',
-        require: 'require.js'
-      })).toBe('browser.js');
+      expect(
+        resolveExportMapEntry({
+          browser: 'browser.js',
+          import: 'import.js',
+          default: 'default.js',
+          require: 'require.js',
+        }),
+      ).toBe('browser.js');
     });
 
     it('picks import', () => {
-      expect(resolveExportMapEntry({ 
-        import: 'import.js',
-        default: 'default.js',
-        require: 'require.js'
-      })).toBe('import.js');
+      expect(
+        resolveExportMapEntry({
+          import: 'import.js',
+          default: 'default.js',
+          require: 'require.js',
+        }),
+      ).toBe('import.js');
     });
 
     it('picks default', () => {
-      expect(resolveExportMapEntry({ 
-        default: 'default.js',
-        require: 'require.js'
-      })).toBe('default.js');
+      expect(
+        resolveExportMapEntry({
+          default: 'default.js',
+          require: 'require.js',
+        }),
+      ).toBe('default.js');
     });
 
     it('picks require', () => {
-      expect(resolveExportMapEntry({ 
-        require: 'require.js',
-        other: 'other.js'
-      })).toBe('require.js');
+      expect(
+        resolveExportMapEntry({
+          require: 'require.js',
+          other: 'other.js',
+        }),
+      ).toBe('require.js');
     });
 
     it('takes conditions', () => {
-      expect(resolveExportMapEntry({
-        development: {
-          browser: 'error.js'
-        },
-        production: {
-          import: 'prod.js'
-        }
-      }, ['production'])).toBe('prod.js');
-    })
-  })
+      expect(
+        resolveExportMapEntry(
+          {
+            development: {
+              browser: 'error.js',
+            },
+            production: {
+              import: 'prod.js',
+            },
+          },
+          ['production'],
+        ),
+      ).toBe('prod.js');
+    });
+  });
 
   describe('normalizeExportMap', () => {
     it('when export map is a string, returns an object with a .', () => {
       let map = normalizeExportMap('./main.js');
 
       expect(map).toStrictEqual({
-        '.': './main.js'
+        '.': './main.js',
       });
     });
 
     it('resolves keys to the entry', () => {
       let map = normalizeExportMap({
         '.': {
-          browser: './entrypoint.js'
+          browser: './entrypoint.js',
         },
         './other': {
-          import: './other.js'
-        }
+          import: './other.js',
+        },
       });
       expect(map).toStrictEqual({
         '.': './entrypoint.js',
-        './other': './other.js'
+        './other': './other.js',
       });
     });
 
-    it('ignores keys that don\'t start with .', () => {
+    it("ignores keys that don't start with .", () => {
       let map = normalizeExportMap({
         '.': './entrypoint.js',
-        'bad': './error.js'
+        bad: './error.js',
       });
 
       expect(map).toStrictEqual({
-        '.': './entrypoint.js'
+        '.': './entrypoint.js',
       });
     });
 
     it('ignores wildcards', () => {
       let map = normalizeExportMap({
         '.': './entrypoint.js',
-        '/lib/*': './lib/*.js'
+        '/lib/*': './lib/*.js',
       });
 
       expect(map).toStrictEqual({
-        '.': './entrypoint.js'
+        '.': './entrypoint.js',
       });
     });
 
     it('resolves arrays the first value', () => {
       let map = normalizeExportMap({
-        '.': [
-          './entrypoint.js',
-          './fallback.js'
-        ]
+        '.': ['./entrypoint.js', './fallback.js'],
       });
 
       expect(map).toStrictEqual({
-        '.': './entrypoint.js'
+        '.': './entrypoint.js',
       });
     });
 
     it('returns undefined if there are no valid entries', () => {
       let map = normalizeExportMap({
-        'bad': './error.js'
+        bad: './error.js',
       });
       expect(map).toBe(undefined);
-    })
+    });
   });
 
   describe('resolveMainEntrypoint', () => {
     it('gets "exports"', () => {
-      let entry = resolveMainEntrypoint({ exports: 'esm.js', main: 'main.js' });
+      let entry = resolveMainEntrypoint({exports: 'esm.js', main: 'main.js'});
       expect(entry).toBe('esm.js');
     });
 
@@ -130,50 +140,50 @@ describe('ESInstall API', () => {
       debugger;
       let entry = resolveMainEntrypoint({
         exports: {
-          '.': 'esm.js'
+          '.': 'esm.js',
         },
-        main: 'main.js'
+        main: 'main.js',
       });
       expect(entry).toBe('esm.js');
     });
 
     it('gets "main"', () => {
-      let entry = resolveMainEntrypoint({ main: 'foo.js' });
+      let entry = resolveMainEntrypoint({main: 'foo.js'});
       expect(entry).toBe('foo.js');
     });
 
     it('gets "module"', () => {
-      let entry = resolveMainEntrypoint({ main: 'error.js', module: 'foo.js' });
+      let entry = resolveMainEntrypoint({main: 'error.js', module: 'foo.js'});
       expect(entry).toBe('foo.js');
     });
 
     it('gets "browser:module"', () => {
-      let entry = resolveMainEntrypoint({ main: 'error.js', 'browser:module': 'mod.js' });
+      let entry = resolveMainEntrypoint({main: 'error.js', 'browser:module': 'mod.js'});
       expect(entry).toBe('mod.js');
     });
 
     it('gets "main:esnext"', () => {
-      let entry = resolveMainEntrypoint({ main: 'error.js', 'main:esnext': 'main.js' });
+      let entry = resolveMainEntrypoint({main: 'error.js', 'main:esnext': 'main.js'});
       expect(entry).toBe('main.js');
     });
 
     it('gets "jsnext:main"', () => {
-      let entry = resolveMainEntrypoint({ main: 'error.js', 'jsnext:main': 'jsnext.js' });
+      let entry = resolveMainEntrypoint({main: 'error.js', 'jsnext:main': 'jsnext.js'});
       expect(entry).toBe('jsnext.js');
     });
 
     it('gets "browser"', () => {
       let entry = resolveMainEntrypoint({
         main: 'error.js',
-        browser: 'browser.js'
+        browser: 'browser.js',
       });
       expect(entry).toBe('browser.js');
 
       entry = resolveMainEntrypoint({
         main: 'error.js',
         browser: {
-          './': 'browser.js'
-        }
+          './': 'browser.js',
+        },
       });
       expect(entry).toBe('browser.js');
     });

--- a/test/esinstall.api.test.js
+++ b/test/esinstall.api.test.js
@@ -40,6 +40,17 @@ describe('ESInstall API', () => {
         other: 'other.js'
       })).toBe('require.js');
     });
+
+    it('takes conditions', () => {
+      expect(resolveExportMapEntry({
+        development: {
+          browser: 'error.js'
+        },
+        production: {
+          import: 'prod.js'
+        }
+      }, ['production'])).toBe('prod.js');
+    })
   })
 
   describe('normalizeExportMap', () => {

--- a/test/esinstall/package-entrypoints/export-map-object-no-key/entrypoint.js
+++ b/test/esinstall/package-entrypoints/export-map-object-no-key/entrypoint.js
@@ -1,0 +1,1 @@
+export const a = 'b';

--- a/test/esinstall/package-entrypoints/export-map-object-no-key/package.json
+++ b/test/esinstall/package-entrypoints/export-map-object-no-key/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.2.3",
+  "name": "export-map-object-no-key",
+  "description": "With dot slash",
+  "exports": {
+    "default": "./no-exist.js",
+    "browser": "./entrypoint.js"
+  }
+}

--- a/test/esinstall/package-entrypoints/export-map-star/entrypoint.js
+++ b/test/esinstall/package-entrypoints/export-map-star/entrypoint.js
@@ -1,0 +1,1 @@
+export const a = 'b';

--- a/test/esinstall/package-entrypoints/export-map-star/package.json
+++ b/test/esinstall/package-entrypoints/export-map-star/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.2.3",
+  "name": "export-map-star",
+  "description": "With star (wildcards)",
+  "exports": {
+    ".": "./entrypoint.js",
+    "./extras/*": "./src/extras/*.js"
+  }
+}

--- a/test/esinstall/package-entrypoints/export-map-star/src/extras/one.js
+++ b/test/esinstall/package-entrypoints/export-map-star/src/extras/one.js
@@ -1,0 +1,1 @@
+export const one = 'one';

--- a/test/esinstall/package-entrypoints/export-map-star/src/extras/other.css
+++ b/test/esinstall/package-entrypoints/export-map-star/src/extras/other.css
@@ -1,0 +1,2 @@
+/* This should not be included */
+body { background: darkorchid; }

--- a/test/esinstall/package-entrypoints/export-map-star/src/extras/three.js
+++ b/test/esinstall/package-entrypoints/export-map-star/src/extras/three.js
@@ -1,0 +1,1 @@
+export const three = 'three';

--- a/test/esinstall/package-entrypoints/export-map-star/src/extras/two.js
+++ b/test/esinstall/package-entrypoints/export-map-star/src/extras/two.js
@@ -1,0 +1,1 @@
+export const two = 'two';

--- a/test/esinstall/package-entrypoints/main-folder/entrypoint/index.js
+++ b/test/esinstall/package-entrypoints/main-folder/entrypoint/index.js
@@ -1,0 +1,1 @@
+export const foobar = 42;

--- a/test/esinstall/package-entrypoints/main-folder/package.json
+++ b/test/esinstall/package-entrypoints/main-folder/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "esinstall-test-main-folder",
+  "version": "1.2.3",
+  "main": "./entrypoint"
+}

--- a/test/esinstall/package-entrypoints/package-entrypoints-export-map.test.js
+++ b/test/esinstall/package-entrypoints/package-entrypoints-export-map.test.js
@@ -24,6 +24,9 @@ describe('package-entrypoints exports configuration', () => {
 
       // "." : { "browser": { "development": "index.js" } }
       'export-map-object-browser-object',
+
+      // { "browser": "index.js" }
+      'export-map-object-no-key',
     ];
 
     const {

--- a/test/esinstall/package-entrypoints/package-entrypoints-export-map.test.js
+++ b/test/esinstall/package-entrypoints/package-entrypoints-export-map.test.js
@@ -1,7 +1,7 @@
 const {install} = require('../../../esinstall/lib');
 const path = require('path');
 
-describe('package-entrypoints browser configuration', () => {
+describe('package-entrypoints exports configuration', () => {
   it('supports all of the variations', async () => {
     const cwd = __dirname;
     const dest = path.join(cwd, 'test-export-map-variations');
@@ -61,14 +61,29 @@ describe('package-entrypoints browser configuration', () => {
      */
   });
 
-  it.skip('"exports" wildcards', async () => {
-    // This should be in the "supports all of the variations" test, putting here for visibility.
-    /**
-     * "exports": {
-          // …
-          "./utils/*": "./utils/*.js"
-        }
-     */
+  it('"exports" wildcards', async () => {
+    const cwd = __dirname;
+    const dest = path.join(cwd, 'test-export-map-star');
+    const targets = [
+      'export-map-star',
+      'export-map-star/extras/one',
+      'export-map-star/extras/two',
+      'export-map-star/extras/three',
+    ];
+
+    const {
+      importMap: {imports},
+    } = await install(targets, {
+      cwd,
+      dest,
+    });
+
+    expect(imports).toStrictEqual({
+      'export-map-star': './export-map-star.js',
+      'export-map-star/extras/one': './export-map-star/extras/one.js',
+      'export-map-star/extras/three': './export-map-star/extras/three.js',
+      'export-map-star/extras/two': './export-map-star/extras/two.js',
+    });
   });
 
   it.skip('"exports" with arrays', async () => {
@@ -81,7 +96,7 @@ describe('package-entrypoints browser configuration', () => {
      */
   });
 
-  it("supports preact's configuration", async () => {
+  it.only("supports preact's configuration", async () => {
     const cwd = __dirname;
     const dest = path.join(cwd, 'test-export-preact');
 

--- a/test/esinstall/package-entrypoints/package-entrypoints-general.test.js
+++ b/test/esinstall/package-entrypoints/package-entrypoints-general.test.js
@@ -56,4 +56,20 @@ describe('package-entrypoints general tests', () => {
       expect(imports[pkg]).toBeTruthy();
     }
   });
+
+  it('Supports "main" when it points to a folder', async () => {
+    const cwd = __dirname;
+    const dest = path.join(cwd, 'test-main-folder');
+    const spec = 'main-folder';
+
+    const {
+      importMap: {imports},
+    } = await install([spec], {
+      cwd,
+      dest,
+    });
+
+    expect(Object.keys(imports)).toHaveLength(1);
+    expect(imports['main-folder']).toBeTruthy();
+  });
 });

--- a/test/esinstall/package-entrypoints/package.json
+++ b/test/esinstall/package-entrypoints/package.json
@@ -27,6 +27,7 @@
     "export-map-object-import": "file:./export-map-object-import",
     "export-map-object-default": "file:./export-map-object-default",
     "export-map-object-require": "file:./export-map-object-require",
+    "export-map-object-no-key": "file:./export-map-object-no-key",
     "export-map-star": "file:./export-map-star",
     "preact": "^10.0.0"
   }

--- a/test/esinstall/package-entrypoints/package.json
+++ b/test/esinstall/package-entrypoints/package.json
@@ -10,6 +10,7 @@
     }
   },
   "dependencies": {
+    "main-folder": "file:./main-folder",
     "browser-path": "file:./browser-path",
     "browser-dot": "file:./browser-dot",
     "browser-dot-slash": "file:./browser-dot-slash",
@@ -26,6 +27,7 @@
     "export-map-object-import": "file:./export-map-object-import",
     "export-map-object-default": "file:./export-map-object-default",
     "export-map-object-require": "file:./export-map-object-require",
+    "export-map-star": "file:./export-map-star",
     "preact": "^10.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6898,6 +6898,9 @@ expect@^26.6.2:
 "export-map-object-import@file:./test/esinstall/package-entrypoints/export-map-object-import":
   version "1.2.3"
 
+"export-map-object-no-key@file:./test/esinstall/package-entrypoints/export-map-object-no-key":
+  version "1.2.3"
+
 "export-map-object-require@file:./test/esinstall/package-entrypoints/export-map-object-require":
   version "1.2.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6901,6 +6901,9 @@ expect@^26.6.2:
 "export-map-object-require@file:./test/esinstall/package-entrypoints/export-map-object-require":
   version "1.2.3"
 
+"export-map-star@file:./test/esinstall/package-entrypoints/export-map-star":
+  version "1.2.3"
+
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
@@ -9706,6 +9709,9 @@ magic-string@^0.25.5, magic-string@^0.25.7:
   integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
   dependencies:
     sourcemap-codec "^1.4.4"
+
+"main-folder@file:./test/esinstall/package-entrypoints/main-folder":
+  version "1.2.3"
 
 make-dir@^1.0.0:
   version "1.3.0"


### PR DESCRIPTION
## Changes

This adds new entry point APIs for esinstall. Potentially this could be spun out to its own package, but at this point the APIs are a bit use-case specific (specially for skypack).

New APIs are:

### findExportMapEntry

Given an export map entry it picks out the entry point.

```js
let entry = findExportMapEntry({
  require: 'common.js',
  browser: 'esm.js'
});

console.log(entry); // 'esm.js'
```

It can also take an array of conditions which it will resolve.  Note that this was added for correctness but is not used by anything in snowpack.

```js
let entry = findExportMapEntry({
  development: {
    browser: 'error.js'
  },
  production: {
    browser: 'esm.js'
  }
}, ['production']);

console.log(entry); // 'esm.js'
```

### findManifestEntry

This takes a package.json and finds the primary entry point, or an entrypoint for a subpath, checking the different supported main properties:

```js
let entry = findManifestEntry({
  main: 'main.js',
  browser: 'browser.js',
  'jsnext:main': 'esm.js'
});

console.log(entry); // 'esm.js'
```

### explodeExportMap

Takes an export map and normalizes it to be a key/value pair of entry points to string locations. This takes care of doing the recursive export map dance, exploding wildcards, etc.

```js
let map = explodeExportMap({
  '.': {
    import: 'main.js'
  },
  'invalid': 'error.js'
}, { cwd: '/path/to/module/root' });

console.log(map); // { '.': 'main.js' }
```

This __also__ supports exploding wildcard and slash-ending export map entries like this:

```js
let map = explodeExportMap({
  './extras/*': './src/extras/*'
}, { cwd: '/path/to/module/root' });

console.log(map); // { './extras/one.js': './src/extras/one.js', './extras/two.js': './src/extras/two.js' }
```

The same is true for entries ending with `/`.

## Testing

Added a `test/esinstall.api.test.js` which has unit tests for all of these new exports.

## Docs

Not currently. As these APIs are mostly for use within skypack I wasn't sure if they should be documented or not. Do we want to commit to them? Happy to add, wanted to discuss here first.