### PR TITLE
Add @types/mocha to the react-TS template to support yarn 2

### DIFF
--- a/create-snowpack-app/app-template-react-typescript/package.json
+++ b/create-snowpack-app/app-template-react-typescript/package.json
@@ -33,6 +33,7 @@
     "@snowpack/web-test-runner-plugin": "^0.1.4",
     "@testing-library/react": "^11.0.0",
     "@types/chai": "^4.2.13",
+    "@types/mocha": "^8.2.0",
     "@types/react": "^16.9.49",
     "@types/react-dom": "^16.9.8",
     "@types/snowpack-env": "^2.3.2",


### PR DESCRIPTION
I was writing an e2e test for yarn 2 (see https://github.com/yarnpkg/berry/pull/2341) and noticed that I get this 

```
> yarn dlx create-snowpack-app my-csa-ts --template @snowpack/app-template-react-typescript --use-yarn
> cd my-csa-ts && yarn build
....
[@snowpack/plugin-typescript] src/App.test.tsx(6,1): error TS2582: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha`.
[@snowpack/plugin-typescript] src/App.test.tsx(7,3): error TS2582: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha`.
[@snowpack/plugin-typescript] Error: Command failed with exit code 2: tsc --noEmit
src/App.test.tsx(6,1): error TS2582: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha`.
src/App.test.tsx(7,3): error TS2582: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha`.
```

That is solved by adding `@types/mocha`, which I believe `@web/test-runner` uses under the hood. On npm and yarn 1 it probably works because `@types/mocha` is a transitive dependency somewhere and thus the typescripts compiler sees it in the `node_modules` folder, but yarn 2 needs it to be more explicit.