### PR TITLE
add `none` value for `devOptions.output`

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -302,7 +302,7 @@ export async function startServer(commandOptions: CommandOptions): Promise<Snowp
     };
     paintDashboard(messageBus, config);
     logger.debug(`dashboard started`);
-  } else {
+  } else if (config.devOptions.output === "stream") {
     // "stream": Log relevent events to the console.
     messageBus.on(paintEvent.WORKER_MSG, ({id, msg}) => {
       logger.info(msg.trim(), {name: id});
@@ -310,6 +310,8 @@ export async function startServer(commandOptions: CommandOptions): Promise<Snowp
     messageBus.on(paintEvent.SERVER_START, (info) => {
       console.log(getServerInfoMessage(info));
     });
+  } else {
+    // output is `none` -> do not print anything
   }
 
   const inMemoryBuildCache = new Map<string, SnowpackBuildMap>();

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -107,7 +107,7 @@ const configSchema = {
         port: {type: 'number'},
         bundle: {type: 'boolean'},
         open: {type: 'string'},
-        output: {type: 'string', enum: ['stream', 'dashboard']},
+        output: {type: 'string', enum: ['stream', 'dashboard', 'none']},
         hmr: {type: 'boolean'},
         hmrDelay: {type: 'number'},
         hmrPort: {type: 'number'},


### PR DESCRIPTION
It's a quick workaround to silent the Snowpack `START_SERVER` messages while using it via the JavaScript API. Eventually this should be done differently, but I don't know the project vision yet. 

I'm building a tool similar to @natemoo-re integration and also wanted to hide the default Snowpack messaging.

Related discussion https://github.com/snowpackjs/snowpack/discussions/2044 I didn't know how to use the logger exposed in https://github.com/snowpackjs/snowpack/pull/2056 to achieve the effect from this PR.

## Changes

`devOptions.output` has now a new value of `none`. When set, the Snowpack logging is omitted.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

Manually, I've set the value `none` in my Snowpack integration and observed the server start message was no longer visible.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

I'll add the docs once/if the change is accepted.
