### PR TITLE
SASS plugin, fix default argument Array check

### DIFF
--- a/plugins/plugin-sass/plugin.js
+++ b/plugins/plugin-sass/plugin.js
@@ -117,7 +117,7 @@ module.exports = function sassPlugin(_, {native, compilerOptions = {}} = {}) {
             break;
           }
           default: {
-            if (Array.isArray) {
+            if (Array.isArray(value)) {
               for (const val of value) {
                 parseCompilerOption(flag, val);
               }


### PR DESCRIPTION
## Changes

Fixes issue with @snowpack/plugin-sass where the `compilerOptions` parameters would be incorrectly checked for type.

## Testing

This is basically just a fix for a typo, but proper testing should be added to actually test for, specifically, `loadPath`.

## Docs

Never documented in the first place