### PR TITLE
Offical wip new pkg

### DIFF
--- a/snowpack/src/sources/local.ts
+++ b/snowpack/src/sources/local.ts
@@ -195,7 +195,14 @@ export default {
       return;
     }
     await Promise.all(
-      [...new Set(installTargets.map((t) => t.specifier))].map((spec) => {
+      [
+        ...new Set(
+          installTargets
+            .map((t) => t.specifier)
+            // external packages need not prepare
+            .filter((t) => !config.packageOptions?.external.includes(t)),
+        ),
+      ].map((spec) => {
         return this.resolvePackageImport(path.join(config.root, 'package.json'), spec, config);
       }),
     );

--- a/test/build/prepare-external-package/config-external-package.test.js
+++ b/test/build/prepare-external-package/config-external-package.test.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+const {setupBuildTest} = require('../../test-utils');
+
+describe('prepare: packageOptions.external', () => {
+  beforeAll(() => {
+    setupBuildTest(__dirname);
+  });
+  it('prepare external package', () => {
+    expect(
+      fs.existsSync(path.join(__dirname, 'node_modules/.cache/snowpack/test/array-flatten@3.0.0')),
+    ).toEqual(true);
+    expect(fs.existsSync(path.join(__dirname, 'node_modules/.cache/snowpack/test/fs'))).toEqual(
+      false,
+    );
+    expect(
+      fs.existsSync(path.join(__dirname, 'node_modules/.cache/snowpack/test/vue/types')),
+    ).toEqual(false);
+  });
+});

--- a/test/build/prepare-external-package/package.json
+++ b/test/build/prepare-external-package/package.json
@@ -1,0 +1,27 @@
+{
+  "private": true,
+  "version": "1.0.0",
+  "name": "@snowpack/test-prepare-external-package",
+  "description": "Test for packageOptions.external as it applies to prepare.",
+  "scripts": {
+    "testbuild": "snowpack prepare"
+  },
+  "snowpack": {
+    "mount": {
+      "./src": "/_dist_"
+    },
+    "packageOptions": {
+      "external": [
+        "fs",
+        "vue/types"
+      ],
+      "source": "local"
+    }
+  },
+  "devDependencies": {
+    "snowpack": "link:../../../snowpack"
+  },
+  "dependencies": {
+    "array-flatten": "^3.0.0"
+  }
+}

--- a/test/build/prepare-external-package/src/index.js
+++ b/test/build/prepare-external-package/src/index.js
@@ -1,0 +1,3 @@
+import 'fs';
+import 'array-flatten';
+import 'vue/types';


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Skip prepare for packages in packageOptions.external.

When use `` packageOptions.source = local``.
Sometimes ts file need to import a type file from node_modules like 
```
 import { IType } from 'A/types'; 
```
And it will be mistake in prepare because there is only ``index.d.ts`` file under ``node_modules/A/types``.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

see unit test

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
