### PR TITLE
hmr port improvement for middleware use-case

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -656,7 +656,7 @@ export async function startServer(commandOptions: CommandOptions): Promise<Snowp
         code = wrapHtmlResponse({
           code: code as string,
           hmr: isHMR,
-          hmrPort: hmrEngine.port !== port ? hmrEngine.port : undefined,
+          hmrPort: hmrEngine ? hmrEngine.port : undefined,
           isDev: true,
           config,
           mode: 'development',

--- a/test-dev/__snapshots__/dev.test.ts.snap
+++ b/test-dev/__snapshots__/dev.test.ts.snap
@@ -3,7 +3,8 @@
 exports[`snowpack dev smoke: about 1`] = `
 "<!DOCTYPE html>
 <html>
-  <head><script type=\\"module\\" integrity=\\"sha384-ZsG+E+8Q6Yh0v98Nd0SfOT1bOX82TJaNaBS1npTZYuq4oD09c6rDD2R9pXqMvter\\" src=\\"/_snowpack/hmr-client.js\\"></script><script type=\\"module\\" integrity=\\"sha384-LH/mFhEGRB4jHedP0nqOoIUwc4VX8eWJxEL+qTGWtroqiLJ2vxX169J0oSBMHL5o\\" src=\\"/_snowpack/hmr-error-overlay.js\\"></script></head>
+  <head><script type=\\"text/javascript\\">window.HMR_WEBSOCKET_PORT=8080</script>
+<script type=\\"module\\" integrity=\\"sha384-ZsG+E+8Q6Yh0v98Nd0SfOT1bOX82TJaNaBS1npTZYuq4oD09c6rDD2R9pXqMvter\\" src=\\"/_snowpack/hmr-client.js\\"></script><script type=\\"module\\" integrity=\\"sha384-LH/mFhEGRB4jHedP0nqOoIUwc4VX8eWJxEL+qTGWtroqiLJ2vxX169J0oSBMHL5o\\" src=\\"/_snowpack/hmr-error-overlay.js\\"></script></head>
   <body>
     <p>this is a template in some language that builds to .html</p>
   </body>
@@ -20,7 +21,8 @@ exports[`snowpack dev smoke: html 1`] = `
     <meta name=\\"description\\" content=\\"Web site created using create-snowpack-app\\" />
     <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"/index.css\\" />
     <title>Snowpack App</title>
-  <script type=\\"module\\" integrity=\\"sha384-ZsG+E+8Q6Yh0v98Nd0SfOT1bOX82TJaNaBS1npTZYuq4oD09c6rDD2R9pXqMvter\\" src=\\"/_snowpack/hmr-client.js\\"></script><script type=\\"module\\" integrity=\\"sha384-LH/mFhEGRB4jHedP0nqOoIUwc4VX8eWJxEL+qTGWtroqiLJ2vxX169J0oSBMHL5o\\" src=\\"/_snowpack/hmr-error-overlay.js\\"></script></head>
+  <script type=\\"text/javascript\\">window.HMR_WEBSOCKET_PORT=8080</script>
+<script type=\\"module\\" integrity=\\"sha384-ZsG+E+8Q6Yh0v98Nd0SfOT1bOX82TJaNaBS1npTZYuq4oD09c6rDD2R9pXqMvter\\" src=\\"/_snowpack/hmr-client.js\\"></script><script type=\\"module\\" integrity=\\"sha384-LH/mFhEGRB4jHedP0nqOoIUwc4VX8eWJxEL+qTGWtroqiLJ2vxX169J0oSBMHL5o\\" src=\\"/_snowpack/hmr-error-overlay.js\\"></script></head>
   <body>
     <img id=\\"img\\" src=\\"/logo.svg\\" />
     <canvas id=\\"canvas\\"></canvas>


### PR DESCRIPTION
## Changes

- Always sets the HMR port during development, even if it matches the dev server port
- Still inherits from dev server port if not defined by the user, so most users won't even notice the difference
- Solves one of the issues mentioned here: https://github.com/snowpackjs/snowpack/discussions/2288#discussioncomment-285480
- /cc @Xiot @aral
## Testing

N/A

## Docs

N/A (actually better matches documented behavior)