### PR TITLE
docs(plugins): fix typescript types link

### DIFF
--- a/www/_template/reference/plugins.md
+++ b/www/_template/reference/plugins.md
@@ -6,7 +6,7 @@ description: The Snowpack Plugin API and how to use it.
 
 Looking to get started writing your own plugin? Check out our [Plugin Guide](/guides/plugins) for an overview of how plugins work and a walk-through to help you create your own.
 
-Looking for a good summary? Check out our ["SnowpackPlugin" TypeScript definition](https://github.com/snowpackjs/snowpack/tree/main/snowpack/src/types/snowpack.ts) for a fully documented and up-to-date overview of the Plugin API and all supported options.
+Looking for a good summary? Check out our ["SnowpackPlugin" TypeScript definition](https://github.com/snowpackjs/snowpack/blob/main/snowpack/src/types.ts#L130) for a fully documented and up-to-date overview of the Plugin API and all supported options.
 
 ### Overview
 


### PR DESCRIPTION
## Changes
Fix broken TS types link
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing
n/a
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs
Plugins section updated
<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
