### PR TITLE
add support for internal export map imports

### DIFF
--- a/esinstall/package.json
+++ b/esinstall/package.json
@@ -39,7 +39,6 @@
     "index.esm.mjs"
   ],
   "dependencies": {
-    "@rollup/plugin-alias": "^3.0.1",
     "@rollup/plugin-commonjs": "^16.0.0",
     "@rollup/plugin-inject": "^4.0.2",
     "@rollup/plugin-json": "^4.0.0",
@@ -53,6 +52,7 @@
     "mkdirp": "^1.0.3",
     "picomatch": "^2.2.2",
     "rimraf": "^3.0.0",
+    "slash": "^3.0.0",
     "rollup": "^2.34.0",
     "rollup-plugin-polyfill-node": "^0.5.0",
     "validate-npm-package-name": "^3.0.0",

--- a/esinstall/src/rollup-plugins/rollup-plugin-alias.ts
+++ b/esinstall/src/rollup-plugins/rollup-plugin-alias.ts
@@ -1,0 +1,111 @@
+/**
+This plugin was forked from the https://github.com/rollup/plugins/tree/master/packages/alias package:
+
+The MIT License (MIT)
+
+Copyright (c) 2019 RollupJS Plugin Contributors (https://github.com/rollup/plugins/graphs/contributors)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+*/
+
+import { platform } from 'os';
+import slash from 'slash';
+import type { PartialResolvedId, Plugin } from 'rollup';
+
+const VOLUME = /^([A-Z]:)/i;
+const IS_WINDOWS = platform() === 'win32';
+const noop = () => null;
+
+function matches(alias: Alias, importee: string) {
+  if (alias.find instanceof RegExp) {
+    return alias.find.test(importee);
+  }
+  if (importee.length < alias.find.length) {
+    return false;
+  }
+  if (importee === alias.find) {
+    return true;
+  }
+  if (alias.exact) {
+    return false;
+  }
+  const importeeStartsWithKey = importee.indexOf(alias.find) === 0;
+  const importeeHasSlashAfterKey = importee.substring(alias.find.length)[0] === '/';
+  return importeeStartsWithKey && importeeHasSlashAfterKey;
+}
+
+function normalizeId(id: string): string;
+function normalizeId(id: string | undefined): string | undefined;
+function normalizeId(id: string | undefined) {
+  if (typeof id === 'string' && (IS_WINDOWS || VOLUME.test(id))) {
+    return slash(id.replace(VOLUME, ''));
+  }
+  return id;
+}
+
+interface Alias {
+  find: string | RegExp, 
+  replacement: string,
+  exact: boolean,
+};
+
+function getEntries({ entries }): readonly Alias[] {
+  if (!entries) {
+    return [];
+  }
+  return entries;
+}
+
+export function rollupPluginAlias(options: {entries: Alias[]}): Plugin {
+  const entries = getEntries(options);
+
+  if (entries.length === 0) {
+    return {
+      name: 'alias',
+      resolveId: noop
+    };
+  }
+
+  return {
+    name: 'alias',
+    resolveId(importee, importer) {
+      const importeeId = normalizeId(importee);
+      const importerId = normalizeId(importer);
+
+      // First match is supposed to be the correct one
+      const matchedEntry = entries.find((entry) => matches(entry, importeeId));
+      if (!matchedEntry || !importerId) {
+        return null;
+      }
+
+      const updatedId = normalizeId(
+        importeeId.replace(matchedEntry.find, matchedEntry.replacement)
+      );
+
+      return this.resolve(updatedId, importer, { skipSelf: true }).then((resolved) => {
+        let finalResult: PartialResolvedId | null = resolved;
+        if (!finalResult) {
+          finalResult = { id: updatedId };
+        }
+        return finalResult;
+      });
+    }
+  };
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test/esinstall/*"
   ],
   "devDependencies": {
+    "@rollup/plugin-alias": "^3.0.1",
     "@skypack/package-check": "^0.2.0",
     "@types/babel__traverse": "^7.0.7",
     "@types/cacache": "^12.0.1",

--- a/test/esinstall/package-entrypoints/export-map-internal-imports/entrypoint.js
+++ b/test/esinstall/package-entrypoints/export-map-internal-imports/entrypoint.js
@@ -1,0 +1,3 @@
+import * as pkg from 'export-map-internal-imports/imported-by-entrypoint';
+console.log(pkg);
+export const a = 3;

--- a/test/esinstall/package-entrypoints/export-map-internal-imports/imported-by-entrypoint.js
+++ b/test/esinstall/package-entrypoints/export-map-internal-imports/imported-by-entrypoint.js
@@ -1,0 +1,1 @@
+export const a = 2;

--- a/test/esinstall/package-entrypoints/export-map-internal-imports/imports-entrypoint.js
+++ b/test/esinstall/package-entrypoints/export-map-internal-imports/imports-entrypoint.js
@@ -1,0 +1,4 @@
+import * as pkg from 'export-map-internal-imports';
+console.log(pkg);
+
+export const a = 1;

--- a/test/esinstall/package-entrypoints/export-map-internal-imports/package.json
+++ b/test/esinstall/package-entrypoints/export-map-internal-imports/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.2.3",
+  "name": "export-map-internal-imports",
+  "exports": {
+    ".": "./entrypoint.js",
+    "./imported-by-entrypoint": "./imported-by-entrypoint.js",
+    "./imports-entrypoint": "./imports-entrypoint.js"
+  }
+}

--- a/test/esinstall/package-entrypoints/package-entrypoints-export-map.test.js
+++ b/test/esinstall/package-entrypoints/package-entrypoints-export-map.test.js
@@ -42,6 +42,33 @@ describe('package-entrypoints exports configuration', () => {
     }
   });
 
+  it('export-map-internal-imports', async () => {
+    const cwd = __dirname;
+    const dest = path.join(cwd, 'test-export-map-internal-imports');
+
+    const {importMap} = await runTest(
+      [
+        'export-map-internal-imports',
+        'export-map-internal-imports/imported-by-entrypoint',
+        'export-map-internal-imports/imports-entrypoint',
+      ],
+      {
+        cwd,
+        dest,
+      },
+    );
+
+    expect(importMap).toStrictEqual({
+      imports: {
+        'export-map-internal-imports': './export-map-internal-imports.js',
+        'export-map-internal-imports/imported-by-entrypoint':
+          './export-map-internal-imports/imported-by-entrypoint.js',
+        'export-map-internal-imports/imports-entrypoint':
+          './export-map-internal-imports/imports-entrypoint.js',
+      },
+    });
+  });
+
   it.skip('"exports": "./index.js"', async () => {
     // This should be in the "supports all of the variations" test, putting here for visibility.
   });


### PR DESCRIPTION
## Changes

- Adds support for self-referencing: https://nodejs.org/api/packages.html#packages_self_referencing_a_package_using_its_name
- This is defined as a feature of export maps, but really it's a feature of non-export maps as well (When "pkg" imports "pkg", node_module nesting will eventually lead it to resolve to itself).

## Testing

- Test added

## Docs

- N/A