### PR TITLE
Fixes snowpack typescript types cache directory

### DIFF
--- a/snowpack/src/sources/remote.ts
+++ b/snowpack/src/sources/remote.ts
@@ -148,7 +148,7 @@ export default {
             .installTypes(
               packageName,
               packageSemver,
-              path.join(this.getCacheFolder(config), '.snowpack/types'),
+              path.join(this.getCacheFolder(config), 'types'),
             )
             .catch(() => 'thats fine!');
         }


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Changes directory structure from `.snowpack/.snowpack/types` to `.snowpack/types` when building a cache of typescript types.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

Tested locally with linked package.
No tests added.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

No need. Documentation is correct. This is just a bug fix.
