### PR TITLE
Add a way to config Hmr Error Overlay ignore some error.

### DIFF
--- a/snowpack/assets/hmr-client.js
+++ b/snowpack/assets/hmr-client.js
@@ -236,6 +236,15 @@ log('listening for file changes...');
 
 /** Runtime error reporting: If a runtime error occurs, show it in an overlay. */
 isWindowDefined && window.addEventListener('error', function (event) {
+  if (window.snowpackHmrErrorOverlayIgnoreErrors) {
+    const ignoreErrors = window.snowpackHmrErrorOverlayIgnoreErrors;
+    for (const item of ignoreErrors) {
+      if (event.message && event.message.match(item)) {
+        console.warn('[ESM-HMR] Hmr Error Overlay Ignored', event.message);
+        return
+      }
+    }
+  }
   // Generate an "error location" string
   let fileLoc;
   if (event.filename) {


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Some time we when to ignore some error when use Hmr Error Overlay. Such as error: [ResizeObserver loop limit exceeded] (https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded).

Learn from Sentry, https://blog.sentry.io/2017/03/27/tips-for-reducing-javascript-error-noise#ignore-troublesome-errors, I add `window.snowpackHmrErrorOverlayIgnoreErrors` to do it.

Code: https://github.com/snowpackjs/snowpack/pull/2363/files#diff-a469e5beb7b6062baa2325f61e5d5e73a94c17767fa166a42ef32920dca89e0aR239

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

No need update test case, need test it manually.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

TODO, may be explain this in here: https://www.snowpack.dev/reference/configuration#devoptions.hmrerroroverlay