### PR TITLE
Add extensible resolve paths option

### DIFF
--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -85,7 +85,7 @@ function isImportOfPackage(importUrl: string, packageName: string) {
  */
 function resolveWebDependency(
   dep: string,
-  resolveOptions: {cwd: string; packageLookupFields: string[]},
+  resolveOptions: {cwd: string; packageLookupFields: string[], resolvePaths: string[]},
 ): DependencyLoc {
   const loc = resolveEntrypoint(dep, resolveOptions);
 
@@ -115,6 +115,7 @@ function generateEnvReplacements(env: Object): {[key: string]: string} {
 
 interface InstallOptions {
   cwd: string;
+  resolvePaths?: string[];
   alias: Record<string, string>;
   importMap?: ImportMap;
   logger: AbstractLogger;
@@ -158,6 +159,7 @@ function setOptionDefaults(_options: PublicInstallOptions): InstallOptions {
   }
   const options = {
     cwd: process.cwd(),
+    resolvePaths: [],
     alias: {},
     logger: {
       debug: () => {}, // silence debug messages by default
@@ -189,6 +191,7 @@ export async function install(
 ): Promise<InstallResult> {
   const {
     cwd,
+    resolvePaths,
     alias: installAlias,
     importMap: _importMap,
     logger,
@@ -261,6 +264,7 @@ export async function install(
       const resolvedResult = resolveWebDependency(installSpecifier, {
         cwd,
         packageLookupFields,
+        resolvePaths: resolvePaths || []
       });
       if (resolvedResult.type === 'BUNDLE') {
         installEntrypoints[targetName] = resolvedResult.loc;

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -1346,7 +1346,7 @@ export async function startServer(commandOptions: CommandOptions): Promise<Snowp
     Object.keys(sourceImportMap.imports)
       .map((specifier) => {
         const [packageName] = parsePackageImportSpecifier(specifier);
-        return resolveDependencyManifest(packageName, config.root);
+        return resolveDependencyManifest(packageName, config.root, config.packageOptions.resolvePaths);
       }) // resolve symlink src location
       .filter(([_, packageManifest]) => packageManifest && !packageManifest['_id']) // only watch symlinked deps for now
       .map(([fileLoc]) => `${path.dirname(fileLoc!)}/**`),

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -235,6 +235,7 @@ export interface PackageSourceLocal
   source: 'local';
   external: string[];
   knownEntrypoints: string[];
+  resolvePaths?: string[];
 }
 
 export interface PackageSourceRemote {
@@ -243,6 +244,7 @@ export interface PackageSourceRemote {
   external: string[];
   cache: string;
   types: boolean;
+  resolvePaths?: string[];
 }
 
 // interface this library uses internally


### PR DESCRIPTION
This makes it possible to specify other directories, alongside the default of `process.cwd()`, for esinstall and Snowpack to use when resolving modules.

## My use case

I’m using Snowpack as middleware and my server’s directory and the directory being served are different. I want modules installed in my server’s directory to be accessible from the directory being served. Basically, I’m building a server that lets you serve Svelte + Snowpack apps without you having to install Snowpack or Svelte in the sites you’re building (so there is no generator/scaffolding required). It does a bit more than this but this combination is how you build client-side interfaces with it.

E.g., 

```
My server: runs from ~/my-server
                                            ╰ node_modules
                                                         ╰ svelte
My site: located at ~/my-site
```

I wand my site to be able to use svelte without the person building the site having to install it themselves.

Note, you will still need a Rollup plugin defined in your snowpack configuration file in order for this to work. Something like:

```js
  packageOptions: {
    resolvePaths: [__dirname],
    polyfillNode: true,
    rollup: {
      plugins: [
        {
          name: 'place.small-web.org:inject-svelte',
          resolveId(id) {
            console.log('resolving id', id)
            const svelteBasePath = path.join(__dirname, 'node_modules', 'svelte')
            const sveltePath = path.join(svelteBasePath, 'index.mjs')
            const svelteInternalPath = path.join(svelteBasePath, 'internal', 'index.mjs')
            switch (id) {
              case 'svelte':
                return sveltePath
              case 'svelte/internal':
                return svelteInternalPath
              default:
                return null
            }
          }
        }
      ]
    }
  },
```
 
## Changes

  - It adds a `resolvePaths` property to the snowpack configuration, under `packageOptions`.
  - It modifies esinstall and Snowpack to use the directories specified therein – alongside the default of `process.cwd()` when resolving modules.

## Testing

Currently no tests added.

## Docs

Currently not documented

## Relevant discussion

  - https://github.com/snowpackjs/snowpack/discussions/2327


## Notes

Please let me know if I’ve been able to explain the use case clearly. Would also love your thoughts on the approach before proceeding with tests and documentation.