### PR TITLE
Fix typo in JavaScript API docs

### DIFF
--- a/www/_template/reference/javascript-interface.md
+++ b/www/_template/reference/javascript-interface.md
@@ -44,7 +44,7 @@ const config = createConfiguration({...});
 const server = await startServer({config}); // returns: SnowpackDevServer
 ```
 
-Start a new Snowpack dev server instance. This is the equvilent of running `snowpack dev` on the command line.
+Start a new Snowpack dev server instance. This is the equivalent of running `snowpack dev` on the command line.
 
 Once started, you can load files from your dev server and Snowpack will build them as requested. This is an important feature to understand: Snowpack's dev server does zero file building on startup, and instead builds files only once they are requested via the server's `loadUrl` method.
 


### PR DESCRIPTION
## Changes

This project is awesome 🏔️ 🎉 

I noticed a typo while reading through the docs, so I thought I'd make a small contribution to fix it.

The change is: "equvilent" -> "equivalent"

## Testing

N/A

## Docs

✅ 
