### PR TITLE
Fix deprecated option buildOptions.metaDir

### DIFF
--- a/plugins/plugin-optimize/test/plugin.test.js
+++ b/plugins/plugin-optimize/test/plugin.test.js
@@ -24,7 +24,7 @@ describe('@snowpack/plugin-optimize', () => {
 
   it('minimal - no options', async () => {
     const pluginInstance = plugin({
-      buildOptions: {metaDir: '_snowpack'},
+      buildOptions: {metaUrlPath: '_snowpack'},
     });
 
     await pluginInstance.optimize({
@@ -38,7 +38,7 @@ describe('@snowpack/plugin-optimize', () => {
   it('minimal - no minification', async () => {
     const pluginInstance = plugin(
       {
-        buildOptions: {metaDir: '_snowpack'},
+        buildOptions: {metaUrlPath: '_snowpack'},
       },
       {
         minifyJS: false,
@@ -58,7 +58,7 @@ describe('@snowpack/plugin-optimize', () => {
   it('no HTML minification, with preloadModules', async () => {
     const pluginInstance = plugin(
       {
-        buildOptions: {metaDir: '_snowpack'},
+        buildOptions: {metaUrlPath: '_snowpack'},
       },
       {
         minifyHTML: false,
@@ -77,7 +77,7 @@ describe('@snowpack/plugin-optimize', () => {
   it('minimal - target', async () => {
     const pluginInstance = plugin(
       {
-        buildOptions: {metaDir: '_snowpack'},
+        buildOptions: {metaUrlPath: '_snowpack'},
       },
       {
         target: ['es2018'],


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Follup to #2251: replace `buildOptions.metaDir` with `buildOptions.metaUrlPath`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

No tests added as this was already causing tests to break

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

Bug fix only