### PR TITLE
Support snowpack server config overrides in web-test-runner-plugin

### DIFF
--- a/plugins/web-test-runner-plugin/plugin.js
+++ b/plugins/web-test-runner-plugin/plugin.js
@@ -15,10 +15,13 @@ To Resolve:
   return {
     name: 'snowpack-plugin',
     async serverStart({fileWatcher}) {
-      config = await snowpack.loadConfiguration({
-        packageOptions: {external: ['/__web-dev-server__web-socket.js']},
-        devOptions: {open: 'none', output: 'stream', hmr: false},
-      });
+      const configOverrides = Object.assign({}, snowpackConfig);
+      configOverrides.packageOptions = configOverrides.packageOptions || {};
+      configOverrides.packageOptions.external = configOverrides.packageOptions.external || [];
+      configOverrides.packageOptions.external.push('/__web-dev-server__web-socket.js');
+      configOverrides.devOptions = Object.assign({}, { open: 'none', output: 'stream', hmr: false }, configOverrides.devOptions);
+
+      config = await snowpack.loadConfiguration(configOverrides);
       fileWatcher.add(Object.keys(config.mount));
       server = await snowpack.startServer({
         config,


### PR DESCRIPTION
## Changes

Merge the snowpackConfig that can be passed in to the plugin with the overrides used to start the snowpack server in the plugin.

## Testing

I manually verified the change in a project using snowpack and @web/test-runner.

## Docs

I didn't update the docs. I wasn't sure if you wanted to advertise this since the docs say there are no options to configure even though there already was one used in the plugin. I'm happy to update docs if you'd like.
