### PR TITLE
fix: prettier snowpack/src/build dir

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 vendor
 dist
-build
+test/**/build
+create-snowpack-app/**/build
 packages
 pkg
 TEST_BUILD_OUT

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "jest": "^26.2.2",
     "jest-specific-snapshot": "^4.0.0",
     "lerna": "^3.22.1",
-    "prettier": "^2.0.5",
+    "prettier": "^2.2.1",
     "strip-ansi": "^6.0.0",
     "typescript": "^4.0.0"
   },

--- a/snowpack/src/build/build-pipeline.ts
+++ b/snowpack/src/build/build-pipeline.ts
@@ -177,8 +177,7 @@ async function runPipelineTransformStep(
           output[destExt].map = undefined;
         } else if (result && typeof result === 'object') {
           // V2 API, structured result variant
-          const contents =
-            (result as PluginTransformResult).contents || (result as any).result;
+          const contents = (result as PluginTransformResult).contents || (result as any).result;
           if (contents) {
             output[destExt].code = contents;
             const map = (result as PluginTransformResult).map;

--- a/snowpack/src/build/import-resolver.ts
+++ b/snowpack/src/build/import-resolver.ts
@@ -51,13 +51,13 @@ function resolveSourceSpecifier(lazyFileLoc: string, config: SnowpackConfig) {
   const extensionMatch = getExtensionMatch(lazyFileLoc, config._extensionMap);
 
   if (extensionMatch) {
-  const [inputExt, outputExts] = extensionMatch;
-  if (outputExts.length > 1) {
-    lazyFileLoc = addExtension(lazyFileLoc, outputExts[0]);
-  } else {
-    lazyFileLoc = replaceExtension(lazyFileLoc, inputExt, outputExts[0]);
+    const [inputExt, outputExts] = extensionMatch;
+    if (outputExts.length > 1) {
+      lazyFileLoc = addExtension(lazyFileLoc, outputExts[0]);
+    } else {
+      lazyFileLoc = replaceExtension(lazyFileLoc, inputExt, outputExts[0]);
+    }
   }
-}
 
   return getUrlForFile(lazyFileLoc, config);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11783,7 +11783,7 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^2.0.5:
+prettier@^2.0.5, prettier@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
   integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
This line ignore all `build` directories, includes `snowpack/src/build` which shouldn't be exclude.
https://github.com/snowpackjs/snowpack/blob/df3919802f85278722ad2b9fb252959d0c2a02c5/.prettierignore#L3

So we need to add `!snowpack/**` to `.prettierignore` too so that `snowpack/src/build` directory can be formated too.

Refs: https://github.com/snowpackjs/snowpack/commit/690d3b1d6dae52cb212c1195b6ebeadd531f8820#r46029320
## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->
Format.
## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
Format.