### PR TITLE
don't escape utf-8 characters by cheerio and esbuild

### DIFF
--- a/plugins/plugin-optimize/plugin.js
+++ b/plugins/plugin-optimize/plugin.js
@@ -60,7 +60,11 @@ exports.default = function plugin(config, userDefinedOptions) {
 
         // minify if enabled
         if (options.minifyJS) {
-          const minified = await esbuildService.transform(code, {minify: true, target});
+          const minified = await esbuildService.transform(code, {
+            minify: true,
+            charset: 'utf8',
+            target,
+          });
           code = minified.code;
           fs.writeFileSync(file, code);
         }

--- a/snowpack/src/build/optimize.ts
+++ b/snowpack/src/build/optimize.ts
@@ -70,7 +70,7 @@ async function scanHtmlEntrypoints(htmlFiles: string[]): Promise<(ScannedHtmlEnt
   return Promise.all(
     htmlFiles.map(async (htmlFile) => {
       const code = await fs.readFile(htmlFile, 'utf8');
-      const root = cheerio.load(code);
+      const root = cheerio.load(code, { decodeEntities: false });
       const isHtmlFragment = root.html().startsWith('<html><head></head><body>');
       if (isHtmlFragment) {
         return null;
@@ -401,6 +401,7 @@ async function runEsbuildOnBuildDirectory(
     external: Array.from(new Set(allFiles.map((f) => '*' + path.extname(f)))).filter(
       (ext) => ext !== '*.js' && ext !== '*.mjs' && ext !== '*.css' && ext !== '*',
     ),
+    charset: 'utf8',
   });
   const manifestFile = outputFiles!.find((f) => f.path.endsWith('build-manifest.json'))!;
   const manifestContents = manifestFile.text;
@@ -532,6 +533,7 @@ export async function runBuiltInOptimize(config: SnowpackConfig) {
           loader: path.extname(f).slice(1) as 'js' | 'css',
           minify: options.minify,
           target: options.target,
+          charset: 'utf8',
         });
         code = minified.code;
         await fs.writeFile(f, code);

--- a/snowpack/src/plugins/plugin-esbuild.ts
+++ b/snowpack/src/plugins/plugin-esbuild.ts
@@ -39,6 +39,7 @@ export function esbuildPlugin(config: SnowpackConfig, {input}: {input: string[]}
         jsxFragment,
         sourcefile: filePath,
         sourcemap: config.buildOptions.sourcemap,
+        charset: 'utf8',
       });
       for (const warning of warnings) {
         logger.error(`${colors.bold('!')} ${filePath}

--- a/test/build/utf8/package.json
+++ b/test/build/utf8/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "version": "1.0.0",
+  "name": "@snowpack/test-utf8",
+  "scripts": {
+    "testbuild": "snowpack build"
+  },
+  "devDependencies": {
+    "snowpack": "^3.0.0"
+  }
+}

--- a/test/build/utf8/public/index.html
+++ b/test/build/utf8/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8" />
+    <title>utf-8 test</title>
+    <script src="index.js" type="module" defer></script>
+  </head>
+  <body>
+    <h1>Testing UTF-8: проверка юникода</h1>
+  </body>
+</html>

--- a/test/build/utf8/snowpack.config.js
+++ b/test/build/utf8/snowpack.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  mount: {
+    './public': '/',
+    './src': '/',
+  },
+  optimize: {
+    bundle: true,
+    minify: true,
+  }
+};

--- a/test/build/utf8/src/index.ts
+++ b/test/build/utf8/src/index.ts
@@ -1,0 +1,5 @@
+export function getText() {
+  return "testing utf-8 characters: юникод не эскейпится 👌";
+}
+
+document.body.append(getText());

--- a/test/build/utf8/utf8.test.js
+++ b/test/build/utf8/utf8.test.js
@@ -1,0 +1,26 @@
+const path = require('path');
+const {setupBuildTest, readFiles} = require('../../test-utils');
+
+const cwd = path.join(__dirname, 'build');
+
+let files = {};
+
+describe('utf8', () => {
+  beforeAll(() => {
+    setupBuildTest(__dirname);
+
+    files = readFiles(cwd);
+  });
+
+  it("Unicode characters aren't escaped in html", () => {
+    expect(files['/index.html']).toEqual(
+      expect.stringContaining("проверка юникода"),
+    );
+  });
+
+  it("Unicode characters aren't escaped in typescript", () => {
+    expect(files['/index.js']).toEqual(
+      expect.stringContaining("юникод не эскейпится 👌"),
+    );
+  });
+});


### PR DESCRIPTION
## Changes

Passing options to esbuild and cheerio to prevent them from escaping unicode characters.

## Testing

Added test with Cyrillic letters.

## Docs

Not needed, as this is an expected behavior.
