### PR TITLE
Return truncated tip on the plugins guide

### DIFF
--- a/www/_template/guides/plugins.md
+++ b/www/_template/guides/plugins.md
@@ -310,4 +310,4 @@ In general, make sure to mind the following checklist:
 - The `resolve.input` and `resolve.output` file extension arrays are vital to how Snowpack understands your build pipeline, and are always required for `load()` to run correctly.
 - If `load()` doesn't return anything, the file isn’t loaded and the `load()` of the next suitable plugin is called.
 - If `transform()` doesn't return anything, the file isn’t transformed.
-- If you want to build a plugin that runs some code only on initialization (such as `@snowpack/pl
+- If you want to build a plugin that runs some code only on initialization (such as `@snowpack/plugin-dotenv`), put your side-effect code inside the function that returns your plugin. But be sure to still return a plugin object. A simple `{ name }` object will do.


### PR DESCRIPTION
Looks like this text was accidentally truncated in [this commit](https://github.com/snowpackjs/snowpack/commit/e66d54e59cfea54b494846638f5e2d35049ea2fd)

## Changes

Fixes a broken doc

## Testing

No changes, doc change only

## Docs

Returns truncated text