### PR TITLE
Fix recursive compiler option arguments

### DIFF
--- a/plugins/plugin-sass/plugin.js
+++ b/plugins/plugin-sass/plugin.js
@@ -119,7 +119,7 @@ module.exports = function sassPlugin(_, {native, compilerOptions = {}} = {}) {
           default: {
             if (Array.isArray) {
               for (const val of value) {
-                parseCompilerOption(flag, val);
+                parseCompilerOption([flag, val]);
               }
               break;
             }


### PR DESCRIPTION


## Changes

Previously the `flag` string got destructured into individual characters. Wrapping as an array fixes the issue.

**Before**
![image](https://user-images.githubusercontent.com/377188/106674900-13f66200-6582-11eb-8bc2-9f36ce619056.png)

**After**
![image](https://user-images.githubusercontent.com/377188/106674942-1fe22400-6582-11eb-969c-d59e5ae1b8a8.png)


## Testing

No tests added as there currently aren't any tests specifically for Load Path with an array (my use case) so I thought that this feature likely isn't launched yet and tests will be added at a later date.
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

No docs updated, bug fix only
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
