### PR TITLE
Update svelte.md w/ ctrl + c to kill process on mac

### DIFF
--- a/www/_template/tutorials/svelte.md
+++ b/www/_template/tutorials/svelte.md
@@ -75,7 +75,7 @@ module.exports = {
   ],
 ```
 
-Restart your Snowpack dev server to run it with the new configuration. Exit the process (ctrl + c in most Windows/Linux and cmd + c for Mac) and start it again with `npm run start`.
+Restart your Snowpack dev server to run it with the new configuration. Exit the process (ctrl + c in most Windows/Linux/macOS) and start it again with `npm run start`.
 
 > 💡 Tip: Restart the Snowpack development server when you make configuration changes (changes to the `snowpack.config.js`).
 


### PR DESCRIPTION
one of the few cross platform key combos

## Changes

<!-- What does this change, in plain language? -->
note that ctrl+c exits process on most platforms
remove "cmd + c" for mac
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
