### PR TITLE
fix issue with types package

### DIFF
--- a/esinstall/src/entrypoints.ts
+++ b/esinstall/src/entrypoints.ts
@@ -216,19 +216,26 @@ export function resolveEntrypoint(
 
   // Sometimes packages don't give an entrypoint, assuming you'll fall back to "index.js".
   if (!foundEntrypoint) {
-    for(let possibleEntrypoint of ['index.js', 'index.json', depManifest.types || depManifest.typings || 'index.d.ts']) {
+    for(let possibleEntrypoint of ['index.js', 'index.json']) {
       try {
         return realpathSync.native(resolve.sync(path.join(depManifestLoc || '', '..', possibleEntrypoint)));
       } catch {
 
       }
     }
+
+    // Couldn't find any entrypoints so throwing
+    throw new Error(`Unable to find any entrypoint for "${dep}". It could be a typo, or this package might not have a main entrypoint.`);
   }
   if (typeof foundEntrypoint !== 'string') {
     throw new Error(`"${dep}" has unexpected entrypoint: ${JSON.stringify(foundEntrypoint)}.`);
   }
 
-  return realpathSync.native(resolve.sync(path.join(depManifestLoc || '', '..', foundEntrypoint)));
+  try {
+    return realpathSync.native(resolve.sync(path.join(depManifestLoc || '', '..', foundEntrypoint)));
+  } catch {
+    throw new Error(`We were able to resolve "${dep}", but the file does not exist on disk.`);
+  }
 }
 
 const picoMatchGlobalOptions = Object.freeze({

--- a/esinstall/src/entrypoints.ts
+++ b/esinstall/src/entrypoints.ts
@@ -231,10 +231,11 @@ export function resolveEntrypoint(
     throw new Error(`"${dep}" has unexpected entrypoint: ${JSON.stringify(foundEntrypoint)}.`);
   }
 
+  const finalPath = path.join(depManifestLoc || '', '..', foundEntrypoint);
   try {
-    return realpathSync.native(resolve.sync(path.join(depManifestLoc || '', '..', foundEntrypoint)));
+    return realpathSync.native(resolve.sync(finalPath));
   } catch {
-    throw new Error(`We were able to resolve "${dep}", but the file does not exist on disk.`);
+    throw new Error(`We resolved "${dep}" to ${finalPath}, but the file does not exist on disk.`);
   }
 }
 

--- a/esinstall/src/entrypoints.ts
+++ b/esinstall/src/entrypoints.ts
@@ -20,10 +20,6 @@ export const MAIN_FIELDS = [
 const BROKEN_BROWSER_ENTRYPOINT = ['@sheerun/mutationobserver-shim'];
 const FILE_EXTENSION_REGEX = /\..+$/;
 
-function hasTypes(manifest: PackageManifest): boolean {
-  return !!(manifest.types || manifest.typings);
-}
-
 function getMissingEntrypointHint(
   packageEntrypoint: string,
   normalizedMap: Record<string, string>,
@@ -218,11 +214,6 @@ export function resolveEntrypoint(
     packageLookupFields,
   });
 
-  // Some packages are types-only. If this is one of those packages, resolve with that.
-  if (!foundEntrypoint && hasTypes(depManifest)) {
-    const typesLoc = (depManifest.types || depManifest.typings) as string;
-    return path.join(depManifestLoc, '..', typesLoc);
-  }
   // Sometimes packages don't give an entrypoint, assuming you'll fall back to "index.js".
   if (!foundEntrypoint) {
     foundEntrypoint = 'index.js';

--- a/esinstall/src/entrypoints.ts
+++ b/esinstall/src/entrypoints.ts
@@ -216,7 +216,13 @@ export function resolveEntrypoint(
 
   // Sometimes packages don't give an entrypoint, assuming you'll fall back to "index.js".
   if (!foundEntrypoint) {
-    foundEntrypoint = 'index.js';
+    for(let possibleEntrypoint of ['index.js', 'index.json', depManifest.types || depManifest.typings || 'index.d.ts']) {
+      try {
+        return realpathSync.native(resolve.sync(path.join(depManifestLoc || '', '..', possibleEntrypoint)));
+      } catch {
+
+      }
+    }
   }
   if (typeof foundEntrypoint !== 'string') {
     throw new Error(`"${dep}" has unexpected entrypoint: ${JSON.stringify(foundEntrypoint)}.`);

--- a/test/esinstall/import-types/import-types.test.js
+++ b/test/esinstall/import-types/import-types.test.js
@@ -7,14 +7,20 @@ describe('importing types', () => {
     const dest = path.join(cwd, 'test-types-only');
     const spec = 'type-only-pkg';
 
-    const {
-      importMap: {imports},
-    } = await runTest([spec, 'array-flatten'], {
-      cwd,
-      dest,
-    });
+    try {
+      const {
+        importMap: {imports},
+      } = await runTest([spec, 'array-flatten'], {
+        cwd,
+        dest,
+      });
 
-    // This package should not have been installed because it only contains types.
-    expect(imports[spec]).toBeFalsy();
+      // This package should not have been installed because it only contains types.
+      expect(imports[spec]).toBeFalsy();
+    } catch(err) {
+      expect(err.toString()).toEqual(
+        expect.stringContaining('Unable to find any entrypoint')
+      );
+    }
   });
 });

--- a/test/esinstall/package-entrypoints/implicit-main/index.d.ts
+++ b/test/esinstall/package-entrypoints/implicit-main/index.d.ts
@@ -1,0 +1,4 @@
+
+export interface HelloJS {
+  type: number;
+}

--- a/test/esinstall/package-entrypoints/implicit-main/index.js
+++ b/test/esinstall/package-entrypoints/implicit-main/index.js
@@ -1,0 +1,2 @@
+
+export const a = 'b';

--- a/test/esinstall/package-entrypoints/implicit-main/package.json
+++ b/test/esinstall/package-entrypoints/implicit-main/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "implicit-main",
+  "version": "1.2.3",
+  "types": "index.d.ts"
+}

--- a/test/esinstall/package-entrypoints/package-entrypoints-general.test.js
+++ b/test/esinstall/package-entrypoints/package-entrypoints-general.test.js
@@ -72,4 +72,20 @@ describe('package-entrypoints general tests', () => {
     expect(Object.keys(imports)).toHaveLength(1);
     expect(imports['main-folder']).toBeTruthy();
   });
+
+  it('Supports an implicit main when types also exist', async () => {
+    const cwd = __dirname;
+    const dest = path.join(cwd, 'test-implicit-main');
+    const spec = 'implicit-main';
+
+    const {
+      importMap: {imports},
+    } = await runTest([spec], {
+      cwd,
+      dest,
+    });
+
+    expect(Object.keys(imports)).toHaveLength(1);
+    expect(imports['implicit-main']).toBeTruthy();
+  });
 });

--- a/test/esinstall/package-entrypoints/package.json
+++ b/test/esinstall/package-entrypoints/package.json
@@ -28,6 +28,7 @@
     "export-map-object-no-key": "file:./export-map-object-no-key",
     "export-map-star": "file:./export-map-star",
     "export-map-trailing-slash": "file:./export-map-trailing-slash",
-    "preact": "^10.0.0"
+    "preact": "^10.0.0",
+    "implicit-main": "file:./implicit-main"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8121,6 +8121,9 @@ immutable@^3:
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
   integrity sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=
 
+"implicit-main@file:./test/esinstall/package-entrypoints/implicit-main":
+  version "1.2.3"
+
 import-fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"


### PR DESCRIPTION
## Changes

- Resolving a package to it's "entrypoint" should never resolve to a types file. When we want to "install" a package, we always want JavaScript.
- Released as a preview to `esinstall@next`
- /cc @matthewp 

## Testing

- Tested in #2707

## Docs

- N/A
