### PR TITLE
fix(plugin-webpack): Keep original HTML attributes on script tags

### DIFF
--- a/plugins/plugin-webpack/plugin.js
+++ b/plugins/plugin-webpack/plugin.js
@@ -65,7 +65,10 @@ function emitHTMLFiles({doms, jsEntries, stats, baseUrl, buildDirectory, htmlMin
         const head = dom.window.document.querySelector('head');
 
         for (const jsFile of jsFiles) {
-          const scriptEl = dom.window.document.createElement('script');
+          // Clone node so we keep original attributes, and remove
+          // `type=module` as that is not needed
+          const scriptEl = originalScriptEl.cloneNode();
+          scriptEl.removeAttribute("type")
           scriptEl.src = url.parse(baseUrl).protocol
             ? url.resolve(baseUrl, jsFile)
             : path.posix.join(baseUrl, jsFile);


### PR DESCRIPTION
## Changes

Basically, it keeps any HTML attribute on `script` tags that are processed by this plugin. `plugin-webpack` was picking the `JSEntries` from snowpack and replacing their `script` tags with a new one, with the files produced by webpack. With that, previous attributes like `defer` or `async` were not being respected.

This plugin fixes that. The only attribute that is ignored is the `type` attribute, given that `script` tags processed by this plugin are really not a `module` anymore.

## Testing

Unfortunately, tests are being skipped and are even commented out given an issue with `fs`. I dealt with this back in November and the tests were producing an expected snapshot.

Manual testing seems to work and all HTML attributes not named `type` are preserved.

## Docs

Don't really know what to do add here. I think this is a bug, as it's striping out vital attributes from `script` tags, so if docs need updating let me know.