### PR TITLE
Add root level export of clearCache

### DIFF
--- a/snowpack/src/index.ts
+++ b/snowpack/src/index.ts
@@ -17,7 +17,7 @@ export * from './types';
 export {startServer} from './commands/dev';
 export {build} from './commands/build';
 export {loadConfiguration, createConfiguration} from './config.js';
-export {readLockfile as loadLockfile} from './util.js';
+export {clearCache, readLockfile as loadLockfile} from './util.js';
 export {getUrlForFile} from './build/file-urls';
 export {logger} from './logger';
 


### PR DESCRIPTION
## Changes

This adds a root-level export of `clearCache` (otherwise, consumers must import it as `import { clearCache } from 'snowpack/util.js'`).

[From discussion here.](https://github.com/snowpackjs/snowpack/discussions/2154#discussioncomment-282381)

## Testing

I don't believe this requires additional tests.

Running `yarn test` locally from root I see:

```
Test Suites: 58 failed, 2 skipped, 14 passed, 72 of 74 total
Tests:       77 failed, 7 skipped, 71 passed, 155 total
Snapshots:   2 failed, 149 obsolete, 37 passed, 39 total
```

On the master `main` branch, I see:

```
Test Suites: 58 failed, 2 skipped, 14 passed, 72 of 74 total
Tests:       77 failed, 7 skipped, 71 passed, 155 total
Snapshots:   2 failed, 149 obsolete, 37 passed, 39 total
```

So I'm seeing test failures across the repo, but this PR does not introduce any new regressions.

## Docs

No documentation is added.

(It's not clear to me whether it should be, as there's currently no documentation around `clearCache` in general, but I'd be happy to add some if required.)