### PR TITLE
fix(plugin-optimize): read remote js file throws an error

### DIFF
--- a/plugins/plugin-optimize/lib/js.js
+++ b/plugins/plugin-optimize/lib/js.js
@@ -13,6 +13,10 @@ function scanJS({file, rootDir, scannedFiles, importList}) {
     // 1. scan file for static imports
     scannedFiles.add(file); // keep track of scanned files so we never redo work
     importList.add(file); // make sure import is marked
+    if (isRemoteModule(file)) { // don’t scan remote modules
+      return importList;
+    }
+
     let code = fs.readFileSync(file, 'utf-8');
     const [imports] = parse(code);
     imports


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
When remote script is included in html file, the remote url will be scanned and an error will be thrown. So, if it is a remote URL, return the result, do not read the file by `fs`.

![image](https://user-images.githubusercontent.com/17677589/105624969-ccc0f080-5e60-11eb-8320-c2145041bfde.png)


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
