### PR TITLE
support clean urls (e.g. "/about" -> "/about.html") for built html files

### DIFF
--- a/test-dev/__snapshots__/dev.test.ts.snap
+++ b/test-dev/__snapshots__/dev.test.ts.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`snowpack dev smoke: about 1`] = `
+"<!DOCTYPE html>
+<html>
+  <head><script type=\\"module\\" integrity=\\"sha384-ZsG+E+8Q6Yh0v98Nd0SfOT1bOX82TJaNaBS1npTZYuq4oD09c6rDD2R9pXqMvter\\" src=\\"/__snowpack__/hmr-client.js\\"></script><script type=\\"module\\" integrity=\\"sha384-LH/mFhEGRB4jHedP0nqOoIUwc4VX8eWJxEL+qTGWtroqiLJ2vxX169J0oSBMHL5o\\" src=\\"/__snowpack__/hmr-error-overlay.js\\"></script></head>
+  <body>
+    <p>this is a template in some language that builds to .html</p>
+  </body>
+</html>"
+`;
+
 exports[`snowpack dev smoke: html 1`] = `
 "<!DOCTYPE html>
 <html lang=\\"en\\">

--- a/test-dev/dev.test.ts
+++ b/test-dev/dev.test.ts
@@ -22,7 +22,7 @@ describe('snowpack dev', () => {
   });
 
   it('smoke', async () => {
-    expect.assertions(3);
+    expect.assertions(4);
 
     const cwd = path.join(__dirname, 'smoke');
 
@@ -65,5 +65,9 @@ describe('snowpack dev', () => {
     // get built JS
     const {data: jsBody} = await get('http://localhost:8080/_dist_/index.js');
     expect(jsBody).toMatchSnapshot('js');
+
+    // get built HTML
+    const {data: aboutBody} = await get('http://localhost:8080/about');
+    expect(aboutBody).toMatchSnapshot('about');
   });
 });

--- a/test-dev/smoke/package.json
+++ b/test-dev/smoke/package.json
@@ -1,14 +1,6 @@
 {
-  "snowpack": {
-    "devOptions": {
-      "open": "none"
-    },
-    "mount": {
-      "public": "/",
-      "src": "/_dist_"
-    }
-  },
   "dependencies": {
+    "@snowpack/plugin-build-script": "^2.0.7",
     "canvas-confetti": "^1.2.0",
     "snowpack": "^2.14.3"
   }

--- a/test-dev/smoke/public/about.tmpl
+++ b/test-dev/smoke/public/about.tmpl
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+    <p>this is a template in some language that builds to .html</p>
+  </body>
+</html>

--- a/test-dev/smoke/snowpack.config.js
+++ b/test-dev/smoke/snowpack.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+  devOptions: {
+    open: "none"
+  },
+  mount: {
+    public: "/",
+    src: "/_dist_"
+  },
+  plugins: [
+    [
+      '@snowpack/plugin-build-script',
+      {
+        input: ['.tmpl'],
+        output: ['.html'],
+        cmd: 'cat $FILE',
+      },
+    ],
+  ],
+};


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
Previously, the dev server would only resolve bare routes to `.html` files (e.g. "/" -> "/index.html", "/foo" -> "/foo.html", etc...) when the `.html` file actually exists on disk; if the `.html` file was built by a plugin it could only be served from its exact path.

I encountered this when writing [a plugin](https://github.com/mxmul/snowpack-plugin-nunjucks) that builds Nunjucks templates to html. It was surprising that I could access the output from `localhost:8080/index.html` but not `localhost:8080/`.

With this diff, we try to build those files when they don't exist on disk.

Fixes #2023

## Testing

<!-- How was this change tested? -->
Added a regression test to `./test-dev/dev.test.ts`

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
bug fix only
