### PR TITLE
Unconditionally add plugin-esbuild to end of plugins list

### DIFF
--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -303,15 +303,8 @@ function loadPlugins(
     plugins.push(plugin);
   });
 
-  // add internal JS handler plugin if none specified
-  const needsDefaultPlugin = new Set(['.mjs', '.jsx', '.ts', '.tsx']);
-  plugins
-    .filter(({resolve}) => !!resolve)
-    .reduce((arr, a) => arr.concat(a.resolve!.input), [] as string[])
-    .forEach((ext) => needsDefaultPlugin.delete(ext));
-  if (needsDefaultPlugin.size > 0) {
-    plugins.unshift(execPluginFactory(esbuildPlugin, {input: [...needsDefaultPlugin]}));
-  }
+  // add internal JS handler plugin
+  plugins.push(execPluginFactory(esbuildPlugin, {input: ['.mjs', '.jsx', '.ts', '.tsx']}));
 
   const extensionMap = plugins.reduce((map, {resolve}) => {
     if (resolve) {


### PR DESCRIPTION
## Changes

Resolves #2265. 

## Testing

I created a fresh React app with `create-snowpack-app` and added a custom plugin that resolved `[".js", ".jsx"]` and returned nothing from its `load()` method. The page failed to load `index.js`, as expected, because `plugin-esbuild` was not added.

I linked this app to a build of Snowpack on this feature branch, cleared the cache, and started the dev server. The page loaded successfully, as expected, because `plugin-esbuild` was run after my custom plugin did not claim any files.

## Docs

This change only matches the expected behavior of the following line, so no docs changes are necessary.

> If load() doesn’t return anything, the file isn’t loaded and the load() of the next suitable plugin is called.

Thanks!
