### PR TITLE
Add proper default browser support for mac

### DIFF
--- a/snowpack/package.json
+++ b/snowpack/package.json
@@ -45,6 +45,7 @@
     "vendor"
   ],
   "dependencies": {
+    "default-browser-id": "^2.0.0",
     "esbuild": "^0.8.7",
     "open": "^7.0.4",
     "rollup": "^2.34.0"

--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -14,6 +14,7 @@ import url from 'url';
 import localPackageSource from './sources/local';
 import remotePackageSource from './sources/remote';
 import {ImportMap, LockfileManifest, PackageSource, SnowpackConfig} from './types';
+import getDefaultBrowserId from 'default-browser-id';
 
 export const GLOBAL_CACHE_DIR = globalCacheDir('snowpack');
 export const LOCKFILE_NAME = 'snowpack.deps.json';
@@ -263,13 +264,13 @@ export async function openInBrowser(
     : /brave/i.test(browser)
     ? appNames[process.platform]['brave']
     : browser;
-  const isMac = process.platform === 'darwin';
-  const isBrowserChrome = /chrome|default/i.test(browser);
-  if (!isMac || !isBrowserChrome) {
+  const isMacChrome =
+    process.platform === 'darwin' &&
+    (/chrome/i.test(browser) || /chrome/i.test(await getDefaultBrowserId()));
+  if (!isMacChrome) {
     await (browser === 'default' ? open(url) : open(url, {app: browser}));
     return;
   }
-
   try {
     // If we're on macOS, and we haven't requested a specific browser,
     // we can try opening Chrome with AppleScript. This lets us reuse an

--- a/yarn.lock
+++ b/yarn.lock
@@ -4300,6 +4300,11 @@ better-assert@~1.0.0:
   dependencies:
     callsite "1.0.0"
 
+big-integer@^1.6.7:
+  version "1.6.48"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
+  integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -4360,6 +4365,13 @@ bootstrap@^4.5.2:
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.5.3.tgz#c6a72b355aaf323920be800246a6e4ef30997fe6"
   integrity sha512-o9ppKQioXGqhw8Z7mah6KdTYpNQY//tipnkxppWhPbiSWdD+1raYsnhwEZjkTHYbGee4cVQ0Rx65EhOY/HNLcQ==
+
+bplist-parser@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/bplist-parser/-/bplist-parser-0.1.1.tgz#d60d5dcc20cba6dc7e1f299b35d3e1f95dafbae6"
+  integrity sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=
+  dependencies:
+    big-integer "^1.6.7"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -6102,6 +6114,15 @@ deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
+default-browser-id@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/default-browser-id/-/default-browser-id-2.0.0.tgz#01ecce371a71e85f15a17177e7863047e73dbe7d"
+  integrity sha1-AezONxpx6F8VoXF354YwR+c9vn0=
+  dependencies:
+    bplist-parser "^0.1.0"
+    pify "^2.3.0"
+    untildify "^2.0.0"
 
 defaults@^1.0.3:
   version "1.0.3"
@@ -14467,6 +14488,13 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+untildify@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/untildify/-/untildify-2.1.0.tgz#17eb2807987f76952e9c0485fc311d06a826a2e0"
+  integrity sha1-F+soB5h/dpUunASF/DEdBqgmouA=
+  dependencies:
+    os-homedir "^1.0.0"
 
 upath@^1.1.1, upath@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## Changes

- Currently, we'd always open Chrome on mac machines when "open" was set to default
- This fixes that support with a proper lookup to first check that chrome is your default browser

## Testing

- Too env-specific to test

## Docs

- N/A