### PR TITLE
fix wrong argument passed to parseCompilerOption(array[])

### DIFF
--- a/plugins/plugin-sass/plugin.js
+++ b/plugins/plugin-sass/plugin.js
@@ -119,7 +119,7 @@ module.exports = function sassPlugin(_, {native, compilerOptions = {}} = {}) {
           default: {
             if (Array.isArray) {
               for (const val of value) {
-                parseCompilerOption(flag, val);
+                parseCompilerOption([flag, val]);
               }
               break;
             }


### PR DESCRIPTION
`parseCompilerOption` takes array `[flag,val]` ,but `parseCompilerOption(flag,val)` found in `line 122`


## Changes
change `line 122` to `parseCompilerOption([flag, val]);`

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing
tested and work for the multiple loadpath -> `loadPath:string[]`

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
