### PR TITLE
Add support for export map trailing slash + star mapping object values

### DIFF
--- a/esinstall/src/entrypoints.ts
+++ b/esinstall/src/entrypoints.ts
@@ -212,14 +212,14 @@ const picoMatchGlobalOptions = Object.freeze({
 
 function* forEachExportEntry(
   exportField: ExportField,
-): Generator<[string, unknown], any, undefined> {
+): Generator<[string, ExportMapEntry], any, undefined> {
   const simpleExportMap = findExportMapEntry(exportField);
 
   // Handle case where export map is a string, or if there‘s only one file in the entire export map
   if (simpleExportMap) {
     yield ['.', simpleExportMap];
 
-    return;
+    return undefined;
   }
 
   for (const [key, val] of Object.entries(exportField)) {
@@ -278,7 +278,9 @@ function* forEachExportEntryExploded(
     // Deprecated but we still want to support this.
     // https://nodejs.org/api/packages.html#packages_subpath_folder_mappings
     if (key.endsWith('/')) {
-      if (typeof val !== 'string') {
+      const keyValue = findExportMapEntry(val);
+
+      if (typeof keyValue !== 'string') {
         continue;
       }
 
@@ -287,17 +289,19 @@ function* forEachExportEntryExploded(
         continue;
       }
 
-      yield* forEachWildcardEntry(key + '*', val + '*', cwd);
+      yield* forEachWildcardEntry(key + '*', keyValue + '*', cwd);
 
       continue;
     }
 
     // Wildcards https://nodejs.org/api/packages.html#packages_subpath_patterns
     if (key.includes('*')) {
-      if (typeof val !== 'string') {
+      const keyValue = findExportMapEntry(val);
+
+      if (typeof keyValue !== 'string') {
         continue;
       }
-      yield* forEachWildcardEntry(key, val, cwd);
+      yield* forEachWildcardEntry(key, keyValue, cwd);
 
       continue;
     }

--- a/test/esinstall.api.test.js
+++ b/test/esinstall.api.test.js
@@ -217,5 +217,62 @@ describe('ESInstall API', () => {
         './extras/three': './src/extras/three.js',
       });
     });
+
+    it('explodes wildcard exports with object values', () => {
+      let map = explodeExportMap(
+        {
+          '.': './entrypoint.js',
+          './extras/*': {
+            import: './src/extras/*.js',
+          },
+        },
+        {cwd: __dirname + '/esinstall/package-entrypoints/export-map-star'},
+      );
+
+      expect(map).toStrictEqual({
+        '.': './entrypoint.js',
+        './extras/one': './src/extras/one.js',
+        './extras/two': './src/extras/two.js',
+        './extras/three': './src/extras/three.js',
+      });
+    });
+
+    it('explodes trailing slash exports', () => {
+      let map = explodeExportMap(
+        {
+          '.': './entrypoint.js',
+          './extras/': './src/extras/',
+        },
+        {cwd: __dirname + '/esinstall/package-entrypoints/export-map-trailing-slash'},
+      );
+
+      expect(map).toStrictEqual({
+        '.': './entrypoint.js',
+        './extras/one.js': './src/extras/one.js',
+        './extras/other.css': './src/extras/other.css',
+        './extras/two.js': './src/extras/two.js',
+        './extras/three.js': './src/extras/three.js',
+      });
+    });
+
+    it('explodes trailing slash exports with object values', () => {
+      let map = explodeExportMap(
+        {
+          '.': './entrypoint.js',
+          './extras/': {
+            default: './src/extras/',
+          },
+        },
+        {cwd: __dirname + '/esinstall/package-entrypoints/export-map-trailing-slash'},
+      );
+
+      expect(map).toStrictEqual({
+        '.': './entrypoint.js',
+        './extras/one.js': './src/extras/one.js',
+        './extras/other.css': './src/extras/other.css',
+        './extras/two.js': './src/extras/two.js',
+        './extras/three.js': './src/extras/three.js',
+      });
+    });
   });
 });

--- a/test/esinstall/package-entrypoints/export-map-trailing-slash/entrypoint.js
+++ b/test/esinstall/package-entrypoints/export-map-trailing-slash/entrypoint.js
@@ -1,0 +1,1 @@
+export const a = 'b';

--- a/test/esinstall/package-entrypoints/export-map-trailing-slash/package.json
+++ b/test/esinstall/package-entrypoints/export-map-trailing-slash/package.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.2.3",
+  "name": "export-map-star",
+  "description": "With star (wildcards)",
+  "exports": {
+    ".": "./entrypoint.js",
+    "./extras/": "./src/extras/",
+    "./more/": {
+      "default": "./src/more/",
+      "fake_prop": "./error/more/"
+    }
+  }
+}

--- a/test/esinstall/package-entrypoints/export-map-trailing-slash/src/extras/one.js
+++ b/test/esinstall/package-entrypoints/export-map-trailing-slash/src/extras/one.js
@@ -1,0 +1,1 @@
+export const one = 'one';

--- a/test/esinstall/package-entrypoints/export-map-trailing-slash/src/extras/other.css
+++ b/test/esinstall/package-entrypoints/export-map-trailing-slash/src/extras/other.css
@@ -1,0 +1,2 @@
+/* This should not be included */
+body { background: darkorchid; }

--- a/test/esinstall/package-entrypoints/export-map-trailing-slash/src/extras/three.js
+++ b/test/esinstall/package-entrypoints/export-map-trailing-slash/src/extras/three.js
@@ -1,0 +1,1 @@
+export const three = 'three';

--- a/test/esinstall/package-entrypoints/export-map-trailing-slash/src/extras/two.js
+++ b/test/esinstall/package-entrypoints/export-map-trailing-slash/src/extras/two.js
@@ -1,0 +1,1 @@
+export const two = 'two';

--- a/test/esinstall/package-entrypoints/export-map-trailing-slash/src/more/one.js
+++ b/test/esinstall/package-entrypoints/export-map-trailing-slash/src/more/one.js
@@ -1,0 +1,1 @@
+export const a = 'b';

--- a/test/esinstall/package-entrypoints/package-entrypoints-export-map.test.js
+++ b/test/esinstall/package-entrypoints/package-entrypoints-export-map.test.js
@@ -89,6 +89,33 @@ describe('package-entrypoints exports configuration', () => {
     });
   });
 
+  it('"exports" trailing slash', async () => {
+    const cwd = __dirname;
+    const dest = path.join(cwd, 'test-export-map-trailing-slash');
+    const targets = [
+      'export-map-trailing-slash',
+      'export-map-trailing-slash/extras/one.js',
+      'export-map-trailing-slash/extras/two.js',
+      'export-map-trailing-slash/extras/three.js',
+      'export-map-trailing-slash/more/one.js',
+    ];
+
+    const {
+      importMap: {imports},
+    } = await install(targets, {
+      cwd,
+      dest,
+    });
+
+    expect(imports).toStrictEqual({
+      'export-map-trailing-slash': './export-map-trailing-slash.js',
+      'export-map-trailing-slash/extras/one.js': './export-map-trailing-slash/extras/one.js',
+      'export-map-trailing-slash/extras/three.js': './export-map-trailing-slash/extras/three.js',
+      'export-map-trailing-slash/extras/two.js': './export-map-trailing-slash/extras/two.js',
+      'export-map-trailing-slash/more/one.js': './export-map-trailing-slash/more/one.js',
+    });
+  });
+
   it.skip('"exports" with arrays', async () => {
     // This should be in the "supports all of the variations" test, putting here for visibility.
     /**
@@ -99,7 +126,7 @@ describe('package-entrypoints exports configuration', () => {
      */
   });
 
-  it.only("supports preact's configuration", async () => {
+  it("supports preact's configuration", async () => {
     const cwd = __dirname;
     const dest = path.join(cwd, 'test-export-preact');
 

--- a/test/esinstall/package-entrypoints/package.json
+++ b/test/esinstall/package-entrypoints/package.json
@@ -24,6 +24,7 @@
     "export-map-object-require": "file:./export-map-object-require",
     "export-map-object-no-key": "file:./export-map-object-no-key",
     "export-map-star": "file:./export-map-star",
+    "export-map-trailing-slash": "file:./export-map-trailing-slash",
     "preact": "^10.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6907,6 +6907,9 @@ expect@^26.6.2:
 "export-map-star@file:./test/esinstall/package-entrypoints/export-map-star":
   version "1.2.3"
 
+"export-map-trailing-slash@file:./test/esinstall/package-entrypoints/export-map-trailing-slash":
+  version "1.2.3"
+
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"


### PR DESCRIPTION
## Changes

This adds support for these scenarios:

```json
"./extras/": {
  "development": "./src/extras/"
}
```

```json
"./extras/*": {
  "development": "./src/extras/*"
}
```

Where the value is an object and not a string. This fixes the export map in lit-html@2.0.0-pre.5

## Testing

Tests added for all of the scenarios.

## Docs

N/A