### PR TITLE
Support verbose flag for template installation

### DIFF
--- a/create-snowpack-app/cli/createSnowpackApp.js
+++ b/create-snowpack-app/cli/createSnowpackApp.js
@@ -23,7 +23,7 @@ function hasPmInstalled(packageManager) {
 }
 
 function validateArgs(args) {
-  const {template, useYarn, usePnpm, force, target, install, _} = yargs(args);
+  const {template, useYarn, usePnpm, force, target, install, verbose, _} = yargs(args);
   const toInstall = install !== undefined ? install : true;
   if (useYarn && usePnpm) {
     logError('You can not use Yarn and pnpm at the same time.');
@@ -55,6 +55,7 @@ function validateArgs(args) {
     targetDirectoryRelative,
     targetDirectory,
     toInstall,
+    verbose,
   };
 }
 
@@ -125,6 +126,7 @@ const {
   toInstall,
   targetDirectoryRelative,
   targetDirectory,
+  verbose,
 } = validateArgs(process.argv);
 
 let installer = 'npm';
@@ -144,16 +146,19 @@ const installedTemplate = isLocalTemplate
 
   console.log(`\n  - Using template ${colors.cyan(template)}`);
   console.log(`  - Creating a new project in ${colors.cyan(targetDirectory)}`);
-
   fs.mkdirSync(targetDirectory, {recursive: true});
   await fs.promises.writeFile(path.join(targetDirectory, 'package.json'), `{"name": "my-csa-app"}`);
   // fetch from npm or GitHub if not local (which will be most of the time)
   if (!isLocalTemplate) {
     try {
-      await execa('npm', ['install', template, '--ignore-scripts'], {
-        cwd: targetDirectory,
-        all: true,
-      });
+      await execa(
+        'npm',
+        ['install', template, '--ignore-scripts', '--loglevel', verbose ? 'verbose' : 'error'],
+        {
+          cwd: targetDirectory,
+          all: true,
+        },
+      );
     } catch (err) {
       // Only log output if the command failed
       console.error(err.all);
@@ -174,11 +179,19 @@ const installedTemplate = isLocalTemplate
     function installProcess(packageManager) {
       switch (packageManager) {
         case 'npm':
-          return execa('npm', ['install', '--loglevel', 'error'], npmInstallOptions);
+          return execa(
+            'npm',
+            ['install', '--loglevel', verbose ? 'verbose' : 'error'],
+            npmInstallOptions,
+          );
         case 'yarn':
-          return execa('yarn', ['--silent'], npmInstallOptions);
+          return execa('yarn', [verbose ? '--verbose' : '--silent'], npmInstallOptions);
         case 'pnpm':
-          return execa('pnpm', ['install', '--reporter=silent'], npmInstallOptions);
+          return execa(
+            'pnpm',
+            ['install', `--reporter=${verbose ? 'default' : 'silent'}`],
+            npmInstallOptions,
+          );
         default:
           throw new Error('Unspecified package installer.');
       }


### PR DESCRIPTION
## Changes

Support `--verbose` flag in template installations

## Testing

Linking and running `npx create-snowpack-app new-project-directory --template  @snowpack/app-template-react --verbose`

## Docs

Not yet
