### PR TITLE
Expose http server created by SnowpackDevServer

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -1369,6 +1369,7 @@ export async function startServer(commandOptions: CommandOptions): Promise<Snowp
   depWatcher.on('unlink', onDepWatchEvent);
 
   const sp = {
+    server,
     port,
     loadUrl,
     handleRequest,


### PR DESCRIPTION
## Changes

This change provides external access to the http server internally created and started by `SnowpackDevServer.startServer`.

The use case for this is to allow callers to reuse the http server, for example, when creating a socket server using Socket.IO.

Here is an example from my snowpack template repo that does this:
https://github.com/billyzkid/snowpack-universal-app-template/blob/master/server/index.js#L12

## Testing

TODO

## Docs

TODO
