### PR TITLE
dev: reintroduce reinstall after linked deps changed

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -1352,7 +1352,7 @@ export async function startServer(commandOptions: CommandOptions): Promise<Snowp
       .map(([fileLoc]) => `${path.dirname(fileLoc!)}/**`),
   );
   function onDepWatchEvent() {
-    hmrEngine.broadcastMessage({type: 'reload'});
+    pkgSource.recoverMissingPackageImport([], config).then(() => hmrEngine.broadcastMessage({type: 'reload'}));
   }
   const depWatcher = chokidar.watch([...symlinkedFileLocs], {
     cwd: '/', // we’re using absolute paths, so watch from root


### PR DESCRIPTION
## Changes

When changes in a linked dependency are detected, issue a dependency reinstall and hmr-reload.

This restores behaviour that was deleted by https://github.com/snowpackjs/snowpack/commit/610fb9d28452bf24758387a00fe81a4ed103e503#diff-397ad42a6f1b0ebd83079f8dc295da3bd6fbdf252dd7938edaef1df87862ff7aL955

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
