### PR TITLE
Add more ANSI clear sequences found in the wild

### DIFF
--- a/plugins/plugin-run-script/plugin.js
+++ b/plugins/plugin-run-script/plugin.js
@@ -1,6 +1,11 @@
 const execa = require('execa');
 const npmRunPath = require('npm-run-path');
 
+const CLEAR_SEQUENCES = [
+  '\x1Bc',
+  '\x1B[2J\x1B[0;0f',
+]
+
 function runScriptPlugin(snowpackConfig, {name, cmd, watch, output}) {
   const [cmdProgram] = cmd.split(' ');
   const watchCmd = watch && watch.replace('$1', cmd);
@@ -22,9 +27,11 @@ function runScriptPlugin(snowpackConfig, {name, cmd, watch, output}) {
           log('CONSOLE_INFO', {msg: stdOutput});
           return;
         }
-        if (stdOutput.includes('\u001bc') || stdOutput.includes('\x1Bc')) {
-          log('WORKER_RESET', {});
-          stdOutput = stdOutput.replace(/\x1Bc/, '').replace(/\u001bc/, '');
+        if (CLEAR_SEQUENCES.some(s => stdOutput.includes(s))) {
+            log('WORKER_RESET', {});
+            for (let s of CLEAR_SEQUENCES) {
+                stdOutput = stdOutput.replace(s, '');
+            }
         }
         if (cmdProgram === 'tsc') {
           const errorMatch = stdOutput.match(/Found (\d+) error/);


### PR DESCRIPTION
As used in `eslint-watch`:

https://github.com/rizowski/eslint-watch/blob/6669791c2bbd3209a047377738404f959fadde9b/src/commands/clear.js

## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
