### PR TITLE
added upgrade event for http2 websockets

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -728,13 +728,10 @@ export async function startServer(
       handleRequest(req, res);
     })
       .on('upgrade', (req, socket) => {
-        let reqUrl = req.url!;
-        const matchedRoute = matchRoute(reqUrl);
+        const matchedRoute = matchRoute(req.url!);
         // If a route is matched, call the route function
-        if (matchedRoute) {
-          if (typeof matchedRoute.dest !== 'string') {
-            return matchedRoute.dest(req, socket);
-          }
+        if (matchedRoute && typeof matchedRoute.dest !== 'string') {
+          return matchedRoute.dest(req, socket);
         }
       })
       .on('error', (err: Error) => {

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -727,6 +727,16 @@ export async function startServer(
       // Otherwise, pass requests directly to Snowpack's request handler.
       handleRequest(req, res);
     })
+      .on('upgrade', (req, socket) => {
+        let reqUrl = req.url!;
+        const matchedRoute = matchRoute(reqUrl);
+        // If a route is matched, call the route function
+        if (matchedRoute) {
+          if (typeof matchedRoute.dest !== 'string') {
+            return matchedRoute.dest(req, socket);
+          }
+        }
+      })
       .on('error', (err: Error) => {
         logger.error(colors.red(`  ✘ Failed to start server at port ${colors.bold(port!)}.`), err);
         server!.close();


### PR DESCRIPTION
## Changes

Re-add support for proxied websockets by passing the upgrade event to the routing. Its not the most elegant solution

## Testing

adding a websocket route works after this change

## Docs

fixed regression.