### PR TITLE
Configuration: Correct link to Environment Variables guide.

### DIFF
--- a/www/_template/reference/configuration.md
+++ b/www/_template/reference/configuration.md
@@ -408,7 +408,7 @@ _NOTE:_ Deprecated, see `buildOptions.metaUrlPath`.
 **Type**: `string`  
 **Default**: `_snowpack_`
 
-Rename the default directory for Snowpack metadata. In every build, Snowpack creates meta files for loading things like [HMR](/concepts/hot-module-replacement), [Environment Variables](/reference/configuration#environment-variables), and your built npm packages.
+Rename the default directory for Snowpack metadata. In every build, Snowpack creates meta files for loading things like [HMR](/concepts/hot-module-replacement), [Environment Variables](/reference/environment-variables), and your built npm packages.
 
 When you build your project, this will be a path on disk relative to the `buildOptions.out` directory.
 


### PR DESCRIPTION
## Changes

Changed the "environment variables" link to go to `/reference/environment-variables`, because the existing link doesn't go anywhere.

There isn't an element in the config reference with an `id` or `name` matching `environment-variables`. Quickly glancing through the history, I don't see that there ever was, but I could have missed it.


## Testing

GitHub preview

## Docs

Docs-only change