### PR TITLE
Add helper to transform file name from source <> build

### DIFF
--- a/snowpack/src/build/file-urls.ts
+++ b/snowpack/src/build/file-urls.ts
@@ -16,22 +16,13 @@ export function getUrlForFileMount({
   mountEntry: MountEntry;
   config: SnowpackConfig;
 }): string {
-  const fileName = path.basename(fileLoc);
   const resolvedDirUrl = mountEntry.url === '/' ? '' : mountEntry.url;
   const mountedUrl = fileLoc.replace(mountKey, resolvedDirUrl).replace(/[/\\]+/g, '/');
   if (mountEntry.static) {
     return mountedUrl;
   }
-  const extensionMatch = getExtensionMatch(fileName, config._extensionMap);
-  if (!extensionMatch) {
-    return mountedUrl;
-  }
-  const [inputExt, outputExts] = extensionMatch;
-  if (outputExts.length > 1) {
-    return addExtension(mountedUrl, outputExts[0]);
-  } else {
-    return replaceExtension(mountedUrl, inputExt, outputExts[0]);
-  }
+
+  return transformToBuildFileName(mountedUrl, config);
 }
 
 /**
@@ -66,4 +57,29 @@ export function getUrlForFile(fileLoc: string, config: SnowpackConfig): string |
   }
   const [mountKey, mountEntry] = mountEntryResult;
   return getUrlForFileMount({fileLoc, mountKey, mountEntry, config});
+}
+
+/**
+ * Map a source filename to the filename outputted by the build
+ */
+export function transformToBuildFileName(
+  sourceFileName: string,
+  config: SnowpackConfig,
+  customExtension?: string,
+): string {
+  const extensionMatch = getExtensionMatch(sourceFileName, config._extensionMap);
+
+  if (!extensionMatch) {
+    return sourceFileName;
+  }
+
+  const [inputExt, outputExts] = extensionMatch;
+
+  const buildFileExt = customExtension !== undefined ? customExtension : outputExts[0];
+
+  if (outputExts.length > 1) {
+    return addExtension(sourceFileName, buildFileExt);
+  } else {
+    return replaceExtension(sourceFileName, inputExt, buildFileExt);
+  }
 }

--- a/snowpack/src/build/import-resolver.ts
+++ b/snowpack/src/build/import-resolver.ts
@@ -1,15 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 import {SnowpackConfig} from '../types';
-import {
-  addExtension,
-  findMatchingAliasEntry,
-  getExtensionMatch,
-  hasExtension,
-  isRemoteUrl,
-  replaceExtension,
-} from '../util';
-import {getUrlForFile} from './file-urls';
+import {findMatchingAliasEntry, hasExtension, isRemoteUrl, replaceExtension} from '../util';
+import {getUrlForFile, transformToBuildFileName} from './file-urls';
 
 /** Perform a file disk lookup for the requested import specifier. */
 export function getFsStat(importedFileOnDisk: string): fs.Stats | false {
@@ -47,17 +40,7 @@ function resolveSourceSpecifier(lazyFileLoc: string, config: SnowpackConfig) {
     lazyFileLoc = lazyFileLoc + '.js';
   }
 
-  // Transform the file extension (from input to output)
-  const extensionMatch = getExtensionMatch(lazyFileLoc, config._extensionMap);
-
-  if (extensionMatch) {
-    const [inputExt, outputExts] = extensionMatch;
-    if (outputExts.length > 1) {
-      lazyFileLoc = addExtension(lazyFileLoc, outputExts[0]);
-    } else {
-      lazyFileLoc = replaceExtension(lazyFileLoc, inputExt, outputExts[0]);
-    }
-  }
+  lazyFileLoc = transformToBuildFileName(lazyFileLoc, config);
 
   return getUrlForFile(lazyFileLoc, config);
 }

--- a/snowpack/src/commands/build.ts
+++ b/snowpack/src/commands/build.ts
@@ -13,7 +13,11 @@ import {
   wrapImportProxy,
 } from '../build/build-import-proxy';
 import {buildFile, runPipelineCleanupStep, runPipelineOptimizeStep} from '../build/build-pipeline';
-import {getMountEntryForFile, getUrlForFileMount} from '../build/file-urls';
+import {
+  getMountEntryForFile,
+  getUrlForFileMount,
+  transformToBuildFileName,
+} from '../build/file-urls';
 import {createImportResolver} from '../build/import-resolver';
 import {runBuiltInOptimize} from '../build/optimize';
 import {EsmHmrEngine} from '../hmr-server-engine';
@@ -32,10 +36,8 @@ import {
   SnowpackSourceFile,
 } from '../types';
 import {
-  addExtension,
   cssSourceMappingURL,
   deleteFromBuildSafe,
-  getExtensionMatch,
   HMR_CLIENT_CODE,
   HMR_OVERLAY_CODE,
   isFsEventsEnabled,
@@ -182,20 +184,11 @@ class FileBuilder {
       if (!code) {
         continue;
       }
-      let outFilename = path.basename(url.fileURLToPath(this.fileURL));
-      const extensionMatch = getExtensionMatch(this.fileURL.toString(), this.config._extensionMap);
-      if (extensionMatch) {
-        const [inputExt, outputExts] = extensionMatch;
-        if (outputExts.length > 1) {
-          outFilename = addExtension(path.basename(url.fileURLToPath(this.fileURL)), fileExt);
-        } else {
-          outFilename = replaceExtension(
-            path.basename(url.fileURLToPath(this.fileURL)),
-            inputExt,
-            fileExt,
-          );
-        }
-      }
+      const outFilename = transformToBuildFileName(
+        path.basename(url.fileURLToPath(this.fileURL)),
+        this.config,
+        fileExt,
+      );
       const outLoc = path.join(this.outDir, outFilename);
       const sourceMappingURL = outFilename + '.map';
       if (this.mountEntry.resolve && typeof code === 'string') {

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -51,7 +51,7 @@ import {
   wrapImportProxy,
 } from '../build/build-import-proxy';
 import {buildFile as _buildFile, getInputsFromOutput} from '../build/build-pipeline';
-import {getUrlForFile} from '../build/file-urls';
+import {getUrlForFile, transformToBuildFileName} from '../build/file-urls';
 import {createImportResolver} from '../build/import-resolver';
 import {EsmHmrEngine} from '../hmr-server-engine';
 import {logger} from '../logger';
@@ -1372,6 +1372,8 @@ export async function startServer(commandOptions: CommandOptions): Promise<Snowp
     sendResponseFile,
     sendResponseError,
     getUrlForFile: (fileLoc: string) => getUrlForFile(fileLoc, config),
+    transformToBuildFileName: (sourceFileName: string) =>
+      transformToBuildFileName(sourceFileName, config),
     onFileChange: (callback) => (onFileChangeCallback = callback),
     getServerRuntime: (options) => getServerRuntime(sp, options),
     async shutdown() {

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -85,6 +85,7 @@ export interface SnowpackDevServer {
   getServerRuntime: (options?: {invalidateOnChange?: boolean}) => ServerRuntime;
   sendResponseError: (req: http.IncomingMessage, res: http.ServerResponse, status: number) => void;
   getUrlForFile: (fileLoc: string) => string | null;
+  transformToBuildFileName: (sourceFileName: string) => string;
   onFileChange: (callback: OnFileChangeCallback) => void;
   shutdown(): Promise<void>;
 }

--- a/test/snowpack/build/file-urls.test.ts
+++ b/test/snowpack/build/file-urls.test.ts
@@ -1,0 +1,46 @@
+const{transformToBuildFileName} = require('../../../snowpack/lib/build/file-urls')
+
+describe('transformToBuildFileName()', () => {
+  const TEST_CONFIG = {
+    _extensionMap: {
+      '.one': ['.js'],
+      '.many': ['.js', '.css']
+    }
+  }
+
+  test('file extension with 1:1 mapping is replaced', () => {
+    const fileName = 'filename.one'
+
+    const buildFileName = transformToBuildFileName(fileName, TEST_CONFIG)
+
+    expect(buildFileName).toBe('filename.js')
+  })
+
+
+  test('file extension with 1:1 mapping is replaced with custom extension', () => {
+    const fileName = 'filename.one'
+    const customExtension = '.custom'
+
+    const buildFileName = transformToBuildFileName(fileName, TEST_CONFIG, customExtension)
+
+    expect(buildFileName).toBe('filename.custom')
+  })
+
+  test('file extension with 1:N mapping is appened', () => {
+    const fileName = 'filename.many'
+
+    const buildFileName = transformToBuildFileName('filename.many', TEST_CONFIG)
+
+    expect(buildFileName).toBe('filename.many.js')
+  })
+
+
+  test('file extension with 1:N mapping is appened with custom extension', () => {
+    const fileName = 'filename.many'
+    const customExtension = '.custom'
+
+    const buildFileName = transformToBuildFileName(fileName, TEST_CONFIG, customExtension)
+
+    expect(buildFileName).toBe('filename.many.custom')
+  })
+})

--- a/www/_template/reference/javascript-interface.md
+++ b/www/_template/reference/javascript-interface.md
@@ -79,6 +79,17 @@ const {contents} = server.loadUrl(fileUrl, {...});
 
 A helper function to find the final hosted URL for any source file. Useful when combined with `loadUrl`, since you may only know a file's location on disk without knowing it's final hosted URL.
 
+### SnowpackDevServer.transformToBuildFileName()
+
+`transformToBuildFileName(sourceFileName: string) => string;`
+
+```ts
+const server = await startServer({ config });
+const buildFileName = server.transformToBuildFileName('index.jsx');
+```
+
+A helper function to transform the source filename to the one outputted by the build.
+
 #### SnowpackDevServer.sendResponseError()
 
 `sendResponseError(req: http.IncomingMessage, res: http.ServerResponse, status: number) => void;`


### PR DESCRIPTION
## Changes

https://github.com/snowpackjs/snowpack/issues/2263#issue-785426063

- Adds helper functions for getting the file name in the build from the source file name (and vice-versa)
- Refactors code to use these helper functions

## Testing

- The code refactors current implementation into shared function so we shouldn't expect snapshots to change
- Current tests are passing
- Tests have also been added to document the `1:1` vs `1:N` file extension mapping in `test/snowpack/build/file-urls.test.ts`

## Docs
- Yes `javascript-interface.md` docs have been updated with documentation for new exposed function `SnowpackDevServer.transformToBuildFileName()`
