### PR TITLE
Allow serving sourcemaps.

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -589,7 +589,7 @@ export async function startServer(commandOptions: CommandOptions): Promise<Snowp
       throw new NotFoundError(attemptedFileLoads);
     }
 
-    if (!isRoute && !isProxyModule) {
+    if (!isRoute && !isProxyModule && !isSourceMap) {
       const expectedUrl = getUrlForFile(foundFile.fileLoc, config);
       if (expectedUrl !== url.parse(reqUrl).pathname) {
         logger.warn(`Bad Request: "${reqUrl}" should be requested as "${expectedUrl}".`);


### PR DESCRIPTION
Allows for sourcemaps to be requested.

## Changes
When a sourcemap was being requested, snowpack would always respond with
```
Bad Request: "/components/hello.js.map" should be requested as "/components/hello.js".
```
Is is because the check to see if the path was invalid was not taking sourcemaps into consideration.
By adding `!isSourceMap`, it allows the request to contiue and successfully server the sourcemap

## Testing
Tested this manually.
After this change, sourcemaps were successfully served.

## Docs
bug fix only
