### PR TITLE
Fix explodeExportMap expanding dirs

### DIFF
--- a/esinstall/src/entrypoints.ts
+++ b/esinstall/src/entrypoints.ts
@@ -1,4 +1,4 @@
-import {readdirSync, existsSync, realpathSync} from 'fs';
+import {readdirSync, existsSync, realpathSync, statSync} from 'fs';
 import path from 'path';
 import validatePackageName from 'validate-npm-package-name';
 import {ExportField, ExportMapEntry, PackageManifestWithExports, PackageManifest} from './types';
@@ -275,7 +275,9 @@ function* forEachWildcardEntry(
   let valueDirectoryFullPath = path.join(cwd, valueDirectoryName);
 
   if (existsSync(valueDirectoryFullPath)) {
-    let filesInDirectory = readdirSync(valueDirectoryFullPath);
+    let filesInDirectory = readdirSync(valueDirectoryFullPath).filter(
+      (filepath) => statSync(path.join(valueDirectoryFullPath, filepath)).isFile(), // ignore directories
+    );
 
     for (let filename of filesInDirectory) {
       // Create a relative path for this file to match against the regex

--- a/test/esinstall.api.test.js
+++ b/test/esinstall.api.test.js
@@ -274,5 +274,22 @@ describe('ESInstall API', () => {
         './extras/three.js': './src/extras/three.js',
       });
     });
+
+    it('explodes trailing slash exports but ignores subdirs', () => {
+      let map = explodeExportMap(
+        {
+          '.': './entrypoint.js',
+          './dist/': './dist/',
+          './dist/esm/helpers.js': './dist/esm/helpers.js',
+        },
+        {cwd: __dirname + '/esinstall/package-entrypoints/export-map-trailing-slash'},
+      );
+
+      expect(map).toStrictEqual({
+        '.': './entrypoint.js',
+        './dist/index.js': './dist/index.js',
+        './dist/esm/helpers.js': './dist/esm/helpers.js',
+      });
+    });
   });
 });

--- a/test/esinstall/package-entrypoints/export-map-trailing-slash/dist/esm/helpers.js
+++ b/test/esinstall/package-entrypoints/export-map-trailing-slash/dist/esm/helpers.js
@@ -1,0 +1,1 @@
+export const helpers = 'helpers';

--- a/test/esinstall/package-entrypoints/export-map-trailing-slash/dist/index.js
+++ b/test/esinstall/package-entrypoints/export-map-trailing-slash/dist/index.js
@@ -1,0 +1,1 @@
+export const index = 'index';


### PR DESCRIPTION
## Changes

For `@babel/runtime@7.12.5` (current), this is the export map that `explodeExportMap()` produces:

```diff
  "exports": {
    "./helpers/": "./helpers",
+   "./helpers/esm/": "./helpers/esm"
```

Because `./helpers/` is a directory, it calls `readdirSync` but doesn’t filter out directories within that, so it adds a directory to the export map without expanding it.

This PR fixes that, and adds a test.

**Before**

<img width="709" alt="Screen Shot 2021-01-26 at 18 47 43" src="https://user-images.githubusercontent.com/1369770/105931663-cff6e080-6008-11eb-879c-efcdd410bead.png">

Test was added first; was able to recreate failure before adding code

**After**

<img width="488" alt="Screen Shot 2021-01-26 at 19 01 35" src="https://user-images.githubusercontent.com/1369770/105931718-ee5cdc00-6008-11eb-9b47-11249fde34ab.png">

Test passes! 🎉 

## Testing

Test added!

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

No docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
