### PR TITLE
svelte plugin: propagate the `hydratable` compiler option to rollup build

### DIFF
--- a/plugins/plugin-svelte/plugin.js
+++ b/plugins/plugin-svelte/plugin.js
@@ -22,7 +22,13 @@ module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
     packageOptions.rollup.plugins.push(
       svelteRollupPlugin({
         include: /\.svelte$/,
-        compilerOptions: {dev: isDev},
+        compilerOptions: {
+          dev: isDev,
+          hydratable:
+            pluginOptions.compilerOptions
+              ? pluginOptions.compilerOptions.hydratable
+              : false
+        },
         // Snowpack wraps JS-imported CSS in a JS wrapper, so use
         // Svelte's own first-class `emitCss: false` here.
         // TODO: Remove once Snowpack adds first-class CSS import support in deps.

--- a/plugins/plugin-svelte/plugin.js
+++ b/plugins/plugin-svelte/plugin.js
@@ -24,10 +24,9 @@ module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
         include: /\.svelte$/,
         compilerOptions: {
           dev: isDev,
-          hydratable:
-            pluginOptions.compilerOptions
-              ? pluginOptions.compilerOptions.hydratable
-              : false
+          hydratable: pluginOptions.compilerOptions
+            ? pluginOptions.compilerOptions.hydratable
+            : false,
         },
         // Snowpack wraps JS-imported CSS in a JS wrapper, so use
         // Svelte's own first-class `emitCss: false` here.

--- a/plugins/plugin-svelte/test/plugin.test.js
+++ b/plugins/plugin-svelte/test/plugin.test.js
@@ -141,6 +141,7 @@ describe('@snowpack/plugin-svelte (mocked)', () => {
       ]
     `);
   });
+
   it('supports importing svelte components', async () => {
     const config = {...DEFAULT_CONFIG};
     plugin(config, {});
@@ -149,6 +150,7 @@ describe('@snowpack/plugin-svelte (mocked)', () => {
     plugin(config, {});
     expect(config.packageOptions.packageLookupFields).toEqual(['module', 'svelte']);
   });
+
   it('propagates `compilerOptions.hydratable` to rollup', () => {
     mockRollup.mockClear();
     const config = {

--- a/plugins/plugin-svelte/test/plugin.test.js
+++ b/plugins/plugin-svelte/test/plugin.test.js
@@ -2,7 +2,10 @@ const path = require('path');
 
 const mockCompiler = jest.fn().mockImplementation((code) => ({js: {code}}));
 const mockPreprocessor = jest.fn().mockImplementation((code) => code);
+const mockRollup = jest.fn();
+
 jest.mock('svelte/compiler', () => ({compile: mockCompiler, preprocess: mockPreprocessor})); // important: mock before import
+jest.mock('rollup-plugin-svelte', () => mockRollup); // important: mock before import
 
 const plugin = require('../plugin');
 
@@ -145,5 +148,24 @@ describe('@snowpack/plugin-svelte (mocked)', () => {
     config.packageOptions.packageLookupFields = ['module'];
     plugin(config, {});
     expect(config.packageOptions.packageLookupFields).toEqual(['module', 'svelte']);
+  });
+  it('propagates `compilerOptions.hydratable` to rollup', () => {
+    mockRollup.mockClear();
+    const config = {
+      ...DEFAULT_CONFIG,
+    };
+
+    const pluginOptions = {
+      compilerOptions: {
+        dev: true,
+        hydratable: true,
+      },
+      emitCss: false,
+      include: /\.svelte$/,
+    };
+
+    plugin(config, pluginOptions);
+
+    expect(mockRollup).toHaveBeenLastCalledWith(pluginOptions);
   });
 });


### PR DESCRIPTION
## Changes

First off - nice work on the JS API and server runtime, very cool.

I'm building an app that uses the above to render Svelte components on the server.  The app in question depends on Svelte components located in `node_modules`, so they're pre-compiled in the build step.  I hit a snag where the `hydratable` option was being passed to components in my mount directory, but not ones that were pre-built.  This change passes said `hydratable` option to Rollup in the build step, maintaining consistency across components.

Here's the repo displaying the phenomena in question: https://github.com/mkshio/hyperlab/blob/master/hyperlab/index.js

## Testing

Added a unit test 👍🏼 
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

Please let me know if any docs need to be updated.  I find this behavior to be implicit/expected, but I can call it out if need be.

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
