### PR TITLE
Do preprocess for npm Svelte modules

### DIFF
--- a/plugins/plugin-svelte/plugin.js
+++ b/plugins/plugin-svelte/plugin.js
@@ -14,25 +14,6 @@ module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
   const useSourceMaps =
     snowpackConfig.buildOptions.sourcemap || snowpackConfig.buildOptions.sourceMaps;
 
-  // Support importing Svelte files when you install dependencies.
-  const packageOptions = snowpackConfig.packageOptions || snowpackConfig.installOptions;
-  if (packageOptions.source === 'local') {
-    packageOptions.rollup = packageOptions.rollup || {};
-    packageOptions.rollup.plugins = packageOptions.rollup.plugins || [];
-    packageOptions.rollup.plugins.push(
-      svelteRollupPlugin({
-        include: /\.svelte$/,
-        compilerOptions: {dev: isDev},
-        // Snowpack wraps JS-imported CSS in a JS wrapper, so use
-        // Svelte's own first-class `emitCss: false` here.
-        // TODO: Remove once Snowpack adds first-class CSS import support in deps.
-        emitCss: false,
-      }),
-    );
-    // Support importing sharable Svelte components.
-    packageOptions.packageLookupFields.push('svelte');
-  }
-
   if (
     pluginOptions.generate !== undefined ||
     pluginOptions.dev !== undefined ||
@@ -86,6 +67,26 @@ module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
     preprocessOptions = require('svelte-preprocess')();
   }
 
+  // Support importing Svelte files when you install dependencies.
+  const packageOptions = snowpackConfig.packageOptions || snowpackConfig.installOptions;
+  if (packageOptions.source === 'local') {
+    packageOptions.rollup = packageOptions.rollup || {};
+    packageOptions.rollup.plugins = packageOptions.rollup.plugins || [];
+    packageOptions.rollup.plugins.push(
+      svelteRollupPlugin({
+        include: /\.svelte$/,
+        compilerOptions: {dev: isDev},
+        preprocess: preprocessOptions,
+        // Snowpack wraps JS-imported CSS in a JS wrapper, so use
+        // Svelte's own first-class `emitCss: false` here.
+        // TODO: Remove once Snowpack adds first-class CSS import support in deps.
+        emitCss: false,
+      }),
+    );
+    // Support importing sharable Svelte components.
+    packageOptions.packageLookupFields.push('svelte');
+  }
+  
   return {
     name: '@snowpack/plugin-svelte',
     resolve: {


### PR DESCRIPTION
## Changes

Svelte modules that use SCSS and is located inside of node_modules can compile now

## Testing

Successful compiled with import of Svelte file from node_modules

## Docs

'preprocess' is already documented, but this option is not fully works