### PR TITLE
Typo in config docs code block

### DIFF
--- a/www/_template/reference/configuration.md
+++ b/www/_template/reference/configuration.md
@@ -17,7 +17,7 @@ module.exports = {
 // Example: snowpack.config.js (ESM)
 // This is ESM-format config file. to enable
 // Add "type": "module" in your package.json
-export **Default** {
+export default {
   plugins: [
     /* ... */
   ],


### PR DESCRIPTION
## Changes

Fixes a typo in a code block in the configuration docs

## Testing

NA

## Docs

Is docs