### PR TITLE
fix snowpack.config.js copy operation on init

### DIFF
--- a/snowpack/src/commands/init.ts
+++ b/snowpack/src/commands/init.ts
@@ -3,7 +3,7 @@ import {bold, dim} from 'kleur/colors';
 import path from 'path';
 import {logger} from '../logger';
 import {CommandOptions} from '../types';
-import {INIT_TEMPLATE_FILE} from '../util';
+import {INIT_TEMPLATE_FILENAME} from '../util';
 
 export async function command(commandOptions: CommandOptions) {
   const {config} = commandOptions;
@@ -13,6 +13,6 @@ export async function command(commandOptions: CommandOptions) {
     logger.error(`Error: File already exists, cannot overwrite ${destLoc}`);
     process.exit(1);
   }
-  await fs.copyFile(INIT_TEMPLATE_FILE, destLoc, fsConstants.COPYFILE_EXCL);
+  await fs.copyFile(INIT_TEMPLATE_FILENAME, destLoc, fsConstants.COPYFILE_EXCL);
   logger.info(`File created! Open ${bold('snowpack.config.js')} to customize your project.`);
 }

--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -477,7 +477,5 @@ export const HMR_OVERLAY_CODE = fs.readFileSync(
   path.resolve(__dirname, '../assets/hmr-error-overlay.js'),
   'utf8',
 );
-export const INIT_TEMPLATE_FILE = fs.readFileSync(
-  path.resolve(__dirname, '../assets/snowpack-init-file.js'),
-  'utf8',
-);
+
+export const INIT_TEMPLATE_FILENAME = path.resolve(__dirname, '../assets/snowpack-init-file.js');


### PR DESCRIPTION
## Changes

Running `npx snowpack init` on a new project failed to copy the configuration template file. https://github.com/snowpackjs/snowpack/discussions/2285

## Testing

Tests are passing

## Docs

Docs not updated, fixed existing feature.
