### PR TITLE
Update hot-module-replacement.md

### DIFF
--- a/www/_template/reference/hot-module-replacement.md
+++ b/www/_template/reference/hot-module-replacement.md
@@ -15,6 +15,6 @@ if (import.meta.hot) {
 }
 ```
 
-Full API Reference: [snowpack/esm-hmr on GithUb](https://github.com/snowpackjs/esm-hmr)
+Full API Reference: [snowpack/esm-hmr on GitHub](https://github.com/snowpackjs/esm-hmr)
 
 [Learn more](/concepts/hot-module-replacement) about HMR, Fast Refresh, and how it's meant to work in Snowpack.


### PR DESCRIPTION
Update page to fix spelling of GitHub from GithUb

## Changes

<!-- What does this change, in plain language? -->
There was a spelling mistake in GitHub. It was GithUb which was hurting my brain.
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->
Not tested due to just a text change

## Docs

<!-- Was public documentation updated? -->
Yes. That is the whole commit.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
