### PR TITLE
Docs: fix preact alias config

### DIFF
--- a/www/_template/guides/preact.md
+++ b/www/_template/guides/preact.md
@@ -14,10 +14,8 @@ You can import and use Preact without any custom configuration needed.
 ```js
 // Example: Lets you import "react" in your application, but uses preact internally
 // snowpack.config.json
-"installOptions": {
-  "alias": {
+"alias": {
     "react": "preact/compat",
     "react-dom": "preact/compat"
-  }
 }
 ```


### PR DESCRIPTION
## Changes

The changes made reflect v2.7 the snowpack config for preact via alias.

## Testing

The error with the previous config was:
'[New in v2.7] `installOptions.alias` has been moved to a top-level `alias` config. (https://snowpack.dev#all-config-options)'.

The error no longer occurs after the change.

## Docs

The change is for the docs.

[Note]: This is my first pull request to a public library :)