### PR TITLE
fix: do not cache env in jest

### DIFF
--- a/create-snowpack-app/app-scripts-react/jest/importMetaBabelPlugin.js
+++ b/create-snowpack-app/app-scripts-react/jest/importMetaBabelPlugin.js
@@ -1,29 +1,26 @@
-const template = require('@babel/template').default;
+'use strict';
 
-const PUBLIC_ENV_REGEX = /^SNOWPACK_PUBLIC_/;
-function generateEnvObject(mode) {
-  const envObject = {...process.env};
-  for (const env of Object.keys(envObject)) {
-    if (!PUBLIC_ENV_REGEX.test(env)) {
-      delete envObject[env];
-    }
-  }
-  envObject.MODE = mode;
-  envObject.NODE_ENV = mode;
-  return envObject;
-}
+const template = require('@babel/template').default;
 
 /**
  * Add import.meta.env support
  * Note: import.meta.url is not supported at this time
  */
-module.exports = function () {
+module.exports = function importMetaBabelPlugin() {
   const ast = template.ast(`
-  ({env: ${JSON.stringify(generateEnvObject('test'))}})
+  ({
+    env: {
+      ...Object.fromEntries(
+        Object.entries(process.env).filter(([k]) => /^SNOWPACK_PUBLIC_/.test(k)),
+      ),
+      MODE: 'test',
+      NODE_ENV: 'test',
+    },
+  })
 `);
   return {
     visitor: {
-      MetaProperty(path, state) {
+      MetaProperty(path) {
         path.replaceWith(ast);
       },
     },

--- a/create-snowpack-app/app-scripts-svelte/jest/importMetaBabelPlugin.js
+++ b/create-snowpack-app/app-scripts-svelte/jest/importMetaBabelPlugin.js
@@ -1,29 +1,26 @@
-const template = require('@babel/template').default;
+'use strict';
 
-const PUBLIC_ENV_REGEX = /^SNOWPACK_PUBLIC_/;
-function generateEnvObject(mode) {
-  const envObject = {...process.env};
-  for (const env of Object.keys(envObject)) {
-    if (!PUBLIC_ENV_REGEX.test(env)) {
-      delete envObject[env];
-    }
-  }
-  envObject.MODE = mode;
-  envObject.NODE_ENV = mode;
-  return envObject;
-}
+const template = require('@babel/template').default;
 
 /**
  * Add import.meta.env support
  * Note: import.meta.url is not supported at this time
  */
-module.exports = function () {
+module.exports = function importMetaBabelPlugin() {
   const ast = template.ast(`
-  ({env: ${JSON.stringify(generateEnvObject('test'))}})
+  ({
+    env: {
+      ...Object.fromEntries(
+        Object.entries(process.env).filter(([k]) => /^SNOWPACK_PUBLIC_/.test(k)),
+      ),
+      MODE: 'test',
+      NODE_ENV: 'test',
+    },
+  })
 `);
   return {
     visitor: {
-      MetaProperty(path, state) {
+      MetaProperty(path) {
         path.replaceWith(ast);
       },
     },


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

By default babel-jest will cache all code that are already transpiled, so `importMetaBabelPlugin` maybe skipped if no code change (such as adding env via command line). It is unexpected to use previous env.

By getting the env directly from process.env, it will guarantee that it is not cached

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

I am not sure how to test it as this bugfix is about no cache between tests run, but I tried in my local machine

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

bug fix only