### PR TITLE
support additional main fields in sub-dependencies

### DIFF
--- a/esinstall/src/entrypoints.ts
+++ b/esinstall/src/entrypoints.ts
@@ -5,6 +5,15 @@ import {ExportField, ExportMapEntry, PackageManifestWithExports, PackageManifest
 import {parsePackageImportSpecifier, resolveDependencyManifest} from './util';
 import pm from 'picomatch';
 
+export const MAIN_FIELDS = [
+  'browser:module',
+  'module',
+  'browser',
+  'main:esnext',
+  'jsnext:main',
+  'main',
+];
+
 // Rarely, a package will ship a broken "browser" package.json entrypoint.
 // Ignore the "browser" entrypoint in those packages.
 const BROKEN_BROWSER_ENTRYPOINT = ['@sheerun/mutationobserver-shim'];
@@ -39,17 +48,11 @@ export function findManifestEntry(
     }
   }
 
-  foundEntrypoint = [
-    ...packageLookupFields,
-    'browser:module',
-    'module',
-    'main:esnext',
-    'jsnext:main',
-  ]
+  foundEntrypoint = [...packageLookupFields, ...MAIN_FIELDS]
     .map((e) => manifest[e])
     .find(Boolean);
 
-  if (foundEntrypoint) {
+  if (foundEntrypoint && typeof foundEntrypoint === 'string') {
     return foundEntrypoint;
   }
 

--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -317,7 +317,7 @@ ${colors.dim(
       }),
       rollupPluginCatchFetch(),
       rollupPluginNodeResolve({
-        mainFields: MAIN_FIELDS,
+        mainFields: [...packageLookupFields, ...MAIN_FIELDS],
         extensions: ['.mjs', '.cjs', '.js', '.json'], // Default: [ '.mjs', '.js', '.json', '.node' ]
         // whether to prefer built-in modules (e.g. `fs`, `path`) or local ones with the same names
         preferBuiltins: true, // Default: true

--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -37,7 +37,7 @@ import {
   sanitizePackageName,
   writeLockfile,
 } from './util';
-import {resolveEntrypoint} from './entrypoints';
+import {resolveEntrypoint, MAIN_FIELDS} from './entrypoints';
 
 export * from './types';
 export {
@@ -317,7 +317,7 @@ ${colors.dim(
       }),
       rollupPluginCatchFetch(),
       rollupPluginNodeResolve({
-        mainFields: ['browser:module', 'module', 'browser', 'main'],
+        mainFields: MAIN_FIELDS,
         extensions: ['.mjs', '.cjs', '.js', '.json'], // Default: [ '.mjs', '.js', '.json', '.node' ]
         // whether to prefer built-in modules (e.g. `fs`, `path`) or local ones with the same names
         preferBuiltins: true, // Default: true


### PR DESCRIPTION
## Changes

In #2146, manifest entry resolution was expanded to include `main:esnext` and `jsnext:main`, but that currently only works for direct dependencies. In order to support sub-dependencies (dependencies of dependencies), the `mainFields` config for `rollupPluginNodeResolve` should be updated as well. Instead of just copying them over, I've added a single `MAIN_FIELDS` definition and used it in both places.

This PR was created as a result of this discussion: https://github.com/snowpackjs/snowpack/discussions/1669

## Testing

No tests were added as this doesn't add any new functionality. The only functional difference is that 2 new fields are included in Rollup's main field resolution, but there's no need to test that. Existing unit tests around `findManifestEntry` were confirmed to still pass.

## Docs

Bug fix only.
