### PR TITLE
Adding Solid template

### DIFF
--- a/create-snowpack-app/cli/README.md
+++ b/create-snowpack-app/cli/README.md
@@ -38,4 +38,5 @@ npx create-snowpack-app new-dir --template @snowpack/app-template-NAME [--use-ya
 - [glimmer-snowpack](https://github.com/rajasegar/glimmer-snowpack) (Snowpack + [Glimmer.js](https://glimmerjs.com))
 - [snowpack-cycle](https://github.com/rajasegar/snowpack-cycle) (A pre-configured Snowpack app template for [Cycle.js](https://cycle.js.org))
 - [snowpack-angular-template](https://github.com/YogliB/snowpack-template-angular) (A preconfigured template for Snowpack with [Angular](https://angular.io))
+- [snowpack-solid](https://github.com/amoutonbrady/snowpack-solid) (A pre-configured Snowpack app template for [Solid](https://github.com/ryansolid/solid))
 - PRs that add a link to this list are welcome!


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
After I've ran the Solid template for Snowpack for some times, it came to my realization that it got more and more popular. I thought it was finally time to add it to the community templates for visibility

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->
I didn't find any documentation regarding the criteria for submission. Feel free to reject and let me know where they would be so that I can aligned my template with those.
It is actively maintained.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
This mostly standard to other templates, the only difference maybe is that I'd love for people to use `pnpm` as opposed to yarn or npm as I found it to work remarkably well with Snowpack (and Vite for that matter).