### PR TITLE
Update plugins.md

### DIFF
--- a/www/_template/guides/plugins.md
+++ b/www/_template/guides/plugins.md
@@ -49,8 +49,10 @@ In your example Snowpack project, add your plugin to the `snowpack.config.js` al
   ]
 }
 ```
+## Testing and Troubleshooting
 
-TODO: how to test
+* TODO: create a full how to test procedure
+* HINT: Add `--verbose` to the command to see the steps, e.g. `snowpack dev --verbose` or `snowpack build --verbose`
 
 ## Adding user-configurable options to your plugin
 


### PR DESCRIPTION
Add a troubleshooting hint in advance of a full testing/troubleshooting page

## Changes
This documents the `--verbose` option for debugging on the main snowpack.dev site. (I found it rummaging around on Discord...)

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Just a quick eyeball - looks good in Preview
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs
This updates a public document with a useful hint.
<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
