### PR TITLE
add includePaths option to plugin-sass

### DIFF
--- a/plugins/plugin-sass/plugin.js
+++ b/plugins/plugin-sass/plugin.js
@@ -5,6 +5,7 @@ const npmRunPath = require('npm-run-path');
 
 const IMPORT_REGEX = /\@(use|import)\s*['"](.*?)['"]/g;
 const PARTIAL_REGEX = /([\/\\])_(.+)(?![\/\\])/;
+const loadPaths=(paths=[])=> paths.map(n=>"--load-path="+n);
 
 function stripFileExtension(filename) {
   return filename.split('.').slice(0, -1).join('.');
@@ -28,7 +29,7 @@ function scanSassImports(fileContents, filePath, fileExt) {
     });
 }
 
-module.exports = function sassPlugin(_, {native, compilerOptions = {}} = {}) {
+module.exports = function sassPlugin(_, {native, compilerOptions = {},includePaths=[]} = {}) {
   /** A map of partially resolved imports to the files that imported them. */
   const importedByMap = new Map();
 
@@ -98,7 +99,7 @@ module.exports = function sassPlugin(_, {native, compilerOptions = {}} = {}) {
       }
 
       // If file is `.sass`, use YAML-style. Otherwise, use default.
-      const args = ['--stdin', '--load-path', path.dirname(filePath)];
+        const args = ['--stdin',...loadPaths(includePaths)];
       if (fileExt === '.sass') {
         args.push('--indented');
       }

--- a/plugins/plugin-sass/plugin.js
+++ b/plugins/plugin-sass/plugin.js
@@ -99,7 +99,7 @@ module.exports = function sassPlugin(_, {native, compilerOptions = {},includePat
       }
 
       // If file is `.sass`, use YAML-style. Otherwise, use default.
-        const args = ['--stdin',...loadPaths(includePaths)];
+        const args = ['--stdin','--load-path', path.dirname(filePath),...loadPaths(includePaths)];
       if (fileExt === '.sass') {
         args.push('--indented');
       }


### PR DESCRIPTION
[load-path](https://sass-lang.com/documentation/cli/dart-sass#load-path) should be used to provides Sass paths to look for [imports](https://sass-lang.com/documentation/at-rules/import#load-paths). imports are not necessarily in the same directory as the compiled sass file. giving it `path.dirname(filePath)` will only assure that its will find imported file in same directory.
includePaths work the same as dart-sass js-api [includePaths](https://sass-lang.com/documentation/js-api#includepaths)

## Changes
Add `includePaths` to plugin options.
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->



<!-- How was this change tested? -->
## Testing
`src/path/to/folder/_partial.scss`
```
$primaryColor:#333
```
`src/other/path/to/something/App.scss`

```
@import 'partial.scss'

.App{
background-color:$primaryColor;
}
```
- Case 1:
- 
`snowpack.config.js`
```
...
plugins: [
...
[
'@snowpack/plugin-sass', {includePaths: ['src/path/to/folder']}
]
]
}
```
result:PASS

- Case 2:

`snowpack.config.js`
```
...
plugins: [
...
'@snowpack/plugin-sass' 
]
}
```
result :FAIL &
```
Error: Command failed with exit code 65: sass --stdin --load-path /pathToProject/src/other/path/to/something
Error: Can't find stylesheet to import.
  ╷
1 │ @import 'partial';
  │         ^^^^^^^^
  ╵
  - 1:9  root stylesheet
```
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs
| Name                |   Type    | Description                                                                                                                                                                                                                                                                              |
| :------------------ | :-------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `includePaths`            | `array` | This array of strings option provides [load paths](https://sass-lang.com/documentation/at-rules/import#load-paths) for Sass to look for imports. Earlier load paths will take precedence over later ones.|

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
