### PR TITLE
fix: recognise dot as a valid relative import

### DIFF
--- a/snowpack/src/build/import-resolver.ts
+++ b/snowpack/src/build/import-resolver.ts
@@ -80,7 +80,7 @@ export function createImportResolver({fileLoc, config}: {fileLoc: string; config
     if (spec.startsWith('/')) {
       return spec;
     }
-    if (spec.startsWith('./') || spec.startsWith('../')) {
+    if (spec.startsWith('./') || spec.startsWith('../') || spec === '.') {
       const importedFileLoc = path.resolve(path.dirname(fileLoc), spec);
       return resolveSourceSpecifier(importedFileLoc, config) || spec;
     }


### PR DESCRIPTION
## Changes

As per discussion #2661, Snowpack fails to recognise a solitary `'.'` as a valid relative import, even though this is a common pattern to import from the `index.js` / `index.tsx` / etc. file in a directory.

## Testing

Tested by npm linking my local Snowpack build and trying it against my failing project.

## Docs

Bug fix only.
