### PR TITLE
fix polyfill info link in Starting a New Project tutorial

### DIFF
--- a/www/_template/tutorials/getting-started.md
+++ b/www/_template/tutorials/getting-started.md
@@ -171,7 +171,7 @@ You should now see a nifty confetti effect on your site.
 
 <div class="frame"><img src="/img/guides/getting-started/npm-snowpack-confetti.gif" alt="Gif showing the code next to the project running in the browser. When the code snippet is added and saved, a confetti effect shows in the browser" class="screenshot"/></div>
 
-> 💡 Tip: not all npm modules may work well in the browser. Modules dependent on Node.js built-in modules need a polyfill. Read more about how to do this on our [Starting a New Project page.](/tutorials/getting-started#using-npm-packages)
+> 💡 Tip: not all npm modules may work well in the browser. Modules dependent on Node.js built-in modules need a polyfill. You can enable this polyfill by setting Snowpack’s [`packageOptions.polyfillNode` configuration option](/reference/configuration#packageoptions.polyfillnode) to `true`.
 
 ## Adding CSS
 


### PR DESCRIPTION
a followup from discussion https://github.com/snowpackjs/snowpack/discussions/2350

## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

In https://www.snowpack.dev/tutorials/getting-started#using-npm-packages, replace the accidentally-self-referential link with one that actually helps you learn how to enable the polyfill for Node.js built-in modules.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

Docs-only change. Tested by previewing the Markdown in GitHub.

Later, also I tested by looking at the built preview of this PR and confirming the text looks good and the link works: https://snowpack-lqpwcmpu9.vercel.app/tutorials/getting-started#using-npm-packages

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

Docs and only docs were changed.
