### PR TITLE
Add resolve package to snowpack direct dependencies

### DIFF
--- a/snowpack/package.json
+++ b/snowpack/package.json
@@ -48,6 +48,7 @@
     "default-browser-id": "^2.0.0",
     "esbuild": "^0.8.7",
     "open": "^7.0.4",
+    "resolve": "^1.20.0",
     "rollup": "^2.34.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Uses of the [`resolve`](https://www.npmjs.com/package/resolve) package are sometimes getting bundled into snowpack, but this isn't listed as a direct dependency.

This is a common package, so I suspect for most users it is resolvable. However, for new projects (e.g. the minimal create-snowpack-app using snowpack v3.0.12) this is isn't getting installed, causing a module not found error when running snowpack.

You can see in snowpack `v3.0.12` there is a `require("resolve")` on line 1: [snowpack@3.0.12/lib/index.js](https://unpkg.com/browse/snowpack@3.0.12/lib/index.js)

It's not there in `v3.0.11` (and this version of snowpack doesn't error): [snowpack@3.0.11/lib/index.js](https://unpkg.com/browse/snowpack@3.0.11/lib/index.js)

Looks like it was previously being installed along with `esinstall`. This might have been intermittent since c566aa10d78564cfdf41577c5ce46cc5b97517ef ?

## Changes

Adds a direct dependency on [`resolve`](https://www.npmjs.com/package/resolve) to the snowpack package.

## Testing
Steps to reproduce:
- Run `npx create-snowpack-app broken-resolve --template @snowpack/app-template-minimal`
- Install packages (including snowpack `v3.0.12`)
- Run `snowpack dev` and see that snowpack is failing with a `MODULE_NOT_FOUND` error.
- Install `resolve`
- Run `snowpack dev` and see that the error has been addressed.

Error message:
```
$ snowpack dev
node:internal/modules/cjs/loader:928
  throw err;
  ^

Error: Cannot find module 'resolve'
Require stack:
- /.../broken-resolve/node_modules/snowpack/lib/index.js
- /.../broken-resolve/node_modules/snowpack/index.bin.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:925:15)
    at Function.Module._load (node:internal/modules/cjs/loader:769:27)
    at Module.require (node:internal/modules/cjs/loader:997:19)
    at require (node:internal/modules/cjs/helpers:92:18)
    at Object.<anonymous> (/.../broken-resolve/node_modules/snowpack/lib/index.js:1:192)
    at Module._compile (node:internal/modules/cjs/loader:1108:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1137:10)
    at Module.load (node:internal/modules/cjs/loader:973:32)
    at Function.Module._load (node:internal/modules/cjs/loader:813:14)
    at Module.require (node:internal/modules/cjs/loader:997:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/.../broken-resolve/node_modules/snowpack/lib/index.js',
    '/.../broken-resolve/node_modules/snowpack/index.bin.js'
  ]
}
```

## Docs

Bug fix only. Thanks! 😄
