### PR TITLE
Add import support for .interface files, alongside .svelte, and .vue.

### DIFF
--- a/snowpack/src/scan-imports.ts
+++ b/snowpack/src/scan-imports.ts
@@ -191,6 +191,7 @@ function parseFileForInstallTargets({
       }
       case '.html':
       case '.svelte':
+      case '.interface':
       case '.vue': {
         logger.debug(`Scanning ${relativeLoc} for imports as HTML`);
         return [
@@ -227,7 +228,7 @@ function extractJsFromHtml({contents, baseExt}: {contents: string; baseExt: stri
   const allMatches: string[][] = [];
   let match;
   let regex = new RegExp(HTML_JS_REGEX);
-  if (baseExt === '.svelte' || baseExt === '.vue') {
+  if (baseExt === '.svelte' || baseExt === '.interface' || baseExt === '.vue') {
     regex = new RegExp(SVELTE_VUE_REGEX); // scan <script> tags, not <script type="module">
   }
   while ((match = regex.exec(contents))) {


### PR DESCRIPTION
See https://github.com/snowpackjs/snowpack/discussions/2360 for discussion.

## Changes

- Adds import parsing/support to `.interface` files (used by [Place](https://github.com/small-tech/place), the work-in-progress [Small Web](https://small-tech.org/research-and-development/) tool that’s a fork of our own [Site.js](https://sitejs.org)).

This change is backwards compatible and doesn’t affect existing functionality.

Outside of its use on Small Web projects, it means that `.interface` can be used as a generic file format for interface files (alongside `.svelte` and `.vue`) and that imports from those files will be parsed just like they are for the existing two.

## Testing

  - All current tests pass.
  - Given its niche usage, I’m not sure if it requires its own test.

## Docs

I don’t think it needs to be documented currently. Once the Small Web / Place are more widely being used, it might be worth revisiting that.