### PR TITLE
SSR Loader: Support CSS Modules

### DIFF
--- a/snowpack/src/ssr-loader/transform.ts
+++ b/snowpack/src/ssr-loader/transform.ts
@@ -57,7 +57,7 @@ export function transform(data) {
 
       const source = node.source.value;
 
-      if (source.endsWith('.css.proxy.js')) {
+      if (source.endsWith('.css.proxy.js') && !source.endsWith('.module.css.proxy.js')) {
         css.push(source.replace(/\.proxy\.js$/, ''));
       } else {
         deps.push({name, source});


### PR DESCRIPTION
Following up on #2527, this was actually much simpler than I expected.

## Changes

Prior to this change, attempting to use the Snowpack server runtime with CSS Modules would throw `ReferenceError: [export] is not defined`.

> Note: This avoids failures when encountering CSS Modules, but true SSR support would somehow extract the CSS Modules code and expose that to the user. Much like the server runtime currently exposes `css`, maybe it could expose `styles` which would be the CSS rules to inject rather than URLs? 

## Testing

I didn't see any tests for the `ssr-loader` module, but ran this change locally on some examples. It works!

## Docs

Bug fix only