### PR TITLE
changed typescript plugin to accept --build parameter as it needs to …

### DIFF
--- a/plugins/plugin-typescript/plugin.js
+++ b/plugins/plugin-typescript/plugin.js
@@ -6,7 +6,7 @@ function typescriptPlugin(snowpackConfig, {tsc, args} = {}) {
     name: '@snowpack/plugin-typescript',
     async run({isDev, log}) {
       const workerPromise = execa.command(
-        `${tsc ? tsc : 'tsc'} --noEmit ${isDev ? '--watch' : ''} ${args ? args : ''}`,
+        `${tsc ? tsc : 'tsc'} ${args ? args : ''} --noEmit ${isDev ? '--watch' : ''}`,
         {
           env: npmRunPath.env(),
           extendEnv: true,


### PR DESCRIPTION
## Changes

TypeScript plugin will now be able to use other tsconfig as `--build` needs to be the first parameter for `tsc`. It could be of course workaround with switching from `tsc` to `tsc --build someconfig.json`, but it is not elegant as `--build` flag is the tsc param.

## Testing
Tests are passing. No need to update test.

## Docs

No need to update as this is a bug fix.

By the way I am interested in actively contributing to snowpack as it looks promising :).