### PR TITLE
Fix typo configuration.md

### DIFF
--- a/www/_template/reference/configuration.md
+++ b/www/_template/reference/configuration.md
@@ -208,7 +208,7 @@ Toggles HMR on the Snowpack dev server.
 
 Milliseconds to delay HMR-triggered browser update.
 
-### devoptions.hmrPort
+### devOptions.hmrPort
 
 **Type**: `number`  
 **Default**: [`devOptions.port`](#devoptions.port)


### PR DESCRIPTION
## Changes

Just a typo in the doc.

## Testing

No test

## Docs

Yes. Reference / Configuration has been fixed.
