### PR TITLE
Add Sourcemap support to plugin-react-refresh.

### DIFF
--- a/plugins/plugin-react-refresh/babel-plugin-wrap.js
+++ b/plugins/plugin-react-refresh/babel-plugin-wrap.js
@@ -1,0 +1,30 @@
+
+module.exports = function (babel) {
+  const { types: t } = babel;
+
+  function parseCode(code) {
+  	const block = babel.parse(code);
+    const body = block.program.body;
+    return body.length === 0 ? block.comments : body;
+  }
+
+  return {
+    name: "babel-plugin-wrap",
+    visitor: {
+      Program: {
+        exit(path, state) {
+          const {header, footer} = state.opts
+          if (header) {
+            const headerNodes = parseCode(header);
+            path.unshiftContainer('body', ...headerNodes);
+          }
+
+          if (footer) {
+            const footerNodes = parseCode(footer);
+            path.pushContainer('body', ...footerNodes);
+          }
+        }
+      }
+    }
+  };
+}

--- a/plugins/plugin-react-refresh/test/__snapshots__/plugin.test.js.snap
+++ b/plugins/plugin-react-refresh/test/__snapshots__/plugin.test.js.snap
@@ -723,11 +723,785 @@ exports[`@snowpack/plugin-react-refresh transform js and html when hmr is disabl
 
 exports[`@snowpack/plugin-react-refresh transform js and html when hmr is disabled: js and isDev=false 1`] = `undefined`;
 
-exports[`@snowpack/plugin-react-refresh transform js and html when sourceMaps is enabled: html 1`] = `undefined`;
+exports[`@snowpack/plugin-react-refresh transform js and html when sourceMaps is enabled: html 1`] = `
+"<!DOCTYPE html>
+<html lang=\\"en\\">
+  <head>
+    <meta charset=\\"utf-8\\" />
+    <link rel=\\"icon\\" href=\\"/favicon.ico\\" />
+    <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\" />
+    <meta name=\\"description\\" content=\\"Web site created using create-snowpack-app\\" />
+  </head>
+  <body>
+<script>
+  function debounce(e,t){let u;return()=>{clearTimeout(u),u=setTimeout(e,t)}}
+  {
+    const exports = {};
+    /** @license React v0.9.0
+ * react-refresh-runtime.development.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+if (\\"development\\" !== \\"production\\") {
+  (function() {
+'use strict';
+
+// ATTENTION
+// When adding new symbols to this file,
+// Please consider also adding to 'react-devtools-shared/src/backend/ReactSymbols'
+// The Symbol used to tag the ReactElement-like types. If there is no native Symbol
+// nor polyfill, then a plain number is used for performance.
+var REACT_ELEMENT_TYPE = 0xeac7;
+var REACT_PORTAL_TYPE = 0xeaca;
+var REACT_FRAGMENT_TYPE = 0xeacb;
+var REACT_STRICT_MODE_TYPE = 0xeacc;
+var REACT_PROFILER_TYPE = 0xead2;
+var REACT_PROVIDER_TYPE = 0xeacd;
+var REACT_CONTEXT_TYPE = 0xeace;
+var REACT_FORWARD_REF_TYPE = 0xead0;
+var REACT_SUSPENSE_TYPE = 0xead1;
+var REACT_SUSPENSE_LIST_TYPE = 0xead8;
+var REACT_MEMO_TYPE = 0xead3;
+var REACT_LAZY_TYPE = 0xead4;
+var REACT_BLOCK_TYPE = 0xead9;
+var REACT_SERVER_BLOCK_TYPE = 0xeada;
+var REACT_FUNDAMENTAL_TYPE = 0xead5;
+var REACT_SCOPE_TYPE = 0xead7;
+var REACT_OPAQUE_ID_TYPE = 0xeae0;
+var REACT_DEBUG_TRACING_MODE_TYPE = 0xeae1;
+var REACT_OFFSCREEN_TYPE = 0xeae2;
+var REACT_LEGACY_HIDDEN_TYPE = 0xeae3;
+
+if (typeof Symbol === 'function' && Symbol.for) {
+  var symbolFor = Symbol.for;
+  REACT_ELEMENT_TYPE = symbolFor('react.element');
+  REACT_PORTAL_TYPE = symbolFor('react.portal');
+  REACT_FRAGMENT_TYPE = symbolFor('react.fragment');
+  REACT_STRICT_MODE_TYPE = symbolFor('react.strict_mode');
+  REACT_PROFILER_TYPE = symbolFor('react.profiler');
+  REACT_PROVIDER_TYPE = symbolFor('react.provider');
+  REACT_CONTEXT_TYPE = symbolFor('react.context');
+  REACT_FORWARD_REF_TYPE = symbolFor('react.forward_ref');
+  REACT_SUSPENSE_TYPE = symbolFor('react.suspense');
+  REACT_SUSPENSE_LIST_TYPE = symbolFor('react.suspense_list');
+  REACT_MEMO_TYPE = symbolFor('react.memo');
+  REACT_LAZY_TYPE = symbolFor('react.lazy');
+  REACT_BLOCK_TYPE = symbolFor('react.block');
+  REACT_SERVER_BLOCK_TYPE = symbolFor('react.server.block');
+  REACT_FUNDAMENTAL_TYPE = symbolFor('react.fundamental');
+  REACT_SCOPE_TYPE = symbolFor('react.scope');
+  REACT_OPAQUE_ID_TYPE = symbolFor('react.opaque.id');
+  REACT_DEBUG_TRACING_MODE_TYPE = symbolFor('react.debug_trace_mode');
+  REACT_OFFSCREEN_TYPE = symbolFor('react.offscreen');
+  REACT_LEGACY_HIDDEN_TYPE = symbolFor('react.legacy_hidden');
+}
+
+var PossiblyWeakMap = typeof WeakMap === 'function' ? WeakMap : Map; // We never remove these associations.
+// It's OK to reference families, but use WeakMap/Set for types.
+
+var allFamiliesByID = new Map();
+var allFamiliesByType = new PossiblyWeakMap();
+var allSignaturesByType = new PossiblyWeakMap(); // This WeakMap is read by React, so we only put families
+// that have actually been edited here. This keeps checks fast.
+// $FlowIssue
+
+var updatedFamiliesByType = new PossiblyWeakMap(); // This is cleared on every performReactRefresh() call.
+// It is an array of [Family, NextType] tuples.
+
+var pendingUpdates = []; // This is injected by the renderer via DevTools global hook.
+
+var helpersByRendererID = new Map();
+var helpersByRoot = new Map(); // We keep track of mounted roots so we can schedule updates.
+
+var mountedRoots = new Set(); // If a root captures an error, we remember it so we can retry on edit.
+
+var failedRoots = new Set(); // In environments that support WeakMap, we also remember the last element for every root.
+// It needs to be weak because we do this even for roots that failed to mount.
+// If there is no WeakMap, we won't attempt to do retrying.
+// $FlowIssue
+
+var rootElements = // $FlowIssue
+typeof WeakMap === 'function' ? new WeakMap() : null;
+var isPerformingRefresh = false;
+
+function computeFullKey(signature) {
+  if (signature.fullKey !== null) {
+    return signature.fullKey;
+  }
+
+  var fullKey = signature.ownKey;
+  var hooks;
+
+  try {
+    hooks = signature.getCustomHooks();
+  } catch (err) {
+    // This can happen in an edge case, e.g. if expression like Foo.useSomething
+    // depends on Foo which is lazily initialized during rendering.
+    // In that case just assume we'll have to remount.
+    signature.forceReset = true;
+    signature.fullKey = fullKey;
+    return fullKey;
+  }
+
+  for (var i = 0; i < hooks.length; i++) {
+    var hook = hooks[i];
+
+    if (typeof hook !== 'function') {
+      // Something's wrong. Assume we need to remount.
+      signature.forceReset = true;
+      signature.fullKey = fullKey;
+      return fullKey;
+    }
+
+    var nestedHookSignature = allSignaturesByType.get(hook);
+
+    if (nestedHookSignature === undefined) {
+      // No signature means Hook wasn't in the source code, e.g. in a library.
+      // We'll skip it because we can assume it won't change during this session.
+      continue;
+    }
+
+    var nestedHookKey = computeFullKey(nestedHookSignature);
+
+    if (nestedHookSignature.forceReset) {
+      signature.forceReset = true;
+    }
+
+    fullKey += '\\\\n---\\\\n' + nestedHookKey;
+  }
+
+  signature.fullKey = fullKey;
+  return fullKey;
+}
+
+function haveEqualSignatures(prevType, nextType) {
+  var prevSignature = allSignaturesByType.get(prevType);
+  var nextSignature = allSignaturesByType.get(nextType);
+
+  if (prevSignature === undefined && nextSignature === undefined) {
+    return true;
+  }
+
+  if (prevSignature === undefined || nextSignature === undefined) {
+    return false;
+  }
+
+  if (computeFullKey(prevSignature) !== computeFullKey(nextSignature)) {
+    return false;
+  }
+
+  if (nextSignature.forceReset) {
+    return false;
+  }
+
+  return true;
+}
+
+function isReactClass(type) {
+  return type.prototype && type.prototype.isReactComponent;
+}
+
+function canPreserveStateBetween(prevType, nextType) {
+  if (isReactClass(prevType) || isReactClass(nextType)) {
+    return false;
+  }
+
+  if (haveEqualSignatures(prevType, nextType)) {
+    return true;
+  }
+
+  return false;
+}
+
+function resolveFamily(type) {
+  // Only check updated types to keep lookups fast.
+  return updatedFamiliesByType.get(type);
+} // If we didn't care about IE11, we could use new Map/Set(iterable).
+
+
+function cloneMap(map) {
+  var clone = new Map();
+  map.forEach(function (value, key) {
+    clone.set(key, value);
+  });
+  return clone;
+}
+
+function cloneSet(set) {
+  var clone = new Set();
+  set.forEach(function (value) {
+    clone.add(value);
+  });
+  return clone;
+}
+
+function performReactRefresh() {
+
+  if (pendingUpdates.length === 0) {
+    return null;
+  }
+
+  if (isPerformingRefresh) {
+    return null;
+  }
+
+  isPerformingRefresh = true;
+
+  try {
+    var staleFamilies = new Set();
+    var updatedFamilies = new Set();
+    var updates = pendingUpdates;
+    pendingUpdates = [];
+    updates.forEach(function (_ref) {
+      var family = _ref[0],
+          nextType = _ref[1];
+      // Now that we got a real edit, we can create associations
+      // that will be read by the React reconciler.
+      var prevType = family.current;
+      updatedFamiliesByType.set(prevType, family);
+      updatedFamiliesByType.set(nextType, family);
+      family.current = nextType; // Determine whether this should be a re-render or a re-mount.
+
+      if (canPreserveStateBetween(prevType, nextType)) {
+        updatedFamilies.add(family);
+      } else {
+        staleFamilies.add(family);
+      }
+    }); // TODO: rename these fields to something more meaningful.
+
+    var update = {
+      updatedFamilies: updatedFamilies,
+      // Families that will re-render preserving state
+      staleFamilies: staleFamilies // Families that will be remounted
+
+    };
+    helpersByRendererID.forEach(function (helpers) {
+      // Even if there are no roots, set the handler on first update.
+      // This ensures that if *new* roots are mounted, they'll use the resolve handler.
+      helpers.setRefreshHandler(resolveFamily);
+    });
+    var didError = false;
+    var firstError = null; // We snapshot maps and sets that are mutated during commits.
+    // If we don't do this, there is a risk they will be mutated while
+    // we iterate over them. For example, trying to recover a failed root
+    // may cause another root to be added to the failed list -- an infinite loop.
+
+    var failedRootsSnapshot = cloneSet(failedRoots);
+    var mountedRootsSnapshot = cloneSet(mountedRoots);
+    var helpersByRootSnapshot = cloneMap(helpersByRoot);
+    failedRootsSnapshot.forEach(function (root) {
+      var helpers = helpersByRootSnapshot.get(root);
+
+      if (helpers === undefined) {
+        throw new Error('Could not find helpers for a root. This is a bug in React Refresh.');
+      }
+
+      if (!failedRoots.has(root)) {// No longer failed.
+      }
+
+      if (rootElements === null) {
+        return;
+      }
+
+      if (!rootElements.has(root)) {
+        return;
+      }
+
+      var element = rootElements.get(root);
+
+      try {
+        helpers.scheduleRoot(root, element);
+      } catch (err) {
+        if (!didError) {
+          didError = true;
+          firstError = err;
+        } // Keep trying other roots.
+
+      }
+    });
+    mountedRootsSnapshot.forEach(function (root) {
+      var helpers = helpersByRootSnapshot.get(root);
+
+      if (helpers === undefined) {
+        throw new Error('Could not find helpers for a root. This is a bug in React Refresh.');
+      }
+
+      if (!mountedRoots.has(root)) {// No longer mounted.
+      }
+
+      try {
+        helpers.scheduleRefresh(root, update);
+      } catch (err) {
+        if (!didError) {
+          didError = true;
+          firstError = err;
+        } // Keep trying other roots.
+
+      }
+    });
+
+    if (didError) {
+      throw firstError;
+    }
+
+    return update;
+  } finally {
+    isPerformingRefresh = false;
+  }
+}
+function register(type, id) {
+  {
+    if (type === null) {
+      return;
+    }
+
+    if (typeof type !== 'function' && typeof type !== 'object') {
+      return;
+    } // This can happen in an edge case, e.g. if we register
+    // return value of a HOC but it returns a cached component.
+    // Ignore anything but the first registration for each type.
+
+
+    if (allFamiliesByType.has(type)) {
+      return;
+    } // Create family or remember to update it.
+    // None of this bookkeeping affects reconciliation
+    // until the first performReactRefresh() call above.
+
+
+    var family = allFamiliesByID.get(id);
+
+    if (family === undefined) {
+      family = {
+        current: type
+      };
+      allFamiliesByID.set(id, family);
+    } else {
+      pendingUpdates.push([family, type]);
+    }
+
+    allFamiliesByType.set(type, family); // Visit inner types because we might not have registered them.
+
+    if (typeof type === 'object' && type !== null) {
+      switch (type.$typeof) {
+        case REACT_FORWARD_REF_TYPE:
+          register(type.render, id + '$render');
+          break;
+
+        case REACT_MEMO_TYPE:
+          register(type.type, id + '$type');
+          break;
+      }
+    }
+  }
+}
+function setSignature(type, key) {
+  var forceReset = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
+  var getCustomHooks = arguments.length > 3 ? arguments[3] : undefined;
+
+  {
+    allSignaturesByType.set(type, {
+      forceReset: forceReset,
+      ownKey: key,
+      fullKey: null,
+      getCustomHooks: getCustomHooks || function () {
+        return [];
+      }
+    });
+  }
+} // This is lazily called during first render for a type.
+// It captures Hook list at that time so inline requires don't break comparisons.
+
+function collectCustomHooksForSignature(type) {
+  {
+    var signature = allSignaturesByType.get(type);
+
+    if (signature !== undefined) {
+      computeFullKey(signature);
+    }
+  }
+}
+function getFamilyByID(id) {
+  {
+    return allFamiliesByID.get(id);
+  }
+}
+function getFamilyByType(type) {
+  {
+    return allFamiliesByType.get(type);
+  }
+}
+function findAffectedHostInstances(families) {
+  {
+    var affectedInstances = new Set();
+    mountedRoots.forEach(function (root) {
+      var helpers = helpersByRoot.get(root);
+
+      if (helpers === undefined) {
+        throw new Error('Could not find helpers for a root. This is a bug in React Refresh.');
+      }
+
+      var instancesForRoot = helpers.findHostInstancesForRefresh(root, families);
+      instancesForRoot.forEach(function (inst) {
+        affectedInstances.add(inst);
+      });
+    });
+    return affectedInstances;
+  }
+}
+function injectIntoGlobalHook(globalObject) {
+  {
+    // For React Native, the global hook will be set up by require('react-devtools-core').
+    // That code will run before us. So we need to monkeypatch functions on existing hook.
+    // For React Web, the global hook will be set up by the extension.
+    // This will also run before us.
+    var hook = globalObject.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+
+    if (hook === undefined) {
+      // However, if there is no DevTools extension, we'll need to set up the global hook ourselves.
+      // Note that in this case it's important that renderer code runs *after* this method call.
+      // Otherwise, the renderer will think that there is no global hook, and won't do the injection.
+      var nextID = 0;
+      globalObject.__REACT_DEVTOOLS_GLOBAL_HOOK__ = hook = {
+        renderers: new Map(),
+        supportsFiber: true,
+        inject: function (injected) {
+          return nextID++;
+        },
+        onScheduleFiberRoot: function (id, root, children) {},
+        onCommitFiberRoot: function (id, root, maybePriorityLevel, didError) {},
+        onCommitFiberUnmount: function () {}
+      };
+    } // Here, we just want to get a reference to scheduleRefresh.
+
+
+    var oldInject = hook.inject;
+
+    hook.inject = function (injected) {
+      var id = oldInject.apply(this, arguments);
+
+      if (typeof injected.scheduleRefresh === 'function' && typeof injected.setRefreshHandler === 'function') {
+        // This version supports React Refresh.
+        helpersByRendererID.set(id, injected);
+      }
+
+      return id;
+    }; // Do the same for any already injected roots.
+    // This is useful if ReactDOM has already been initialized.
+    // https://github.com/facebook/react/issues/17626
+
+
+    hook.renderers.forEach(function (injected, id) {
+      if (typeof injected.scheduleRefresh === 'function' && typeof injected.setRefreshHandler === 'function') {
+        // This version supports React Refresh.
+        helpersByRendererID.set(id, injected);
+      }
+    }); // We also want to track currently mounted roots.
+
+    var oldOnCommitFiberRoot = hook.onCommitFiberRoot;
+
+    var oldOnScheduleFiberRoot = hook.onScheduleFiberRoot || function () {};
+
+    hook.onScheduleFiberRoot = function (id, root, children) {
+      if (!isPerformingRefresh) {
+        // If it was intentionally scheduled, don't attempt to restore.
+        // This includes intentionally scheduled unmounts.
+        failedRoots.delete(root);
+
+        if (rootElements !== null) {
+          rootElements.set(root, children);
+        }
+      }
+
+      return oldOnScheduleFiberRoot.apply(this, arguments);
+    };
+
+    hook.onCommitFiberRoot = function (id, root, maybePriorityLevel, didError) {
+      var helpers = helpersByRendererID.get(id);
+
+      if (helpers === undefined) {
+        return;
+      }
+
+      helpersByRoot.set(root, helpers);
+      var current = root.current;
+      var alternate = current.alternate; // We need to determine whether this root has just (un)mounted.
+      // This logic is copy-pasted from similar logic in the DevTools backend.
+      // If this breaks with some refactoring, you'll want to update DevTools too.
+
+      if (alternate !== null) {
+        var wasMounted = alternate.memoizedState != null && alternate.memoizedState.element != null;
+        var isMounted = current.memoizedState != null && current.memoizedState.element != null;
+
+        if (!wasMounted && isMounted) {
+          // Mount a new root.
+          mountedRoots.add(root);
+          failedRoots.delete(root);
+        } else if (wasMounted && isMounted) ; else if (wasMounted && !isMounted) {
+          // Unmount an existing root.
+          mountedRoots.delete(root);
+
+          if (didError) {
+            // We'll remount it on future edits.
+            failedRoots.add(root);
+          } else {
+            helpersByRoot.delete(root);
+          }
+        } else if (!wasMounted && !isMounted) {
+          if (didError) {
+            // We'll remount it on future edits.
+            failedRoots.add(root);
+          }
+        }
+      } else {
+        // Mount a new root.
+        mountedRoots.add(root);
+      }
+
+      return oldOnCommitFiberRoot.apply(this, arguments);
+    };
+  }
+}
+function hasUnrecoverableErrors() {
+  // TODO: delete this after removing dependency in RN.
+  return false;
+} // Exposed for testing.
+
+function _getMountedRootCount() {
+  {
+    return mountedRoots.size;
+  }
+} // This is a wrapper over more primitive functions for setting signature.
+// Signatures let us decide whether the Hook order has changed on refresh.
+//
+// This function is intended to be used as a transform target, e.g.:
+// var _s = createSignatureFunctionForTransform()
+//
+// function Hello() {
+//   const [foo, setFoo] = useState(0);
+//   const value = useCustomHook();
+//   _s(); /* Second call triggers collecting the custom Hook list.
+//          * This doesn't happen during the module evaluation because we
+//          * don't want to change the module order with inline requires.
+//          * Next calls are noops. */
+//   return <h1>Hi</h1>;
+// }
+//
+// /* First call specifies the signature: */
+// _s(
+//   Hello,
+//   'useState{[foo, setFoo]}(0)',
+//   () => [useCustomHook], /* Lazy to avoid triggering inline requires */
+// );
+
+function createSignatureFunctionForTransform() {
+  {
+    // We'll fill in the signature in two steps.
+    // First, we'll know the signature itself. This happens outside the component.
+    // Then, we'll know the references to custom Hooks. This happens inside the component.
+    // After that, the returned function will be a fast path no-op.
+    var status = 'needsSignature';
+    var savedType;
+    var hasCustomHooks;
+    return function (type, key, forceReset, getCustomHooks) {
+      switch (status) {
+        case 'needsSignature':
+          if (type !== undefined) {
+            // If we received an argument, this is the initial registration call.
+            savedType = type;
+            hasCustomHooks = typeof getCustomHooks === 'function';
+            setSignature(type, key, forceReset, getCustomHooks); // The next call we expect is from inside a function, to fill in the custom Hooks.
+
+            status = 'needsCustomHooks';
+          }
+
+          break;
+
+        case 'needsCustomHooks':
+          if (hasCustomHooks) {
+            collectCustomHooksForSignature(savedType);
+          }
+
+          status = 'resolved';
+          break;
+      }
+
+      return type;
+    };
+  }
+}
+function isLikelyComponentType(type) {
+  {
+    switch (typeof type) {
+      case 'function':
+        {
+          // First, deal with classes.
+          if (type.prototype != null) {
+            if (type.prototype.isReactComponent) {
+              // React class.
+              return true;
+            }
+
+            var ownNames = Object.getOwnPropertyNames(type.prototype);
+
+            if (ownNames.length > 1 || ownNames[0] !== 'constructor') {
+              // This looks like a class.
+              return false;
+            } // eslint-disable-next-line no-proto
+
+
+            if (type.prototype.__proto__ !== Object.prototype) {
+              // It has a superclass.
+              return false;
+            } // Pass through.
+            // This looks like a regular function with empty prototype.
+
+          } // For plain functions and arrows, use name as a heuristic.
+
+
+          var name = type.name || type.displayName;
+          return typeof name === 'string' && /^[A-Z]/.test(name);
+        }
+
+      case 'object':
+        {
+          if (type != null) {
+            switch (type.$typeof) {
+              case REACT_FORWARD_REF_TYPE:
+              case REACT_MEMO_TYPE:
+                // Definitely React components.
+                return true;
+
+              default:
+                return false;
+            }
+          }
+
+          return false;
+        }
+
+      default:
+        {
+          return false;
+        }
+    }
+  }
+}
+
+exports._getMountedRootCount = _getMountedRootCount;
+exports.collectCustomHooksForSignature = collectCustomHooksForSignature;
+exports.createSignatureFunctionForTransform = createSignatureFunctionForTransform;
+exports.findAffectedHostInstances = findAffectedHostInstances;
+exports.getFamilyByID = getFamilyByID;
+exports.getFamilyByType = getFamilyByType;
+exports.hasUnrecoverableErrors = hasUnrecoverableErrors;
+exports.injectIntoGlobalHook = injectIntoGlobalHook;
+exports.isLikelyComponentType = isLikelyComponentType;
+exports.performReactRefresh = performReactRefresh;
+exports.register = register;
+exports.setSignature = setSignature;
+  })();
+}
+
+    exports.performReactRefresh = debounce(exports.performReactRefresh, 30);
+    window.$RefreshRuntime$ = exports;
+    window.$RefreshRuntime$.injectIntoGlobalHook(window);
+    window.$RefreshReg$ = () => {};
+    window.$RefreshSig$ = () => (type) => type;
+  }
+</script>
+    <div id=\\"root\\"></div>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <script type=\\"module\\" src=\\"/dist/index.js\\"></script>
+  </body>
+</html>"
+`;
 
 exports[`@snowpack/plugin-react-refresh transform js and html when sourceMaps is enabled: html and isDev=false 1`] = `undefined`;
 
-exports[`@snowpack/plugin-react-refresh transform js and html when sourceMaps is enabled: js 1`] = `undefined`;
+exports[`@snowpack/plugin-react-refresh transform js and html when sourceMaps is enabled: js 1`] = `
+Object {
+  "code": "/** React Refresh: Setup **/
+if (import.meta.hot) {
+  if (!window.$RefreshReg$ || !window.$RefreshSig$ || !window.$RefreshRuntime$) {
+    console.warn('@snowpack/plugin-react-refresh: HTML setup script not run. React Fast Refresh only works when Snowpack serves your HTML routes. You may want to remove this plugin.');
+  } else {
+    var prevRefreshReg = window.$RefreshReg$;
+    var prevRefreshSig = window.$RefreshSig$;
+
+    window.$RefreshReg$ = (type, id) => {
+      window.$RefreshRuntime$.register(type, \\"stub.js\\" + \\" \\" + id);
+    };
+
+    window.$RefreshSig$ = window.$RefreshRuntime$.createSignatureFunctionForTransform;
+  }
+}
+
+import React from 'react';
+
+function App() {
+  return /* @__PURE__ */React.createElement('div', null, 'React App');
+}
+
+_c = App;
+export default App;
+
+var _c;
+
+$RefreshReg$(_c, \\"App\\");
+
+if (import.meta.hot) {
+  window.$RefreshReg$ = prevRefreshReg;
+  window.$RefreshSig$ = prevRefreshSig;
+  import.meta.hot.accept(() => {
+    window.$RefreshRuntime$.performReactRefresh();
+  });
+}",
+  "map": Object {
+    "mappings": "AACA;AACA,IAAIA,MAAM,CAACC,IAAP,CAAYC,GAAhB,EAAqB;AACnB,MAAI,CAACC,MAAM,CAACC,YAAR,IAAwB,CAACD,MAAM,CAACE,YAAhC,IAAgD,CAACF,MAAM,CAACG,gBAA5D,EAA8E;AAC5EC,IAAAA,OAAO,CAACC,IAAR,CAAa,qKAAb;AACD,GAFD,MAEO;AACL,QAAIC,cAAc,GAAGN,MAAM,CAACC,YAA5B;AACA,QAAIM,cAAc,GAAGP,MAAM,CAACE,YAA5B;;AACAF,IAAAA,MAAM,CAACC,YAAP,GAAsB,CAACO,IAAD,EAAOC,EAAP,KAAc;AAClCT,MAAAA,MAAM,CAACG,gBAAP,CAAwBO,QAAxB,CAAiCF,IAAjC,EAAuC,YAAY,GAAZ,GAAkBC,EAAzD;AACD,KAFD;;AAGAT,IAAAA,MAAM,CAACE,YAAP,GAAsBF,MAAM,CAACG,gBAAP,CAAwBQ,mCAA9C;AACD;AACF;;AAbD,OAAOC,KAAP,MAAkB,OAAlB;;AACA,SAASC,GAAT,GAAe;AACb,SAAO,eAAgBD,KAAK,CAACE,aAAN,CAAoB,KAApB,EAA2B,IAA3B,EAAiC,WAAjC,CAAvB;AACD;;KAFQD,G;AAGT,eAAeA,GAAf;;;;;;AAFA,IAAIhB,MAAM,CAACC,IAAP,CAAYC,GAAhB,EAAqB;AACnBC,EAAAA,MAAM,CAACC,YAAP,GAAsBK,cAAtB;AACAN,EAAAA,MAAM,CAACE,YAAP,GAAsBK,cAAtB;AACAV,EAAAA,MAAM,CAACC,IAAP,CAAYC,GAAZ,CAAgBgB,MAAhB,CAAuB,MAAM;AAC3Bf,IAAAA,MAAM,CAACG,gBAAP,CAAwBa,mBAAxB;AACD,GAFD;AAGD",
+    "names": Array [
+      "import",
+      "meta",
+      "hot",
+      "window",
+      "$RefreshReg$",
+      "$RefreshSig$",
+      "$RefreshRuntime$",
+      "console",
+      "warn",
+      "prevRefreshReg",
+      "prevRefreshSig",
+      "type",
+      "id",
+      "register",
+      "createSignatureFunctionForTransform",
+      "React",
+      "App",
+      "createElement",
+      "accept",
+      "performReactRefresh",
+    ],
+    "sources": Array [
+      "stub.js",
+    ],
+    "sourcesContent": Array [
+      "import React from 'react';
+function App() {
+  return /* @__PURE__ */ React.createElement('div', null, 'React App');
+}
+export default App;
+",
+    ],
+    "version": 3,
+  },
+}
+`;
 
 exports[`@snowpack/plugin-react-refresh transform js and html when sourceMaps is enabled: js and isDev=false 1`] = `undefined`;
 
@@ -1460,17 +2234,17 @@ function App() {
 _c = App;
 export default App;
 
+var _c;
+
+$RefreshReg$(_c, \\"App\\");
+
 if (import.meta.hot) {
   window.$RefreshReg$ = prevRefreshReg;
   window.$RefreshSig$ = prevRefreshSig;
   import.meta.hot.accept(() => {
     window.$RefreshRuntime$.performReactRefresh();
   });
-}
-
-var _c;
-
-$RefreshReg$(_c, \\"App\\");",
+}",
   "map": null,
 }
 `;

--- a/plugins/plugin-react-refresh/test/__snapshots__/plugin.test.js.snap
+++ b/plugins/plugin-react-refresh/test/__snapshots__/plugin.test.js.snap
@@ -703,12 +703,14 @@ exports.setSignature = setSignature;
 exports[`@snowpack/plugin-react-refresh transform js and html when babel is disabled: html and isDev=false 1`] = `undefined`;
 
 exports[`@snowpack/plugin-react-refresh transform js and html when babel is disabled: js 1`] = `
-"import React from 'react';
+Object {
+  "code": "import React from 'react';
 function App() {
   return /* @__PURE__ */ React.createElement('div', null, 'React App');
 }
 export default App;
-"
+",
+}
 `;
 
 exports[`@snowpack/plugin-react-refresh transform js and html when babel is disabled: js and isDev=false 1`] = `undefined`;
@@ -720,6 +722,14 @@ exports[`@snowpack/plugin-react-refresh transform js and html when hmr is disabl
 exports[`@snowpack/plugin-react-refresh transform js and html when hmr is disabled: js 1`] = `undefined`;
 
 exports[`@snowpack/plugin-react-refresh transform js and html when hmr is disabled: js and isDev=false 1`] = `undefined`;
+
+exports[`@snowpack/plugin-react-refresh transform js and html when sourceMaps is enabled: html 1`] = `undefined`;
+
+exports[`@snowpack/plugin-react-refresh transform js and html when sourceMaps is enabled: html and isDev=false 1`] = `undefined`;
+
+exports[`@snowpack/plugin-react-refresh transform js and html when sourceMaps is enabled: js 1`] = `undefined`;
+
+exports[`@snowpack/plugin-react-refresh transform js and html when sourceMaps is enabled: js and isDev=false 1`] = `undefined`;
 
 exports[`@snowpack/plugin-react-refresh transform js and html: html 1`] = `
 "<!DOCTYPE html>
@@ -1424,17 +1434,19 @@ exports.setSignature = setSignature;
 exports[`@snowpack/plugin-react-refresh transform js and html: html and isDev=false 1`] = `undefined`;
 
 exports[`@snowpack/plugin-react-refresh transform js and html: js 1`] = `
-"
-/** React Refresh: Setup **/
+Object {
+  "code": "/** React Refresh: Setup **/
 if (import.meta.hot) {
   if (!window.$RefreshReg$ || !window.$RefreshSig$ || !window.$RefreshRuntime$) {
     console.warn('@snowpack/plugin-react-refresh: HTML setup script not run. React Fast Refresh only works when Snowpack serves your HTML routes. You may want to remove this plugin.');
   } else {
     var prevRefreshReg = window.$RefreshReg$;
     var prevRefreshSig = window.$RefreshSig$;
+
     window.$RefreshReg$ = (type, id) => {
       window.$RefreshRuntime$.register(type, \\"stub.js\\" + \\" \\" + id);
-    }
+    };
+
     window.$RefreshSig$ = window.$RefreshRuntime$.createSignatureFunctionForTransform;
   }
 }
@@ -1448,18 +1460,19 @@ function App() {
 _c = App;
 export default App;
 
+if (import.meta.hot) {
+  window.$RefreshReg$ = prevRefreshReg;
+  window.$RefreshSig$ = prevRefreshSig;
+  import.meta.hot.accept(() => {
+    window.$RefreshRuntime$.performReactRefresh();
+  });
+}
+
 var _c;
 
-$RefreshReg$(_c, \\"App\\");
-
-/** React Refresh: Connect **/
-if (import.meta.hot) {
-  window.$RefreshReg$ = prevRefreshReg
-  window.$RefreshSig$ = prevRefreshSig
-  import.meta.hot.accept(() => {
-    window.$RefreshRuntime$.performReactRefresh()
-  });
-}"
+$RefreshReg$(_c, \\"App\\");",
+  "map": null,
+}
 `;
 
 exports[`@snowpack/plugin-react-refresh transform js and html: js and isDev=false 1`] = `undefined`;

--- a/plugins/plugin-react-refresh/test/babel-plugin-wrap.test.js
+++ b/plugins/plugin-react-refresh/test/babel-plugin-wrap.test.js
@@ -1,0 +1,25 @@
+const babel = require('@babel/core');
+
+const headerText = `console.log('header');`;
+const footerText = `console.log('footer');`;
+const contents = `console.log('contents');`;
+
+describe('babel-plugin-wrap', () => {
+  it('should wrap contents', async () => {
+    const {code, map} = await babel.transformAsync(contents, {
+      ast: false,
+      compact: false,
+      sourceMaps: true,
+      configFile: false,
+      babelrc: false,
+      plugins: [
+        [require('../babel-plugin-wrap'), {
+          header: headerText,
+          footer: footerText
+        }]
+      ],
+    });
+    expect(code).toEqual(`console.log('header');\nconsole.log('contents');\nconsole.log('footer');`);
+    expect(map).not.toBeUndefined();
+  })
+})

--- a/plugins/plugin-react-refresh/test/plugin.test.js
+++ b/plugins/plugin-react-refresh/test/plugin.test.js
@@ -58,11 +58,15 @@ function mockBabel() {
 async function testPluginInstance(pluginInstance) {
   const pluginTransform = pluginInstance.transform;
   expect(await pluginTransform(htmlTransformOptions)).toMatchSnapshot('html');
-  expect(await pluginTransform(jsTransformOptions)).toMatchSnapshot('js');
+
+  const jsResult1 = await pluginTransform(jsTransformOptions);
+  expect(jsResult1).toMatchSnapshot('js');
   expect(await pluginTransform({...htmlTransformOptions, isDev: false})).toMatchSnapshot(
     'html and isDev=false',
   );
-  expect(await pluginTransform({...jsTransformOptions, isDev: false})).toMatchSnapshot(
+
+  const jsResult2 = await await pluginTransform({...jsTransformOptions, isDev: false});
+  expect(jsResult2).toMatchSnapshot(
     'js and isDev=false',
   );
 }
@@ -74,6 +78,9 @@ describe('@snowpack/plugin-react-refresh', () => {
         devOptions: {
           hmr: true,
         },
+        buildOptions: {
+          sourceMaps: false
+        }
       },
       {babel: true},
     );
@@ -86,6 +93,9 @@ describe('@snowpack/plugin-react-refresh', () => {
         devOptions: {
           hmr: false,
         },
+        buildOptions: {
+          sourceMaps: false
+        }
       },
       {babel: true},
     );
@@ -98,8 +108,26 @@ describe('@snowpack/plugin-react-refresh', () => {
         devOptions: {
           hmr: true,
         },
+        buildOptions: {
+          sourceMaps: false
+        }
       },
       {babel: false},
+    );
+    await testPluginInstance(pluginInstance);
+  });
+
+  test('transform js and html when sourceMaps is enabled', async () => {
+    const pluginInstance = pluginReactRefresh(
+      {
+        devOptions: {
+          hmr: true,
+        },
+        buildOptions: {
+          sourceMaps: true
+        }
+      },
+      {babel: true},
     );
     await testPluginInstance(pluginInstance);
   });

--- a/plugins/plugin-react-refresh/wrappers.js
+++ b/plugins/plugin-react-refresh/wrappers.js
@@ -1,0 +1,31 @@
+const headerText = id => `
+/** React Refresh: Setup **/
+if (import.meta.hot) {
+  if (!window.$RefreshReg$ || !window.$RefreshSig$ || !window.$RefreshRuntime$) {
+    console.warn('@snowpack/plugin-react-refresh: HTML setup script not run. React Fast Refresh only works when Snowpack serves your HTML routes. You may want to remove this plugin.');
+  } else {
+    var prevRefreshReg = window.$RefreshReg$;
+    var prevRefreshSig = window.$RefreshSig$;
+    window.$RefreshReg$ = (type, id) => {
+      window.$RefreshRuntime$.register(type, ${JSON.stringify(id)} + " " + id);
+    }
+    window.$RefreshSig$ = window.$RefreshRuntime$.createSignatureFunctionForTransform;
+  }
+}
+`;
+
+const footerText = () => `
+/** React Refresh: Connect **/
+if (import.meta.hot) {
+  window.$RefreshReg$ = prevRefreshReg
+  window.$RefreshSig$ = prevRefreshSig
+  import.meta.hot.accept(() => {
+    window.$RefreshRuntime$.performReactRefresh()
+  });
+}
+`;
+
+module.exports = {
+  headerText,
+  footerText
+}


### PR DESCRIPTION
Returns sourcemap information (if enabled) from plugin-react-refresh.
Plugin now returns {code, map} instead of just new code.

## Changes

Adds the ability for `plugin-react-refresh` to return sourcemap information.
To keep the sourcemaps accurate, the concatenation of the `if (import.meta.hot)` blocks is now done via babel.
Without this, any sourcemap that is generated from the `load` step would be lost when using the `plugin-react-refresh` plugin.

## Testing

Extended unit tests for the plugin.
Created unit tests for the new babel plugin.

## Docs

There isn't really any documentation to add as the new functionality falls in line with the expected behaviour
