### PR TITLE
Change eslint example command

### DIFF
--- a/www/_template/guides/connecting-tools.md
+++ b/www/_template/guides/connecting-tools.md
@@ -103,7 +103,7 @@ The [`postcss-cli`](https://github.com/postcss/postcss-cli) package must be inst
 // snowpack.config.json
 "plugins": [
   ["@snowpack/plugin-run-script", {
-    "cmd": "eslint \"src/**/*.{js,jsx,ts,tsx}\"",
+    "cmd": "eslint src --ext .js,jsx,.ts,.tsx",
     // Optional: Use npm package "watch" to run on every file change
     "watch": "watch \"$1\" src"
   }]

--- a/www/_template/guides/connecting-tools.md
+++ b/www/_template/guides/connecting-tools.md
@@ -104,8 +104,8 @@ The [`postcss-cli`](https://github.com/postcss/postcss-cli) package must be inst
 "plugins": [
   ["@snowpack/plugin-run-script", {
     "cmd": "eslint src --ext .js,jsx,.ts,.tsx",
-    // Optional: Use npm package "watch" to run on every file change
-    "watch": "watch \"$1\" src"
+    // Optional: Use npm package "eslint-watch" to run on every file change
+    "watch": "esw -w --clear src --ext .js,jsx,.ts,.tsx"
   }]
 ]
 ```


### PR DESCRIPTION
`eslint` seems to fail on globbing if files with some of the extensions do not exist in the path - updated the example to using the `--ext` option instead.

## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
