### PR TITLE
Catch WebSocket message parse errors

### DIFF
--- a/snowpack/src/hmr-server-engine.ts
+++ b/snowpack/src/hmr-server-engine.ts
@@ -86,11 +86,15 @@ export class EsmHmrEngine {
 
   registerListener(client: WebSocket) {
     client.on('message', (data) => {
-      const message = JSON.parse(data.toString());
-      if (message.type === 'hotAccept') {
-        const entry = this.getEntry(message.id, true) as Dependency;
-        entry.isHmrAccepted = true;
-        entry.isHmrEnabled = true;
+      try {
+        const message = JSON.parse(data.toString());
+        if (message.type === 'hotAccept') {
+          const entry = this.getEntry(message.id, true) as Dependency;
+          entry.isHmrAccepted = true;
+          entry.isHmrEnabled = true;
+        }
+      } catch (error) {
+        console.error(error)
       }
     });
   }


### PR DESCRIPTION
## Changes

If malformed messages are received by the hmr socket, then it causes snowpack to crash.

This can be triggered from anywhere:

```js
const url = document.location.origin.replace('http', 'ws')
const socket = new WebSocket(url, 'esm-hmr')
socket.onopen = () => socket.send('not-json')
```

## Testing

I've applied this change locally and it seemed to fix the issue.

## Docs

None (this is a bug fix).