### PR TITLE
chore: remove duplicate import specifier check

### DIFF
--- a/snowpack/src/build/import-resolver.ts
+++ b/snowpack/src/build/import-resolver.ts
@@ -6,7 +6,6 @@ import {
   findMatchingAliasEntry,
   getExtensionMatch,
   hasExtension,
-  isRemoteUrl,
   replaceExtension,
 } from '../util';
 import {getUrlForFile} from './file-urls';
@@ -69,14 +68,6 @@ function resolveSourceSpecifier(lazyFileLoc: string, config: SnowpackConfig) {
  */
 export function createImportResolver({fileLoc, config}: {fileLoc: string; config: SnowpackConfig}) {
   return function importResolver(spec: string): string | false {
-    // Ignore "http://*" imports
-    if (isRemoteUrl(spec)) {
-      return spec;
-    }
-    // Ignore packages marked as external
-    if (config.packageOptions.external?.includes(spec)) {
-      return spec;
-    }
     if (spec.startsWith('/')) {
       return spec;
     }

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -715,6 +715,15 @@ export async function startServer(commandOptions: CommandOptions): Promise<Snowp
           baseExt: responseExt,
         },
         (spec) => {
+          // Ignore "http://*" imports
+          if (isRemoteUrl(spec)) {
+            return spec;
+          }
+          // Ignore packages marked as external
+          if (config.packageOptions.external?.includes(spec)) {
+            return spec;
+          }
+
           // Try to resolve the specifier to a known URL in the project
           let resolvedImportUrl = resolveImportSpecifier(spec);
           // Handle a package import
@@ -726,14 +735,7 @@ export async function startServer(commandOptions: CommandOptions): Promise<Snowp
             missingPackages.push(spec);
             return spec;
           }
-          // Ignore "http://*" imports
-          if (isRemoteUrl(resolvedImportUrl)) {
-            return resolvedImportUrl;
-          }
-          // Ignore packages marked as external
-          if (config.packageOptions.external?.includes(resolvedImportUrl)) {
-            return spec;
-          }
+
           // Handle normal "./" & "../" import specifiers
           const importExtName = path.posix.extname(resolvedImportUrl);
           const isProxyImport = importExtName && importExtName !== '.js';


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
Now we have checked these two import specifier twice, this change make it only checked once.
## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->
Just for a little optimize.
## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
Just for a little optimize.