### PR TITLE
Fix snowpack add/rm for npm packages with @ prefix

### DIFF
--- a/snowpack/src/commands/add-rm.ts
+++ b/snowpack/src/commands/add-rm.ts
@@ -12,12 +12,18 @@ import {
 } from '../util';
 import remotePackageSource from '../sources/remote';
 
+function pkgInfoFromString (str) {
+  const idx = str.lastIndexOf('@');
+  if (idx <= 0) return [str];
+  return [str.slice(0, idx), str.slice(idx + 1)]
+}
+
 export async function addCommand(addValue: string, commandOptions: CommandOptions) {
   const {lockfile, config} = commandOptions;
   if (config.packageOptions.source !== 'remote') {
     throw new Error(`add command requires packageOptions.source="remote".`);
   }
-  let [pkgName, pkgSemver] = addValue.split('@');
+  let [pkgName, pkgSemver] = pkgInfoFromString(addValue);
   const installMessage = pkgSemver ? `${pkgName}@${pkgSemver}` : pkgName;
   logger.info(`fetching ${cyan(installMessage)} from CDN...`);
   if (!pkgSemver || pkgSemver === 'latest') {
@@ -55,7 +61,7 @@ export async function rmCommand(addValue: string, commandOptions: CommandOptions
   if (config.packageOptions.source !== 'remote') {
     throw new Error(`rm command requires packageOptions.source="remote".`);
   }
-  let [pkgName] = addValue.split('@');
+  let [pkgName] = pkgInfoFromString(addValue);
   logger.info(`removing ${cyan(pkgName)} from project lockfile...`);
   const newLockfile: LockfileManifest = convertSkypackImportMapToLockfile(
     lockfile?.dependencies ?? {},


### PR DESCRIPTION
## Changes

Correctly modify snowpack.deps.json after running `snowpack add` with npm organization packages

Example of what was happening before, when running `snowpack add @pixi/app`:

```json
{
  "dependencies": {
    "": "pixi/app"
  },
  "lock": {
    "#pixi/app": "@pixi/app@v5.3.7-fJizkk0by9r3PZhxGwya"
  }
}
```

After applying the fix and running local snowpack:

```json
{
  "dependencies": {
    "@pixi/app": "^5.3.7"
  },
  "lock": {
    "@pixi/app#^5.3.7": "@pixi/app@v5.3.7-fJizkk0by9r3PZhxGwya"
  }
}
```

## Testing

I didn't see any existing tests for the add/rm commands so I didn't add any here now.

However, running it myself locally produces expected results with both org and non-org packages

## Docs

Bug fix only
