### PR TITLE
fix(plugin-react-refresh): typo in warning message

### DIFF
--- a/plugins/plugin-react-refresh/plugin.js
+++ b/plugins/plugin-react-refresh/plugin.js
@@ -67,7 +67,7 @@ async function transformJs(contents, id, cwd, skipTransform) {
 /** React Refresh: Setup **/
 if (import.meta.hot) {
   if (!window.$RefreshReg$ || !window.$RefreshSig$ || !window.$RefreshRuntime$) {
-    console.warn('@snowpack/plugin-react-refresh: HTML setup script not run. React Fast Refresh only works when Snowpack serves your HTML routes. You many want to remove this plugin.');
+    console.warn('@snowpack/plugin-react-refresh: HTML setup script not run. React Fast Refresh only works when Snowpack serves your HTML routes. You may want to remove this plugin.');
   } else {
     var prevRefreshReg = window.$RefreshReg$;
     var prevRefreshSig = window.$RefreshSig$;

--- a/plugins/plugin-react-refresh/test/__snapshots__/plugin.test.js.snap
+++ b/plugins/plugin-react-refresh/test/__snapshots__/plugin.test.js.snap
@@ -1428,7 +1428,7 @@ exports[`@snowpack/plugin-react-refresh transform js and html: js 1`] = `
 /** React Refresh: Setup **/
 if (import.meta.hot) {
   if (!window.$RefreshReg$ || !window.$RefreshSig$ || !window.$RefreshRuntime$) {
-    console.warn('@snowpack/plugin-react-refresh: HTML setup script not run. React Fast Refresh only works when Snowpack serves your HTML routes. You many want to remove this plugin.');
+    console.warn('@snowpack/plugin-react-refresh: HTML setup script not run. React Fast Refresh only works when Snowpack serves your HTML routes. You may want to remove this plugin.');
   } else {
     var prevRefreshReg = window.$RefreshReg$;
     var prevRefreshSig = window.$RefreshSig$;


### PR DESCRIPTION
Typo in `HTML setup script not run` warning message.

## Changes

I fix a typo in the warning message under the plugin-react-refresh.

## Testing

This is a typo, It seems that no need to test anything, Just read the difference.

## Docs

No need to update the docs, Because this MR only update a typo, and nothing was developed also there is nothing fixed, This is only a typo in the warning message.
