### PR TITLE
Fix markdown in Svelte and React tutorials

### DIFF
--- a/www/_template/tutorials/react.md
+++ b/www/_template/tutorials/react.md
@@ -51,7 +51,7 @@ Now that you have a basic project up and running, to install React, run the foll
 npm install react react-dom --save
 ```
 
-> 💡 Tip: add the "--use-yarn" or "--use-pnpm" flag to use something other than npm
+> 💡 Tip: add the `--use-yarn` or `--use-pnpm` flag to use something other than npm
 
 ## Create your first React component
 

--- a/www/_template/tutorials/svelte.md
+++ b/www/_template/tutorials/svelte.md
@@ -52,7 +52,7 @@ Now that you have a basic project up and running! The next step is to install Sv
 npm install svelte --save
 ```
 
-> 💡 Tip: add the "--use-yarn" or "--use-pnpm" flag to use something other than npm
+> 💡 Tip: add the `--use-yarn` or `--use-pnpm` flag to use something other than npm
 
 ```bash
 npm install @snowpack/plugin-svelte --save-dev


### PR DESCRIPTION
## Changes

React and Svelte quick start tutorials have this useful section:

<img width="757" alt="image" src="https://user-images.githubusercontent.com/2337671/105465228-3c01dd80-5cc5-11eb-82a8-967c2f99273d.png">

Markdown changes two hyphens `--` to an n-dash `–`. When pasting these flags in Terminal I get `[ERROR] Unexpected extra arguments.`

I changed quotes around these flags to a code block to avoid symbol conversion. They would look like `README.md` in a block just above:

<img width="756" alt="image" src="https://user-images.githubusercontent.com/2337671/105465575-aadf3680-5cc5-11eb-8434-948dcf17a67c.png">


## Testing

This change was not tested, because it is a pretty simple Markdown fix.

## Docs

No docs other than the subject of this PR were changed, it is a cosmetic fix.
