### PR TITLE
Allow creating dev server without opening port.

### DIFF
--- a/snowpack/src/commands/build.ts
+++ b/snowpack/src/commands/build.ts
@@ -423,7 +423,9 @@ export async function build(commandOptions: CommandOptions): Promise<SnowpackBui
       path.resolve(internalFilesBuildLoc, 'hmr-error-overlay.js'),
       HMR_OVERLAY_CODE,
     );
-    hmrEngine = new EsmHmrEngine({port: config.devOptions.hmrPort});
+    hmrEngine = new EsmHmrEngine({
+      port: config.devOptions.hmrPort,
+    });
   }
 
   logger.info(colors.yellow('! building source files...'));

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -1207,7 +1207,10 @@ export async function startServer(commandOptions: CommandOptions): Promise<Snowp
 
     return new EsmHmrEngine({
       delay: config.devOptions.hmrDelay ?? 0,
-      server: createServer(() => {}).listen(hmrPort),
+      server: createServer((_, res) => {
+        res.writeHead(426);
+        res.end('Upgrade Required');
+      }),
       port: hmrPort
     })
   }

--- a/snowpack/src/hmr-server-engine.ts
+++ b/snowpack/src/hmr-server-engine.ts
@@ -77,10 +77,8 @@ export class EsmHmrEngine implements IEsmHmrEngine {
       ? new WebSocket.Server({noServer: true})
       : new WebSocket.Server({port: options.port ?? DEFAULT_PORT });
 
-      // @ts-ignore - if address is a string, then the fallbacks will still return the proper value
-    this.port = wss.address()?.port
-      // @ts-ignore - if address is a string, then the fallbacks will still return the proper value
-      ?? this.server?.address()?.port
+    this.port = portOf(wss)
+      ?? portOf(options.server)
       ?? options.port
       ?? DEFAULT_PORT;
 
@@ -282,4 +280,13 @@ export class EsmHmrEngine implements IEsmHmrEngine {
       this.disconnectClient(client);
     }
   }
+}
+
+function portOf(server: WebSocket.Server | http.Server | http2.Http2SecureServer | undefined): number | null {
+  if (!server) { return null; }
+  if (server instanceof WebSocket.Server) {
+    return server.options.noServer ? null : portOf(server.options.server) ?? server.options.port ?? null
+  }
+  // @ts-ignore - fallback handles case where address is a string
+  return server.listening ? server.address()?.port ?? null : null;
 }

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -250,6 +250,7 @@ export interface SnowpackConfig {
     secure: boolean;
     hostname: string;
     port: number;
+    server?: boolean;
     open: string;
     output: 'stream' | 'dashboard';
     hmr?: boolean;


### PR DESCRIPTION
Added a config for `devOptions.server?: boolean` which defaults to `true`;
If `false`, then no http(s) server will be created and it will be up to
the caller to create the initial server.

Created a stub for EsmHmrEngine that avoids any processing if HMR is disabled.

## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

TODO: Add Tests

## Docs

TODO: Update Docs
