### PR TITLE
fix: fix bug about tsconfig  bug.

### DIFF
--- a/plugins/plugin-typescript/README.md
+++ b/plugins/plugin-typescript/README.md
@@ -25,4 +25,4 @@ module.exports = {
 | Name   |   Type   | Description                                                                                                                                                                               |
 | :----- | :------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `tsc`  | `string` | Optional custom tsc command. For example, you can use TypeScript compiler by specifying: `tsc: "tsc"`.                                                                                    |
-| `args` | `string` | Optional arguments to pass to the `tsc` CLI. For example, you can configure a custom project directory (with a custom `tsconfig.json` file) using `args: "--project ./your/custom/path"`. |
+| `args` | `string` | Optional arguments to pass to the `tsc` CLI. For example, you can configure a custom project directory (with a custom `tsconfig.json` file) using `args: "--project ./your/custom/path"`. The default value is `"--project ${rootDir}/tsconfig.json"`.|

--- a/plugins/plugin-typescript/plugin.js
+++ b/plugins/plugin-typescript/plugin.js
@@ -1,7 +1,7 @@
 const execa = require('execa');
 const npmRunPath = require('npm-run-path');
 
-function typescriptPlugin(snowpackConfig, {tsc, args = `--project ${cwd}/tsconfig.json`} = {}) {
+function typescriptPlugin(snowpackConfig, {tsc, args = `--project ${snowpackConfig.root || process.cwd()}/tsconfig.json`} = {}) {
   return {
     name: '@snowpack/plugin-typescript',
     async run({isDev, log}) {

--- a/plugins/plugin-typescript/plugin.js
+++ b/plugins/plugin-typescript/plugin.js
@@ -1,7 +1,7 @@
 const execa = require('execa');
 const npmRunPath = require('npm-run-path');
 
-function typescriptPlugin(snowpackConfig, {tsc, args} = {}) {
+function typescriptPlugin(snowpackConfig, {tsc, args = `--project ${cwd}/tsconfig.json`} = {}) {
   return {
     name: '@snowpack/plugin-typescript',
     async run({isDev, log}) {


### PR DESCRIPTION
## Changes

In most cases. When users import the official typescript plugin. The path of tsconfig.json is in the root dir. So we should set the default value to the arg field. It can also fix the bug https://github.com/snowpackjs/snowpack/discussions/2190.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing
All tests have been passed.
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs
Have been updated.
<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
