### PR TITLE
fix(docs): remove /api prefix in API Proxy guide

### DIFF
--- a/www/_template/guides/routing.md
+++ b/www/_template/guides/routing.md
@@ -41,7 +41,12 @@ module.exports = {
   routes: [
     {
       src: '/api/.*',
-      dest: (req, res) => proxy.web(req, res),
+      dest: (req, res) => {
+        // remove /api prefix (optional)
+        req.url = req.url.replace(/^\/api/, '');
+ 
+        proxy.web(req, res);
+      }
     },
   ],
 };


### PR DESCRIPTION
## Changes

The recommended guide for API Proxying in local development recommends passing incoming requests from `/api/.*` to `node-http-proxy` directly, but in most cases the `/api` path prefix should be removed first. Without this change, you'll get a 404 and may not realize that it's just requesting `http://localhost:3000/api/whatever` instead of `http://localhost:3000/whatever`.

I realize this could be considered more of a usage recommendation for `node-http-proxy`, but I think this small addition makes debugging this particular issue much easier, and is also easy to ignore if you don't need it.

## Testing

Just a docs change, no tests affected/required.

## Docs

Just added a small clarification to avoid accidental misuse.
