### PR TITLE
HMR fixes

### DIFF
--- a/snowpack/assets/hmr-client.js
+++ b/snowpack/assets/hmr-client.js
@@ -146,7 +146,7 @@ async function runCssStyleAccept({url: id}) {
     () => setTimeout(() => document.head.removeChild(oldLinkEl), 30),
     false,
   );
-  oldLinkEl.parentNode.insertBefore(linkEl, oldLinkEl)
+  oldLinkEl.parentNode.insertBefore(linkEl, oldLinkEl);
   return true;
 }
 
@@ -235,23 +235,24 @@ socket.addEventListener('message', ({data: _data}) => {
 log('listening for file changes...');
 
 /** Runtime error reporting: If a runtime error occurs, show it in an overlay. */
-isWindowDefined && window.addEventListener('error', function (event) {
-  // Generate an "error location" string
-  let fileLoc;
-  if (event.filename) {
-    fileLoc = event.filename;
-    if (event.lineno !== undefined) {
-      fileLoc += ` [:${event.lineno}`;
-      if (event.colno !== undefined) {
-        fileLoc += `:${event.colno}`;
+isWindowDefined &&
+  window.addEventListener('error', function (event) {
+    // Generate an "error location" string
+    let fileLoc;
+    if (event.filename) {
+      fileLoc = event.filename;
+      if (event.lineno !== undefined) {
+        fileLoc += ` [:${event.lineno}`;
+        if (event.colno !== undefined) {
+          fileLoc += `:${event.colno}`;
+        }
+        fileLoc += `]`;
       }
-      fileLoc += `]`;
     }
-  }
-  createNewErrorOverlay({
-    title: 'Unhandled Runtime Error',
-    fileLoc,
-    errorMessage: event.message,
-    errorStackTrace: event.error ? event.error.stack : undefined,
+    createNewErrorOverlay({
+      title: 'Unhandled Runtime Error',
+      fileLoc,
+      errorMessage: event.message,
+      errorStackTrace: event.error ? event.error.stack : undefined,
+    });
   });
-});

--- a/snowpack/assets/hmr-client.js
+++ b/snowpack/assets/hmr-client.js
@@ -151,7 +151,7 @@ async function runCssStyleAccept({url: id}) {
 }
 
 /** Called when a new module is loaded, to pass the updated module to the "active" module */
-async function runJsModuleAccept({url: id, bubbled}) {
+async function runJsModuleAccept({url: id, bubbled, updateId}) {
   const state = REGISTERED_MODULES[id];
   if (!state) {
     return false;
@@ -160,11 +160,11 @@ async function runJsModuleAccept({url: id, bubbled}) {
     return false;
   }
   const acceptCallbacks = state.acceptCallbacks;
-  const updateID = Date.now();
   for (const {deps, callback: acceptCallback} of acceptCallbacks) {
     const [module, ...depModules] = await Promise.all([
-      import(id + `?mtime=${updateID}`),
-      ...deps.map((d) => import(d + `?mtime=${updateID}`)),
+      import(id + `?mtime=${updateId}`),
+      // FIXME we can't know the correct updateId for dependencies at this point
+      ...deps.map((d) => import(d + `?mtime=${updateId}`)),
     ]);
     acceptCallback({module, bubbled, deps: depModules});
   }

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -1376,7 +1376,12 @@ export async function startServer(commandOptions: CommandOptions): Promise<Snowp
     getServerRuntime: (options) => getServerRuntime(sp, options),
     async shutdown() {
       await watcher.close();
-      server.close();
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
     },
   } as SnowpackDevServer;
   return sp;

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -97,6 +97,12 @@ interface FoundFile {
   isResolve: boolean;
 }
 
+interface HmrUpdate {
+  url: string;
+  bubbled: boolean;
+  updateId: string;
+}
+
 const FILE_BUILD_RESULT_ERROR = `Build Result Error: There was a problem with a file build result.`;
 
 /**
@@ -799,18 +805,25 @@ export async function startServer(commandOptions: CommandOptions): Promise<Snowp
       }
 
       let code = wrappedResponse;
-      if (responseFileExt === '.js' && reqUrlHmrParam)
+      if (responseFileExt === '.js') {
+        // NOTE We need to rewrite imports even for a non modified module,
+        // because the module can still use a module that was already modified
+        // and loaded in the browser (hence the browser will know the "current"
+        // version of the module with a ?mtime).
         code = await transformEsmImports(code as string, (imp) => {
           const importUrl = path.posix.resolve(path.posix.dirname(reqPath), imp);
           const node = hmrEngine.getEntry(importUrl);
-          if (node && node.needsReplacement) {
-            hmrEngine.markEntryForReplacement(node, false);
-            return `${imp}?${reqUrlHmrParam}`;
+          if (node) {
+            if (node.needsReplacement) {
+              hmrEngine.markEntryForReplacement(node, false);
+            }
+            if (node.updateId) {
+              return `${imp}?mtime=${node.updateId}`;
+            }
           }
           return imp;
         });
 
-      if (responseFileExt === '.js') {
         const isHmrEnabled = code.includes('import.meta.hot');
         const rawImports = await scanCodeImportsExports(code);
         const resolvedImports = rawImports.map((imp) => {
@@ -821,6 +834,7 @@ export async function startServer(commandOptions: CommandOptions): Promise<Snowp
           spec = spec.replace(/\?mtime=[0-9]+$/, '');
           return path.posix.resolve(path.posix.dirname(reqPath), spec);
         });
+
         hmrEngine.setEntry(originalReqPath, resolvedImports, isHmrEnabled);
       }
 
@@ -1201,14 +1215,32 @@ export async function startServer(commandOptions: CommandOptions): Promise<Snowp
   // Live Reload + File System Watching
   let isLiveReloadPaused = false;
 
-  function updateOrBubble(url: string, visited: Set<string>) {
+  function updateOrBubble(url: string) {
+    // A given entry must get the same updateId for a single bubble phase, even
+    // if it is marked multiple times (i.e. multiple importers), or importers
+    // will get different copies of the module
+    const updateId = String(Date.now());
+    const visited = new Set<string>();
+    const updates = new Map();
+    _updateOrBubble(url, updateId, visited, updates);
+    return updates.values();
+  }
+  function _updateOrBubble(
+    url: string,
+    updateId: string,
+    visited: Set<string>,
+    updates: Map<string, HmrUpdate>,
+  ) {
     if (visited.has(url)) {
       return;
     }
     const node = hmrEngine.getEntry(url);
-    const isBubbled = visited.size > 0;
+    if (node) {
+      node.updateId = updateId;
+    }
     if (node && node.isHmrEnabled) {
-      hmrEngine.broadcastMessage({type: 'update', url, bubbled: isBubbled});
+      const bubbled = visited.size > 0;
+      updates.set(url, {url, bubbled, updateId});
     }
     visited.add(url);
     if (node && node.isHmrAccepted) {
@@ -1216,13 +1248,14 @@ export async function startServer(commandOptions: CommandOptions): Promise<Snowp
     } else if (node && node.dependents.size > 0) {
       node.dependents.forEach((dep) => {
         hmrEngine.markEntryForReplacement(node, true);
-        updateOrBubble(dep, visited);
+        _updateOrBubble(dep, updateId, visited, updates);
       });
     } else {
       // We've reached the top, trigger a full page refresh
       hmrEngine.broadcastMessage({type: 'reload'});
     }
   }
+
   function handleHmrUpdate(fileLoc: string, originalUrl: string) {
     if (isLiveReloadPaused) {
       return;
@@ -1254,7 +1287,10 @@ export async function startServer(commandOptions: CommandOptions): Promise<Snowp
 
     // If the changed file exists on the page, trigger a new HMR update.
     if (hmrEngine.getEntry(updatedUrl)) {
-      updateOrBubble(updatedUrl, new Set());
+      const updates = updateOrBubble(updatedUrl);
+      for (const {url, bubbled, updateId} of updates) {
+        hmrEngine.broadcastMessage({type: 'update', url, bubbled, updateId});
+      }
       return;
     }
 

--- a/snowpack/src/hmr-server-engine.ts
+++ b/snowpack/src/hmr-server-engine.ts
@@ -10,11 +10,12 @@ interface Dependency {
   isHmrAccepted: boolean;
   needsReplacement: boolean;
   needsReplacementCount: number;
+  updateId?: string;
 }
 
 type HMRMessage =
   | {type: 'reload'}
-  | {type: 'update'; url: string; bubbled: boolean}
+  | {type: 'update'; url: string; bubbled: boolean; updateId?: string}
   | {
       type: 'error';
       title: string;
@@ -103,6 +104,7 @@ export class EsmHmrEngine {
       needsReplacementCount: 0,
       isHmrEnabled: false,
       isHmrAccepted: false,
+      updateId: undefined,
     };
     this.dependencyTree.set(sourceUrl, newEntry);
     return newEntry;


### PR DESCRIPTION
Opening a draft PR to share current progress and synchronize efforts...

## Changes

Current HMR engine has a few bugs... The gist of the problems I've identified are duplicated copies of the same module in the browser (as I detailed in #2238, that triggered this investigation), or HMR pulling back outdated versions of some modules, when some of their consuming modules change.

I believe the following current issues, raised in discussions, are all related to these bugs and would be fixed by this PR (the first one is mine, mentioned above, so I'm sure):

- HMR bug? Shared dependencies can get duplicated on update #2238
- Snowpack HMR refreshing but not module replacing #2417
- HMR behaviour #2010
- HMR reverts 1st file after refreshing 2nd file #2054

The proposed fix in this PR is:

- assign `updateId` (used as the `?mtime=` parameter) on the server side, and pass them to the client, instead of generating them client-side when receiving an update

- this allows to always rewrite imports in JS files to use the last known `updateId`, to avoid importing outdated modules on subsequent updates of importers

- ensure that all the modules impacted by a HMR update bubble gets the same `updateId`, to avoid that a module impacted by multiple paths (transitive unaccepted dependencies) may get different `updateId` (and so the browser will incorrectly fetch different copies of the same module version)

The PR currently focuses on HMR with `.js` modules. Not too sure how CSS would/should be impacted yet; any suggestion welcome on this aspect.

I think there are other related points that would deserve being discussed, but they're not directly the object of this PR (yet?), so I'll detail them in comments later.

## Testing

I've setup a test project to help corner & fix the aforementioned issues, all while trying to avoid creating new ones: https://github.com/rixo/snowgun

Current Snowpack (3.0.11) fails 3/5 test cases... which is a bit expected since, for now, I've mainly written tests that illustrates the problems I had already detected.

The branch of this PR passes all current test cases.

To run the tests with snowpack@3.0.11:

```bahs
git clone git@github.com:rixo/snowgun.git
cd snowgun
yarn
yarn test
```

I'm planning on adding more test cases to further specify and guarantee HMR behaviour (thinking about dynamic imports, and what happens when multiple tabs are opened, notably). But that's a bit time consuming, so that may be kind of a long haul effort. Also, I'd like your feedback on the approach, before committing too far into it...

## Docs

Only bug fixes for now.