### PR TITLE
source=skypack -> source=remote

### DIFF
--- a/skypack/src/index.ts
+++ b/skypack/src/index.ts
@@ -6,10 +6,10 @@ import fs from 'fs';
 import url from 'url';
 import got, {Response} from 'got';
 import {IncomingHttpHeaders} from 'http';
-import {ImportMap, RESOURCE_CACHE, SKYPACK_ORIGIN, HAS_CDN_HASH_REGEX} from './util';
+import {ImportMap, RESOURCE_CACHE, HAS_CDN_HASH_REGEX} from './util';
 
 export {rollupPluginSkypack} from './rollup-plugin-remote-cdn';
-export {SKYPACK_ORIGIN} from './util';
+// export const SKYPACK_ORIGIN = `https://cdn.skypack.dev`;
 
 function parseRawPackageImport(spec: string): [string, string | null] {
   const impParts = spec.split('/');
@@ -21,229 +21,206 @@ function parseRawPackageImport(spec: string): [string, string | null] {
   return [name, rest.join('/') || null];
 }
 
-export async function generateImportMap(
-  webDependencies: Record<string, string | null>,
-  inheritFromImportMap?: ImportMap,
-): Promise<ImportMap> {
-  const newLockfile: ImportMap = inheritFromImportMap ? {imports: {...inheritFromImportMap.imports}} : {imports: {}};
-  await Promise.all(
-    Object.entries(webDependencies).map(async ([packageName, packageSemver]) => {
-      if (packageSemver === null) {
-        delete newLockfile.imports[packageName];
-        delete newLockfile.imports[packageName + '/'];
-        return;
-      }
-      const lookupResponse = await lookupBySpecifier(packageName, packageSemver);
-      if (lookupResponse.error) {
-        throw lookupResponse.error;
-      }
-      if (lookupResponse.pinnedUrl) {
-        let keepGoing = true;
-        const deepPinnedUrlParts = lookupResponse.pinnedUrl.split('/');
-        // TODO: Get ?meta support to get this info via JSON instead of header manipulation
-        deepPinnedUrlParts.shift(); // remove ""
-        deepPinnedUrlParts.shift(); // remove "pin"
+export class SkypackSDK {
+  origin: string;
 
-        while (keepGoing) {
-          const investigate = deepPinnedUrlParts.pop()!;
-          if (HAS_CDN_HASH_REGEX.test(investigate)) {
-            keepGoing = false;
-            deepPinnedUrlParts.push(investigate);
-          }
+  constructor(options: {origin?: string} = {}) {
+    this.origin = options.origin || `https://cdn.skypack.dev`;
+  }
+
+  async generateImportMap(
+    webDependencies: Record<string, string | null>,
+    inheritFromImportMap?: ImportMap,
+  ): Promise<ImportMap> {
+    const newLockfile: ImportMap = inheritFromImportMap
+      ? {imports: {...inheritFromImportMap.imports}}
+      : {imports: {}};
+    await Promise.all(
+      Object.entries(webDependencies).map(async ([packageName, packageSemver]) => {
+        if (packageSemver === null) {
+          delete newLockfile.imports[packageName];
+          delete newLockfile.imports[packageName + '/'];
+          return;
         }
-        newLockfile.imports[packageName] = SKYPACK_ORIGIN + '/' + deepPinnedUrlParts.join('/');
-        newLockfile.imports[packageName + '/'] = SKYPACK_ORIGIN + '/' + deepPinnedUrlParts.join('/') + '/';
-      }
-    }),
-  );
-  const newLockfileSorted = Object.keys(newLockfile.imports).sort((a, b) => {
-    // We want 'xxx/' to come after 'xxx', so we convert it to a space (the character with the highest sort order)
-    // See: http://support.ecisolutions.com/doc-ddms/help/reportsmenu/ascii_sort_order_chart.htm
-    return a.replace(/\/$/, ' ').localeCompare(b.replace(/\/$/, ' '));
-  });
-  return {
-    imports: newLockfileSorted.reduce((prev, k) => {
-      prev[k] = newLockfile.imports[k];
-      return prev;
-    }, {}),
-  };
-}
+        const lookupResponse = await this.lookupBySpecifier(packageName, packageSemver);
+        if (lookupResponse.error) {
+          throw lookupResponse.error;
+        }
+        if (lookupResponse.pinnedUrl) {
+          let keepGoing = true;
+          const deepPinnedUrlParts = lookupResponse.pinnedUrl.split('/');
+          // TODO: Get ?meta support to get this info via JSON instead of header manipulation
+          deepPinnedUrlParts.shift(); // remove ""
+          deepPinnedUrlParts.shift(); // remove "pin"
 
-interface ResourceCacheMetadata {
-  headers: IncomingHttpHeaders;
-  statusCode: number;
-  freshUntil: string;
-}
-
-export async function fetchCDN(
-  resourceUrl: string,
-  userAgent?: string,
-): Promise<{
-  body: Buffer;
-  headers: IncomingHttpHeaders;
-  statusCode: number;
-  isCached: boolean;
-  isStale: boolean;
-}> {
-  if (!resourceUrl.startsWith(SKYPACK_ORIGIN)) {
-    resourceUrl = SKYPACK_ORIGIN + resourceUrl;
-  }
-
-  const cachedResult = await cacache.get(RESOURCE_CACHE, resourceUrl).catch(() => null);
-  if (cachedResult) {
-    const cachedResultMetadata = cachedResult.metadata as ResourceCacheMetadata;
-    const freshUntil = new Date(cachedResult.metadata.freshUntil);
-    if (freshUntil >= new Date()) {
-      return {
-        isCached: true,
-        isStale: false,
-        body: cachedResult.data,
-        headers: cachedResultMetadata.headers,
-        statusCode: cachedResultMetadata.statusCode,
-      };
-    }
-  }
-
-  let freshResult: Response<Buffer>;
-  try {
-    freshResult = await got(resourceUrl, {
-      headers: {'user-agent': userAgent || `skypack/v0.0.1`},
-      throwHttpErrors: false,
-      responseType: 'buffer',
+          while (keepGoing) {
+            const investigate = deepPinnedUrlParts.pop()!;
+            if (HAS_CDN_HASH_REGEX.test(investigate)) {
+              keepGoing = false;
+              deepPinnedUrlParts.push(investigate);
+            }
+          }
+          newLockfile.imports[packageName] = this.origin + '/' + deepPinnedUrlParts.join('/');
+          newLockfile.imports[packageName + '/'] =
+            this.origin + '/' + deepPinnedUrlParts.join('/') + '/';
+        }
+      }),
+    );
+    const newLockfileSorted = Object.keys(newLockfile.imports).sort((a, b) => {
+      // We want 'xxx/' to come after 'xxx', so we convert it to a space (the character with the highest sort order)
+      // See: http://support.ecisolutions.com/doc-ddms/help/reportsmenu/ascii_sort_order_chart.htm
+      return a.replace(/\/$/, ' ').localeCompare(b.replace(/\/$/, ' '));
     });
-  } catch (err) {
+    return {
+      imports: newLockfileSorted.reduce((prev, k) => {
+        prev[k] = newLockfile.imports[k];
+        return prev;
+      }, {}),
+    };
+  }
+
+  async fetch(
+    resourceUrl: string,
+    userAgent?: string,
+  ): Promise<{
+    body: Buffer;
+    headers: IncomingHttpHeaders;
+    statusCode: number;
+    isCached: boolean;
+    isStale: boolean;
+  }> {
+    if (!resourceUrl.startsWith(this.origin)) {
+      resourceUrl = this.origin + resourceUrl;
+    }
+
+    const cachedResult = await cacache.get(RESOURCE_CACHE, resourceUrl).catch(() => null);
     if (cachedResult) {
       const cachedResultMetadata = cachedResult.metadata as ResourceCacheMetadata;
+      const freshUntil = new Date(cachedResult.metadata.freshUntil);
+      if (freshUntil >= new Date()) {
+        return {
+          isCached: true,
+          isStale: false,
+          body: cachedResult.data,
+          headers: cachedResultMetadata.headers,
+          statusCode: cachedResultMetadata.statusCode,
+        };
+      }
+    }
+
+    let freshResult: Response<Buffer>;
+    try {
+      freshResult = await got(resourceUrl, {
+        headers: {'user-agent': userAgent || `skypack/v0.0.1`},
+        throwHttpErrors: false,
+        responseType: 'buffer',
+      });
+    } catch (err) {
+      if (cachedResult) {
+        const cachedResultMetadata = cachedResult.metadata as ResourceCacheMetadata;
+        return {
+          isCached: true,
+          isStale: true,
+          body: cachedResult.data,
+          headers: cachedResultMetadata.headers,
+          statusCode: cachedResultMetadata.statusCode,
+        };
+      }
+      throw err;
+    }
+
+    const cacheUntilMatch = freshResult.headers['cache-control']?.match(/max-age=(\d+)/);
+    if (cacheUntilMatch) {
+      var freshUntil = new Date();
+      freshUntil.setSeconds(freshUntil.getSeconds() + parseInt(cacheUntilMatch[1]));
+      // no need to await, since we `.catch()` to swallow any errors.
+      cacache
+        .put(RESOURCE_CACHE, resourceUrl, freshResult.body, {
+          metadata: {
+            headers: freshResult.headers,
+            statusCode: freshResult.statusCode,
+            freshUntil: freshUntil.toUTCString(),
+          } as ResourceCacheMetadata,
+        })
+        .catch(() => null);
+    }
+
+    return {
+      body: freshResult.body,
+      headers: freshResult.headers,
+      statusCode: freshResult.statusCode,
+      isCached: false,
+      isStale: false,
+    };
+  }
+
+  async buildNewPackage(
+    spec: string,
+    semverString?: string,
+    userAgent?: string,
+  ): Promise<BuildNewPackageResponse> {
+    const [packageName, packagePath] = parseRawPackageImport(spec);
+    const lookupUrl =
+      `/new/${packageName}` +
+      (semverString ? `@${semverString}` : ``) +
+      (packagePath ? `/${packagePath}` : ``);
+    try {
+      const {statusCode} = await this.fetch(lookupUrl, userAgent);
       return {
-        isCached: true,
-        isStale: true,
-        body: cachedResult.data,
-        headers: cachedResultMetadata.headers,
-        statusCode: cachedResultMetadata.statusCode,
+        error: null,
+        success: statusCode !== 500,
       };
+    } catch (err) {
+      return {error: err, success: false};
     }
-    throw err;
   }
 
-  const cacheUntilMatch = freshResult.headers['cache-control']?.match(/max-age=(\d+)/);
-  if (cacheUntilMatch) {
-    var freshUntil = new Date();
-    freshUntil.setSeconds(freshUntil.getSeconds() + parseInt(cacheUntilMatch[1]));
-    // no need to await, since we `.catch()` to swallow any errors.
-    cacache
-      .put(RESOURCE_CACHE, resourceUrl, freshResult.body, {
-        metadata: {
-          headers: freshResult.headers,
-          statusCode: freshResult.statusCode,
-          freshUntil: freshUntil.toUTCString(),
-        } as ResourceCacheMetadata,
-      })
-      .catch(() => null);
-  }
-
-  return {
-    body: freshResult.body,
-    headers: freshResult.headers,
-    statusCode: freshResult.statusCode,
-    isCached: false,
-    isStale: false,
-  };
-}
-
-export type BuildNewPackageResponse =
-  | {error: Error; success: false}
-  | {
-      error: null;
-      success: boolean;
-    };
-
-export async function buildNewPackage(
-  spec: string,
-  semverString?: string,
-  userAgent?: string,
-): Promise<BuildNewPackageResponse> {
-  const [packageName, packagePath] = parseRawPackageImport(spec);
-  const lookupUrl =
-    `/new/${packageName}` +
-    (semverString ? `@${semverString}` : ``) +
-    (packagePath ? `/${packagePath}` : ``);
-  try {
-    const {statusCode} = await fetchCDN(lookupUrl, userAgent);
-    return {
-      error: null,
-      success: statusCode !== 500,
-    };
-  } catch (err) {
-    return {error: err, success: false};
-  }
-}
-
-export type LookupBySpecifierResponse =
-  | {error: Error}
-  | {
-      error: null;
-      body: Buffer;
-      isCached: boolean;
-      isStale: boolean;
-      importStatus: string;
-      importUrl: string;
-      pinnedUrl: string | undefined;
-      typesUrl: string | undefined;
-    };
-
-export async function lookupBySpecifier(
-  spec: string,
-  semverString?: string,
-  qs?: string,
-  userAgent?: string,
-): Promise<LookupBySpecifierResponse> {
-  const [packageName, packagePath] = parseRawPackageImport(spec);
-  const lookupUrl =
-    `/${packageName}` +
-    (semverString ? `@${semverString}` : ``) +
-    (packagePath ? `/${packagePath}` : ``) +
-    (qs ? `?${qs}` : ``);
-  try {
-    const {body, statusCode, headers, isCached, isStale} = await fetchCDN(lookupUrl, userAgent);
-    if (statusCode !== 200) {
-      return {error: new Error(body.toString())};
+  async lookupBySpecifier(
+    spec: string,
+    semverString?: string,
+    qs?: string,
+    userAgent?: string,
+  ): Promise<LookupBySpecifierResponse> {
+    const [packageName, packagePath] = parseRawPackageImport(spec);
+    const lookupUrl =
+      `/${packageName}` +
+      (semverString ? `@${semverString}` : ``) +
+      (packagePath ? `/${packagePath}` : ``) +
+      (qs ? `?${qs}` : ``);
+    try {
+      const {body, statusCode, headers, isCached, isStale} = await this.fetch(lookupUrl, userAgent);
+      if (statusCode !== 200) {
+        return {error: new Error(body.toString())};
+      }
+      return {
+        error: null,
+        body,
+        isCached,
+        isStale,
+        importStatus: headers['x-import-status'] as string,
+        importUrl: headers['x-import-url'] as string,
+        pinnedUrl: headers['x-pinned-url'] as string | undefined,
+        typesUrl: headers['x-typescript-types'] as string | undefined,
+      };
+    } catch (err) {
+      return {error: err};
     }
-    return {
-      error: null,
-      body,
-      isCached,
-      isStale,
-      importStatus: headers['x-import-status'] as string,
-      importUrl: headers['x-import-url'] as string,
-      pinnedUrl: headers['x-pinned-url'] as string | undefined,
-      typesUrl: headers['x-typescript-types'] as string | undefined,
-    };
-  } catch (err) {
-    return {error: err};
-  }
-}
-
-export async function clearCache() {
-  return cacache.rm.all(RESOURCE_CACHE);
-}
-
-export async function installTypes(
-  spec: string,
-  semverString?: string,
-  dir?: string) {
-  dir = dir || path.join(process.cwd(), '.types');
-  const lookupResult = await lookupBySpecifier(spec, semverString, 'dts');
-  if (lookupResult.error) {
-    throw lookupResult.error;
-  }
-  if (!lookupResult.typesUrl) {
-    throw new Error(`Skypack CDN: No types found "${spec}"`);
   }
 
-  const typesTarballUrl = lookupResult.typesUrl.replace(/(mode=types.*?)\/.*/, '$1/all.tgz');
+  async installTypes(spec: string, semverString?: string, dir?: string) {
+    dir = dir || path.join(process.cwd(), '.types');
+    const lookupResult = await this.lookupBySpecifier(spec, semverString, 'dts');
+    if (lookupResult.error) {
+      throw lookupResult.error;
+    }
+    if (!lookupResult.typesUrl) {
+      throw new Error(`Skypack CDN: No types found "${spec}"`);
+    }
 
-  await mkdirp(dir);
-  const tempDir = await cacache.tmp.mkdir(RESOURCE_CACHE);
+    const typesTarballUrl = lookupResult.typesUrl.replace(/(mode=types.*?)\/.*/, '$1/all.tgz');
+
+    await mkdirp(dir);
+    const tempDir = await cacache.tmp.mkdir(RESOURCE_CACHE);
 
     let tarballContents: Buffer;
     const cachedTarball = await cacache
@@ -252,7 +229,7 @@ export async function installTypes(
     if (cachedTarball) {
       tarballContents = cachedTarball.data;
     } else {
-      const tarballResponse = await fetchCDN(typesTarballUrl);
+      const tarballResponse = await this.fetch(typesTarballUrl);
       if (tarballResponse.statusCode !== 200) {
         throw new Error(tarballResponse.body.toString());
       }
@@ -275,4 +252,35 @@ export async function installTypes(
       file: typesPackageTarLoc,
       cwd: typesPackageLoc,
     });
+  }
+}
+
+interface ResourceCacheMetadata {
+  headers: IncomingHttpHeaders;
+  statusCode: number;
+  freshUntil: string;
+}
+
+export type BuildNewPackageResponse =
+  | {error: Error; success: false}
+  | {
+      error: null;
+      success: boolean;
+    };
+
+export type LookupBySpecifierResponse =
+  | {error: Error}
+  | {
+      error: null;
+      body: Buffer;
+      isCached: boolean;
+      isStale: boolean;
+      importStatus: string;
+      importUrl: string;
+      pinnedUrl: string | undefined;
+      typesUrl: string | undefined;
+    };
+
+export async function clearCache() {
+  return cacache.rm.all(RESOURCE_CACHE);
 }

--- a/skypack/src/rollup-plugin-remote-cdn.ts
+++ b/skypack/src/rollup-plugin-remote-cdn.ts
@@ -1,10 +1,8 @@
 import cacache from 'cacache';
 import {Plugin, ResolvedId} from 'rollup';
-import {fetchCDN} from './index';
-import {SKYPACK_ORIGIN, HAS_CDN_HASH_REGEX, RESOURCE_CACHE} from './util';
+import {SkypackSDK} from './index';
+import {HAS_CDN_HASH_REGEX, RESOURCE_CACHE} from './util';
 
-const CACHED_FILE_ID_PREFIX = 'snowpack-pkg-cache:';
-const PIKA_CDN_TRIM_LENGTH = SKYPACK_ORIGIN.length;
 
 /**
  * rollup-plugin-remote-cdn
@@ -14,19 +12,19 @@ const PIKA_CDN_TRIM_LENGTH = SKYPACK_ORIGIN.length;
  * successful CDN resolution, we save the file to the local cache and then tell
  * rollup that it's safe to load from the cache in the `load()` hook.
  */
-export function rollupPluginSkypack({
-}: {
-}) {
+export function rollupPluginSkypack({sdk}: {sdk: SkypackSDK}) {
+const CACHED_FILE_ID_PREFIX = 'remote-pkg-cache:';
+
   return {
     name: 'snowpack:rollup-plugin-remote-cdn',
     async resolveId(source: string, importer) {
       let cacheKey: string;
-      if (source.startsWith(SKYPACK_ORIGIN)) {
+      if (source.startsWith(origin)) {
         cacheKey = source;
       } else if (source.startsWith('/-/')) {
-        cacheKey = SKYPACK_ORIGIN + source;
+        cacheKey = origin + source;
       } else if (source.startsWith('/pin/')) {
-        cacheKey = SKYPACK_ORIGIN + source;
+        cacheKey = origin + source;
       } else {
         return null;
       }
@@ -45,7 +43,7 @@ export function rollupPluginSkypack({
       }
 
       // Otherwise, make the remote request and cache the file on success.
-      const {statusCode} = await fetchCDN(cacheKey);
+      const {statusCode} = await sdk.fetch(cacheKey);
       if (statusCode === 200) {
         return CACHED_FILE_ID_PREFIX + cacheKey;
       }
@@ -53,7 +51,7 @@ export function rollupPluginSkypack({
       // If lookup failed, skip this plugin and resolve the import locally instead.
       // TODO: Log that this has happened (if some sort of verbose mode is enabled).
       const packageName = cacheKey
-        .substring(PIKA_CDN_TRIM_LENGTH)
+        .substring(sdk.origin.length)
         .replace('/-/', '')
         .replace('/pin/', '')
         .split('@')[0];
@@ -71,7 +69,7 @@ export function rollupPluginSkypack({
       }
       const cacheKey = id.substring(CACHED_FILE_ID_PREFIX.length);
       console.debug(`load ${cacheKey}`, {name: 'install:remote'});
-      const {body} = await fetchCDN(cacheKey);
+      const {body} = await sdk.fetch(cacheKey);
       console.log(body);
       return body.toString();
     },

--- a/skypack/src/util.ts
+++ b/skypack/src/util.ts
@@ -11,7 +11,6 @@ export interface ImportMap {
 
 export const GLOBAL_CACHE_DIR = globalCacheDir('skypack');
 export const RESOURCE_CACHE = path.join(GLOBAL_CACHE_DIR, 'pkg-cache-3.0');
-export const SKYPACK_ORIGIN = `https://cdn.skypack.dev`;
 export const HAS_CDN_HASH_REGEX = /\-[a-zA-Z0-9]{16,}/;
 
 // A note on cache naming/versioning: We currently version our global caches

--- a/snowpack/src/commands/add-rm.ts
+++ b/snowpack/src/commands/add-rm.ts
@@ -1,7 +1,6 @@
 import {send} from 'httpie';
 import {cyan, dim, underline} from 'kleur/colors';
 import path from 'path';
-import {generateImportMap} from 'skypack';
 import {logger} from '../logger';
 import {CommandOptions, LockfileManifest} from '../types';
 import {
@@ -9,6 +8,7 @@ import {
   convertSkypackImportMapToLockfile,
   LOCKFILE_NAME,
   writeLockfile,
+  remotePackageSDK,
 } from '../util';
 
 export async function addCommand(addValue: string, commandOptions: CommandOptions) {
@@ -24,9 +24,9 @@ export async function addCommand(addValue: string, commandOptions: CommandOption
     pkgSemver = `^${data.version}`;
   }
   logger.info(
-    `adding ${cyan(
-      underline(`${pkgName}@${pkgSemver}`),
-    )} to your project lockfile. ${dim(`(${LOCKFILE_NAME})`)}`,
+    `adding ${cyan(underline(`${pkgName}@${pkgSemver}`))} to your project lockfile. ${dim(
+      `(${LOCKFILE_NAME})`,
+    )}`,
   );
   const addedDependency = {[pkgName]: pkgSemver};
   const newLockfile: LockfileManifest = convertSkypackImportMapToLockfile(
@@ -34,7 +34,7 @@ export async function addCommand(addValue: string, commandOptions: CommandOption
       ...lockfile?.dependencies,
       ...addedDependency,
     },
-    await generateImportMap(
+    await remotePackageSDK.generateImportMap(
       addedDependency,
       lockfile ? convertLockfileToSkypackImportMap(lockfile) : undefined,
     ),
@@ -51,7 +51,7 @@ export async function rmCommand(addValue: string, commandOptions: CommandOptions
   logger.info(`removing ${cyan(pkgName)} from project lockfile...`);
   const newLockfile: LockfileManifest = convertSkypackImportMapToLockfile(
     lockfile?.dependencies ?? {},
-    await generateImportMap(
+    await remotePackageSDK.generateImportMap(
       {[pkgName]: null},
       lockfile ? convertLockfileToSkypackImportMap(lockfile) : undefined,
     ),

--- a/snowpack/src/commands/add-rm.ts
+++ b/snowpack/src/commands/add-rm.ts
@@ -13,19 +13,19 @@ import {
 
 export async function addCommand(addValue: string, commandOptions: CommandOptions) {
   const {lockfile, config} = commandOptions;
-  if (config.packageOptions.source !== 'skypack') {
-    throw new Error(`add command requires packageOptions.source="skypack".`);
+  if (config.packageOptions.source !== 'stream') {
+    throw new Error(`add command requires packageOptions.source="stream".`);
   }
   let [pkgName, pkgSemver] = addValue.split('@');
   const installMessage = pkgSemver ? `${pkgName}@${pkgSemver}` : pkgName;
-  logger.info(`fetching ${cyan(installMessage)} from Skypack CDN...`);
+  logger.info(`fetching ${cyan(installMessage)} from CDN...`);
   if (!pkgSemver || pkgSemver === 'latest') {
     const {data} = await send('GET', `http://registry.npmjs.org/${pkgName}/latest`);
     pkgSemver = `^${data.version}`;
   }
   logger.info(
     `adding ${cyan(
-      underline(`https://cdn.skypack.dev/${pkgName}@${pkgSemver}`),
+      underline(`${pkgName}@${pkgSemver}`),
     )} to your project lockfile. ${dim(`(${LOCKFILE_NAME})`)}`,
   );
   const addedDependency = {[pkgName]: pkgSemver};
@@ -44,8 +44,8 @@ export async function addCommand(addValue: string, commandOptions: CommandOption
 
 export async function rmCommand(addValue: string, commandOptions: CommandOptions) {
   const {lockfile, config} = commandOptions;
-  if (config.packageOptions.source !== 'skypack') {
-    throw new Error(`rm command requires packageOptions.source="skypack".`);
+  if (config.packageOptions.source !== 'stream') {
+    throw new Error(`rm command requires packageOptions.source="stream".`);
   }
   let [pkgName] = addValue.split('@');
   logger.info(`removing ${cyan(pkgName)} from project lockfile...`);

--- a/snowpack/src/commands/add-rm.ts
+++ b/snowpack/src/commands/add-rm.ts
@@ -13,8 +13,8 @@ import {
 
 export async function addCommand(addValue: string, commandOptions: CommandOptions) {
   const {lockfile, config} = commandOptions;
-  if (config.packageOptions.source !== 'stream') {
-    throw new Error(`add command requires packageOptions.source="stream".`);
+  if (config.packageOptions.source !== 'remote') {
+    throw new Error(`add command requires packageOptions.source="remote".`);
   }
   let [pkgName, pkgSemver] = addValue.split('@');
   const installMessage = pkgSemver ? `${pkgName}@${pkgSemver}` : pkgName;
@@ -36,7 +36,7 @@ export async function addCommand(addValue: string, commandOptions: CommandOption
     },
     await remotePackageSDK.generateImportMap(
       addedDependency,
-      lockfile ? convertLockfileToSkypackImportMap(lockfile) : undefined,
+      lockfile ? convertLockfileToSkypackImportMap(config.packageOptions.origin, lockfile) : undefined,
     ),
   );
   await writeLockfile(path.join(config.root, LOCKFILE_NAME), newLockfile);
@@ -44,8 +44,8 @@ export async function addCommand(addValue: string, commandOptions: CommandOption
 
 export async function rmCommand(addValue: string, commandOptions: CommandOptions) {
   const {lockfile, config} = commandOptions;
-  if (config.packageOptions.source !== 'stream') {
-    throw new Error(`rm command requires packageOptions.source="stream".`);
+  if (config.packageOptions.source !== 'remote') {
+    throw new Error(`rm command requires packageOptions.source="remote".`);
   }
   let [pkgName] = addValue.split('@');
   logger.info(`removing ${cyan(pkgName)} from project lockfile...`);
@@ -53,7 +53,7 @@ export async function rmCommand(addValue: string, commandOptions: CommandOptions
     lockfile?.dependencies ?? {},
     await remotePackageSDK.generateImportMap(
       {[pkgName]: null},
-      lockfile ? convertLockfileToSkypackImportMap(lockfile) : undefined,
+      lockfile ? convertLockfileToSkypackImportMap(config.packageOptions.origin, lockfile) : undefined,
     ),
   );
   delete newLockfile.dependencies[pkgName];

--- a/snowpack/src/commands/prepare.ts
+++ b/snowpack/src/commands/prepare.ts
@@ -6,7 +6,7 @@ import {getPackageSource} from '../util';
 export async function command(commandOptions: CommandOptions) {
   const {config, lockfile} = commandOptions;
   logger.info(colors.yellow('! preparing your project...'));
-  if (config.packageOptions.source === 'skypack') {
+  if (config.packageOptions.source === 'stream') {
     if (!config.packageOptions.types) {
       logger.info(
         colors.green('✔') +

--- a/snowpack/src/commands/prepare.ts
+++ b/snowpack/src/commands/prepare.ts
@@ -6,7 +6,7 @@ import {getPackageSource} from '../util';
 export async function command(commandOptions: CommandOptions) {
   const {config, lockfile} = commandOptions;
   logger.info(colors.yellow('! preparing your project...'));
-  if (config.packageOptions.source === 'stream') {
+  if (config.packageOptions.source === 'remote') {
     if (!config.packageOptions.types) {
       logger.info(
         colors.green('✔') +

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -11,7 +11,7 @@ import {
   CLIFlags,
   MountEntry,
   PackageSourceLocal,
-  PackageSourceSkypack,
+  PackageSourceStream,
   PluginLoadResult,
   RouteConfigObject,
   SnowpackConfig,
@@ -72,8 +72,8 @@ export const DEFAULT_PACKAGES_LOCAL_CONFIG: PackageSourceLocal = {
   knownEntrypoints: [],
 };
 
-const DEFAULT_PACKAGES_SKYPACK_CONFIG: PackageSourceSkypack = {
-  source: 'skypack',
+const DEFAULT_PACKAGES_STREAMING_CONFIG: PackageSourceStream = {
+  source: 'stream',
   external: [],
   cache: '.snowpack',
   types: false,
@@ -498,6 +498,11 @@ function valdiateDeprecatedConfig(rawConfig: any) {
       '[v3.0] "config.install" is now "config.packageOptions.knownEntrypoints".',
     );
   }
+  if (rawConfig.experiments?.source === 'skypack') {
+    handleDeprecatedConfigError(
+      '[v3.0] Experiment promoted! "config.experiments.source=skypack" is now "config.packageOptions.source=stream".',
+    );
+  }
   if (rawConfig.experiments?.source) {
     handleDeprecatedConfigError(
       '[v3.0] Experiment promoted! "config.experiments.source" is now "config.packageOptions.source".',
@@ -625,7 +630,7 @@ function resolveRelativeConfig(config: SnowpackUserConfig, configBase: string): 
   if (config.packageOptions?.source === 'local' && config.packageOptions.cwd) {
     config.packageOptions.cwd = path.resolve(configBase, config.packageOptions.cwd);
   }
-  if (config.packageOptions?.source === 'skypack' && config.packageOptions.cache) {
+  if (config.packageOptions?.source === 'stream' && config.packageOptions.cache) {
     config.packageOptions.cache = path.resolve(configBase, config.packageOptions.cache);
   }
   if (config.extends) {
@@ -684,8 +689,8 @@ export function createConfiguration(config: SnowpackUserConfig = {}): SnowpackCo
       DEFAULT_CONFIG,
       {
         packageOptions:
-          config.packageOptions?.source === 'skypack'
-            ? DEFAULT_PACKAGES_SKYPACK_CONFIG
+          config.packageOptions?.source === 'stream'
+            ? DEFAULT_PACKAGES_STREAMING_CONFIG
             : DEFAULT_PACKAGES_LOCAL_CONFIG,
       },
       config,

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -11,7 +11,7 @@ import {
   CLIFlags,
   MountEntry,
   PackageSourceLocal,
-  PackageSourceStream,
+  PackageSourceRemote,
   PluginLoadResult,
   RouteConfigObject,
   SnowpackConfig,
@@ -72,8 +72,11 @@ export const DEFAULT_PACKAGES_LOCAL_CONFIG: PackageSourceLocal = {
   knownEntrypoints: [],
 };
 
-const DEFAULT_PACKAGES_STREAMING_CONFIG: PackageSourceStream = {
-  source: 'stream',
+const REMOTE_PACKAGE_ORIGIN = 'https://pkg.snowpack.dev';
+
+const DEFAULT_PACKAGES_REMOTE_CONFIG: PackageSourceRemote = {
+  source: 'remote',
+  origin: REMOTE_PACKAGE_ORIGIN,
   external: [],
   cache: '.snowpack',
   types: false,
@@ -500,7 +503,7 @@ function valdiateDeprecatedConfig(rawConfig: any) {
   }
   if (rawConfig.experiments?.source === 'skypack') {
     handleDeprecatedConfigError(
-      '[v3.0] Experiment promoted! "config.experiments.source=skypack" is now "config.packageOptions.source=stream".',
+      '[v3.0] Experiment promoted! "config.experiments.source=skypack" is now "config.packageOptions.source=remote".',
     );
   }
   if (rawConfig.experiments?.source) {
@@ -630,7 +633,7 @@ function resolveRelativeConfig(config: SnowpackUserConfig, configBase: string): 
   if (config.packageOptions?.source === 'local' && config.packageOptions.cwd) {
     config.packageOptions.cwd = path.resolve(configBase, config.packageOptions.cwd);
   }
-  if (config.packageOptions?.source === 'stream' && config.packageOptions.cache) {
+  if (config.packageOptions?.source === 'remote' && config.packageOptions.cache) {
     config.packageOptions.cache = path.resolve(configBase, config.packageOptions.cache);
   }
   if (config.extends) {
@@ -689,8 +692,8 @@ export function createConfiguration(config: SnowpackUserConfig = {}): SnowpackCo
       DEFAULT_CONFIG,
       {
         packageOptions:
-          config.packageOptions?.source === 'stream'
-            ? DEFAULT_PACKAGES_STREAMING_CONFIG
+          config.packageOptions?.source === 'remote'
+            ? DEFAULT_PACKAGES_REMOTE_CONFIG
             : DEFAULT_PACKAGES_LOCAL_CONFIG,
       },
       config,

--- a/snowpack/src/sources/local.ts
+++ b/snowpack/src/sources/local.ts
@@ -53,7 +53,7 @@ async function installDependencies(config: SnowpackConfig) {
 let installOptions: EsinstallOptions;
 
 /**
- * Skypack Package Source: A generic interface through which Snowpack
+ * Local Package Source: A generic interface through which Snowpack
  * interacts with esinstall and your locally installed dependencies.
  */
 export default {

--- a/snowpack/src/sources/stream.ts
+++ b/snowpack/src/sources/stream.ts
@@ -3,16 +3,11 @@ import * as colors from 'kleur/colors';
 import path from 'path';
 import {
   clearCache as clearSkypackCache,
-  buildNewPackage,
-  fetchCDN,
-  installTypes,
-  lookupBySpecifier,
   rollupPluginSkypack,
-  SKYPACK_ORIGIN,
 } from 'skypack';
 import {logger} from '../logger';
 import {ImportMap, LockfileManifest, PackageSource, SnowpackConfig} from '../types';
-import {convertLockfileToSkypackImportMap, isJavaScript} from '../util';
+import {convertLockfileToSkypackImportMap, isJavaScript, remotePackageSDK, REMOTE_PACKAGE_ORIGIN} from '../util';
 import rimraf from 'rimraf';
 
 const fetchedPackages = new Set<string>();
@@ -23,7 +18,7 @@ function logFetching(packageName: string, packageSemver: string | undefined) {
   fetchedPackages.add(packageName);
   logger.info(
     `import ${colors.bold(packageName + (packageSemver ? `@${packageSemver}` : ''))} ${colors.dim(
-      `→ ${SKYPACK_ORIGIN}/${packageName}`,
+      `→ ${REMOTE_PACKAGE_ORIGIN}/${packageName}`,
     )}`,
   );
   if (!packageSemver) {
@@ -63,7 +58,7 @@ export default {
     for (const lockEntry of lockEntryList) {
       const [packageName, semverRange] = lockEntry.split('#');
       const exactVersion = lockfile.lock[lockEntry]?.substr(packageName.length + 1);
-      await installTypes(
+      await remotePackageSDK.installTypes(
         packageName,
         exactVersion || semverRange,
         path.join(this.getCacheFolder(config), 'types'),
@@ -80,7 +75,7 @@ export default {
     installOptions.importMap = lockfile ? convertLockfileToSkypackImportMap(lockfile) : undefined;
     installOptions.rollup = installOptions.rollup || {};
     installOptions.rollup.plugins = installOptions.rollup.plugins || [];
-    installOptions.rollup.plugins.push(rollupPluginSkypack({}) as Plugin);
+    installOptions.rollup.plugins.push(rollupPluginSkypack({sdk: remotePackageSDK}) as Plugin);
     // config.installOptions.lockfile = lockfile || undefined;
     return installOptions;
   },
@@ -89,6 +84,7 @@ export default {
     spec: string,
     {config, lockfile}: {config: SnowpackConfig; lockfile: LockfileManifest | null},
   ): Promise<string | Buffer> {
+    console.log(spec);
     let body: Buffer;
     if (
       spec.startsWith('-/') ||
@@ -96,27 +92,27 @@ export default {
       spec.startsWith('new/') ||
       spec.startsWith('error/')
     ) {
-      body = (await fetchCDN(`/${spec}`)).body;
+      body = (await remotePackageSDK.fetch(`/${spec}`)).body;
     } else {
       const [packageName, packagePath] = parseRawPackageImport(spec);
       if (lockfile && lockfile.dependencies[packageName]) {
         const lockEntry = packageName + '#' + lockfile.dependencies[packageName];
         if (packagePath) {
-          body = (await fetchCDN('/' + lockfile.lock[lockEntry] + '/' + packagePath)).body;
+          body = (await remotePackageSDK.fetch('/' + lockfile.lock[lockEntry] + '/' + packagePath)).body;
         } else {
-          body = (await fetchCDN('/' + lockfile.lock[lockEntry])).body;
+          body = (await remotePackageSDK.fetch('/' + lockfile.lock[lockEntry])).body;
         }
       } else {
         const _packageSemver = lockfile?.dependencies && lockfile.dependencies[packageName];
         logFetching(packageName, _packageSemver);
         const packageSemver = _packageSemver || 'latest';
-        let lookupResponse = await lookupBySpecifier(spec, packageSemver);
+        let lookupResponse = await remotePackageSDK.lookupBySpecifier(spec, packageSemver);
         if (!lookupResponse.error && lookupResponse.importStatus === 'NEW') {
-          const buildResponse = await buildNewPackage(spec, packageSemver);
+          const buildResponse = await remotePackageSDK.buildNewPackage(spec, packageSemver);
           if (!buildResponse.success) {
             throw new Error('Package could not be built!');
           }
-          lookupResponse = await lookupBySpecifier(spec, packageSemver);
+          lookupResponse = await remotePackageSDK.lookupBySpecifier(spec, packageSemver);
         }
         if (lookupResponse.error) {
           throw lookupResponse.error;
@@ -124,7 +120,7 @@ export default {
         // Trigger a type fetch asynchronously. We want to resolve the JS as fast as possible, and
         // the result of this is totally disconnected from the loading flow.
         if (!existsSync(path.join(this.getCacheFolder(config), '.snowpack/types', packageName))) {
-          installTypes(
+          remotePackageSDK.installTypes(
             packageName,
             packageSemver,
             path.join(this.getCacheFolder(config), '.snowpack/types'),

--- a/snowpack/src/sources/stream.ts
+++ b/snowpack/src/sources/stream.ts
@@ -25,12 +25,9 @@ function logFetching(packageName: string, packageSemver: string | undefined) {
     `import ${colors.bold(packageName + (packageSemver ? `@${packageSemver}` : ''))} ${colors.dim(
       `→ ${SKYPACK_ORIGIN}/${packageName}`,
     )}`,
-    {name: 'skypack'},
   );
   if (!packageSemver) {
-    logger.info(colors.yellow(`pin project to this version: \`snowpack add ${packageName}\``), {
-      name: 'skypack',
-    });
+    logger.info(colors.yellow(`pin project to this version: \`snowpack add ${packageName}\``));
   }
 }
 
@@ -45,7 +42,7 @@ function parseRawPackageImport(spec: string): [string, string | null] {
 }
 
 /**
- * Skypack Package Source: A generic interface through which
+ * Stream Package Source: A generic interface through which
  * Snowpack interacts with the Skypack CDN. Used to load dependencies
  * from the CDN during both development and optimized building.
  */
@@ -53,7 +50,7 @@ export default {
   async prepare(commandOptions) {
     const {config, lockfile} = commandOptions;
     // Only install types if `packageOptions.types=true`. Otherwise, no need to prepare anything.
-    if (config.packageOptions.source === 'skypack' && !config.packageOptions.types) {
+    if (config.packageOptions.source === 'stream' && !config.packageOptions.types) {
       return {imports: {}};
     }
     const lockEntryList = lockfile && (Object.keys(lockfile.lock) as string[]);
@@ -161,7 +158,7 @@ export default {
 
   getCacheFolder(config) {
     return (
-      (config.packageOptions.source === 'skypack' && config.packageOptions.cache) ||
+      (config.packageOptions.source === 'stream' && config.packageOptions.cache) ||
       path.join(config.root, '.snowpack')
     );
   },

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -201,8 +201,9 @@ export interface PackageSourceLocal extends Omit<EsinstallOptions, 'alias' | 'de
   knownEntrypoints: string[];
 }
 
-export interface PackageSourceStream {
-  source: 'stream';
+export interface PackageSourceRemote {
+  source: 'remote';
+  origin: string;
   external: string[];
   cache: string;
   types: boolean;
@@ -244,7 +245,7 @@ export interface SnowpackConfig {
   testOptions: {
     files: string[];
   };
-  packageOptions: PackageSourceLocal | PackageSourceStream;
+  packageOptions: PackageSourceLocal | PackageSourceRemote;
   /** Optimize your site for production. */
   optimize?: OptimizeOptions;
   /** Configure routes during development. */

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -201,8 +201,8 @@ export interface PackageSourceLocal extends Omit<EsinstallOptions, 'alias' | 'de
   knownEntrypoints: string[];
 }
 
-export interface PackageSourceSkypack {
-  source: 'skypack';
+export interface PackageSourceStream {
+  source: 'stream';
   external: string[];
   cache: string;
   types: boolean;
@@ -244,7 +244,7 @@ export interface SnowpackConfig {
   testOptions: {
     files: string[];
   };
-  packageOptions: PackageSourceLocal | PackageSourceSkypack;
+  packageOptions: PackageSourceLocal | PackageSourceStream;
   /** Optimize your site for production. */
   optimize?: OptimizeOptions;
   /** Configure routes during development. */

--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -9,17 +9,22 @@ import mkdirp from 'mkdirp';
 import open from 'open';
 import path from 'path';
 import rimraf from 'rimraf';
-import {SKYPACK_ORIGIN} from 'skypack';
+import {SkypackSDK} from 'skypack';
 import url from 'url';
 import localPackageSource from './sources/local';
 import streamingPackageSource from './sources/stream';
 import {ImportMap, LockfileManifest, PackageSource, SnowpackConfig} from './types';
 
+export const REMOTE_PACKAGE_ORIGIN = 'https://pkg.snowpack.dev';
 export const GLOBAL_CACHE_DIR = globalCacheDir('snowpack');
 export const LOCKFILE_NAME = 'snowpack.deps.json';
 
 // We need to use eval here to prevent Rollup from detecting this use of `require()`
 export const NATIVE_REQUIRE = eval('require');
+
+
+export const remotePackageSDK = new SkypackSDK({origin: 'https://pkg.snowpack.dev'});
+
 
 // A note on cache naming/versioning: We currently version our global caches
 // with the version of the last breaking change. This allows us to re-use the
@@ -83,8 +88,8 @@ function sortObject<T>(originalObject: Record<string, T>): Record<string, T> {
 export function convertLockfileToSkypackImportMap(lockfile: LockfileManifest): ImportMap {
   const result = {imports: {}};
   for (const [key, val] of Object.entries(lockfile.lock)) {
-    result.imports[key.replace(/\#.*/, '')] = SKYPACK_ORIGIN + '/' + val;
-    result.imports[key.replace(/\#.*/, '') + '/'] = SKYPACK_ORIGIN + '/' + val + '/';
+    result.imports[key.replace(/\#.*/, '')] = REMOTE_PACKAGE_ORIGIN + '/' + val;
+    result.imports[key.replace(/\#.*/, '') + '/'] = REMOTE_PACKAGE_ORIGIN + '/' + val + '/';
   }
   return result;
 }
@@ -95,7 +100,7 @@ export function convertSkypackImportMapToLockfile(
 ): LockfileManifest {
   const result = {dependencies, lock: {}};
   for (const [key, val] of Object.entries(dependencies)) {
-    result.lock[key + '#' + val] = importMap.imports[key].replace(SKYPACK_ORIGIN + '/', '');
+    result.lock[key + '#' + val] = importMap.imports[key].replace(REMOTE_PACKAGE_ORIGIN + '/', '');
   }
   return result;
 }

--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -12,7 +12,7 @@ import rimraf from 'rimraf';
 import {SKYPACK_ORIGIN} from 'skypack';
 import url from 'url';
 import localPackageSource from './sources/local';
-import skypackPackageSource from './sources/skypack';
+import streamingPackageSource from './sources/stream';
 import {ImportMap, LockfileManifest, PackageSource, SnowpackConfig} from './types';
 
 export const GLOBAL_CACHE_DIR = globalCacheDir('snowpack');
@@ -110,8 +110,8 @@ export function isTruthy<T>(item: T | false | null | undefined): item is T {
   return Boolean(item);
 }
 
-export function getPackageSource(source: 'skypack' | 'local'): PackageSource {
-  return source === 'local' ? localPackageSource : skypackPackageSource;
+export function getPackageSource(source: 'stream' | 'local'): PackageSource {
+  return source === 'local' ? localPackageSource : streamingPackageSource;
 }
 
 /**
@@ -299,7 +299,7 @@ export async function clearCache() {
   return Promise.all([
     cacache.rm.all(BUILD_CACHE),
     localPackageSource.clearCache(),
-    skypackPackageSource.clearCache(),
+    streamingPackageSource.clearCache(),
   ]);
 }
 


### PR DESCRIPTION
## Changes

- Make it more clear what setting this source means
- Experiments with loading from https://pkg.snowpack.dev (just a redirect to skypack, but makes it all feel a bit more integrated)
- ~**Open question:** is "source=stream" the right terminology? Since we use "source=local" to refer to loading your packages out of your node_modules directory, should it be "source=remote" instead?~ Update: I went with `source=remote`

## Testing

- Tested manually

## Docs

- Still TODO before v3.0 release
