### PR TITLE
Update Community Templates README.md

### DIFF
--- a/create-snowpack-app/cli/README.md
+++ b/create-snowpack-app/cli/README.md
@@ -36,6 +36,6 @@ npx create-snowpack-app new-dir --template @snowpack/app-template-NAME [--use-ya
 - [snowpack-svelte-ts-tw](https://github.com/GarrettCannon/snowpack-svelte-ts-tw) (Snowpack + Svelte + Typescript + TailwindCSS)
 - [snowpack-template-tailwind](https://github.com/jonalvarezz/snowpack-template-tailwind) (Snowpack + TailwindCSS + Autopublish to GitHub Pages)
 - [glimmer-snowpack](https://github.com/rajasegar/glimmer-snowpack) (Snowpack + [Glimmer.js](https://glimmerjs.com))
-- [snowpack-cycle](https://github.com/rajasegar/snowpack-cycle]) (A pre-configured Snowpack app template for [Cycle.js](https://cycle.js.org))
-- [snowpack-angular-template](https://github.com/YogliB/snowpack-template-angular]) (A preconfigured template for Snowpack with [Angular](https://angular.io))
+- [snowpack-cycle](https://github.com/rajasegar/snowpack-cycle) (A pre-configured Snowpack app template for [Cycle.js](https://cycle.js.org))
+- [snowpack-angular-template](https://github.com/YogliB/snowpack-template-angular) (A preconfigured template for Snowpack with [Angular](https://angular.io))
 - PRs that add a link to this list are welcome!


### PR DESCRIPTION
fix link typo

## Changes

snowpack-cycle and snowpack-angular-template link was incorrect

## Testing

no need
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

Yes. This just fix document by remove typo ']' from URL
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
