### PR TITLE
build: expose stat printing option

### DIFF
--- a/snowpack/src/commands/build.ts
+++ b/snowpack/src/commands/build.ts
@@ -127,7 +127,7 @@ async function installOptimizedDependencies(
     installTargets,
     installOptions,
     config: commandOptions.config,
-    shouldPrintStats: false,
+    shouldPrintStats: commandOptions.config.buildOptions.stat,
   });
   return installResult;
 }

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -50,6 +50,7 @@ const DEFAULT_CONFIG: SnowpackUserConfig = {
     watch: false,
     htmlFragments: false,
     ssr: false,
+    stat: false,
   },
   testOptions: {
     files: ['__tests__/**/*', '**/*.@(spec|test).*'],
@@ -157,6 +158,7 @@ const configSchema = {
         htmlFragments: {type: 'boolean'},
         jsxFactory: {type: 'string'},
         jsxFragment: {type: 'string'},
+        stat: {type: 'boolean'},
       },
     },
     testOptions: {

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -275,6 +275,7 @@ export interface SnowpackConfig {
     jsxFactory: string | undefined;
     jsxFragment: string | undefined;
     ssr: boolean;
+    stat: boolean;
   };
   testOptions: {
     files: string[];


### PR DESCRIPTION
## Changes

reintroduces install-stats printing via `snowpack build --stat` or `snowpack.config.js`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
