### PR TITLE
Support compound output file extensions

### DIFF
--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -182,7 +182,7 @@ module.exports = function (snowpackConfig, pluginOptions) {
 
 This is a simplified version of the official Snowpack Babel plugin, which builds all JavaScript, TypeScript, and JSX files in your application with the `load()` method.
 
-The `load()` method is responsible for loading and build files from disk while the `resolve` property tells Snowpack which files the plugin can load and what to expect as output. In this case, the plugin claims responsibility for files matching any of the file extensions found in `resolve.input`, and outputs `.js` JavaScript (declared via `resolve.output`).
+The `load()` method is responsible for loading and build files from disk while the `resolve` property tells Snowpack which files the plugin can load and what to expect as output. In this case, the plugin claims responsibility for files matching any of the file extensions found in `resolve.input`, and outputs `.js` JavaScript (declared via `resolve.output`). `resolve.output` can also use a multi-part extension such as `.module.css` or `.hbs.js`—files will be matched from most specific extension to least.
 
 **See it in action:** Let's say that we have a source file at `src/components/App.jsx`. Because the `.jsx` file extension matches an extension in our plugin's `resolve.input` array, Snowpack lets this plugin claim responsibility for loading this file. `load()` executes, Babel builds the JSX input file from disk, and JavaScript is returned to the final build.
 


### PR DESCRIPTION
## Changes

This change makes it possible to use a plugin that outputs "compound" file extensions containing more than one `.`. For example:

```js
resolve: { input: [".hbs"], output: [".hbs.js"] }
```

Why would we want to do this? Because our input can contain pairs of files like:

```
./components
├── hello.hbs
└── hello.js
```

where we want to compile the `.hbs` to Javascript *without* colliding with the preexisting `hello.js`.

This already worked in `snowpack build`, but failed in `snowpack dev` because the server would always parse the request URL extension as `.js`, while the plugin was providing `.hbs.js`, resulting in a 404.

This change causes the longest matching output plugin extension to be chosen. Since all plugin extensions must start with a `.`, this change is backward compatible (no existing plugin output extensions contain each other as suffixes, because that didn't work before this PR).


## Testing

The only existing test infrastructure I could find that covers `snowpack dev` is the smoke test app in `test-dev/smoke`. If you'd like me to add a custom plugin to that scenario that demonstrates this feature, I'm happy to do that, but the current example is so small and simple I wasn't sure if you intend to keep adding random plugins to it to test every edge case.

I also drafted a [complete build test](https://github.com/ef4/snowpack/commit/7e04183c0a84b3e3a4d5ef0776d310dfe3b76c03) before I realized those tests aren't relevant to `snowpack dev`, but if you think it's useful to have coverage of this scenario I could also include that.

I tested this against my own sample app.

## Docs

I don't think this needs a documentation change, the docs already successfully showed me how to make the plugin I wanted, I just needed this small extension to get it to behave correctly in dev.
