### PR TITLE
docs(plugins): Show correct "updated" date-time for plugins

### DIFF
--- a/www/_template/plugins.njk
+++ b/www/_template/plugins.njk
@@ -96,6 +96,7 @@ description: 'Snowpack plugins allow for configuration-minimal tooling integrati
   import {html, render} from 'htm/preact/standalone.module.js';
 
     function Card({result}) {
+      const updatedAtFormatted = Intl.DateTimeFormat('en', {month: "long", day: "numeric", year: "numeric"}).format(Date.parse(result.updatedAt));
       return html ` <li class="card">
       <img class="plugin-icon" src="/img/plug-light.svg" />
       <header class="card-header">
@@ -110,7 +111,7 @@ description: 'Snowpack plugins allow for configuration-minimal tooling integrati
         .split('. ')[0]}</p>
       <p class="card-subtitle">
 		    Updated <time class="" datetime="${result
-        .updatedAt}">August 10, 2020</time>
+        .updatedAt}">${updatedAtFormatted}</time>
       </p>
     </li>`;
     }


### PR DESCRIPTION
## Changes

The plugin catalog currently presents the "updated" info of each plugin hardcoded to "August 10, 2020". With this bug fix, the actual time is shown while preserving the intended date-time format.

Screenshot:

![image](https://user-images.githubusercontent.com/7271961/105639623-af4c5080-5e79-11eb-9701-802b788bbaa0.png)

## Testing

Tested manually on local machine, no tests exist for the website.

## Docs

Bug fix in the docs only, no docs exist.
