### PR TITLE
Fix Sass partial changes not triggering recompiles in Dev

### DIFF
--- a/plugins/plugin-sass/plugin.js
+++ b/plugins/plugin-sass/plugin.js
@@ -51,7 +51,6 @@ function scanSassImports(fileContents, filePath, fileExt, partials = new Set()) 
     .forEach((fileName) => {
       let pathName = path.resolve(path.dirname(filePath), fileName);
 
-      // Recursively find any child partials that have not already been added.
       if (partials.has(pathName)) {
         return;
       }
@@ -67,6 +66,7 @@ function scanSassImports(fileContents, filePath, fileExt, partials = new Set()) 
         }
       } catch (err) {}
 
+      // Recursively find any child partials that have not already been added.
       const partialsContent = findChildPartials(pathName, fileName, fileExt);
       if (partialsContent) {
         const childPartials = scanSassImports(partialsContent, pathName, fileExt, partials);

--- a/plugins/plugin-sass/plugin.js
+++ b/plugins/plugin-sass/plugin.js
@@ -11,7 +11,7 @@ function stripFileExtension(filename) {
 }
 
 function findChildPartials(pathName, fileExt) {
-  let dirPath = path.parse(pathName).dir;
+  const dirPath = path.parse(pathName).dir;
   let fileName = pathName.split('/').pop();
 
   // Prepend a "_" to signify a partial.

--- a/plugins/plugin-sass/plugin.js
+++ b/plugins/plugin-sass/plugin.js
@@ -55,7 +55,7 @@ function scanSassImports(fileContents, filePath, fileExt, partials = new Set()) 
         return;
       }
 
-      // Add this partial to the main list to avoid duplicates.
+      // Add this partial to the main list being passed to avoid duplicates.
       partials.add(pathName);
 
       // If it is a directory then look for an _index file.

--- a/plugins/plugin-sass/test/__snapshots__/plugin.test.js.snap
+++ b/plugins/plugin-sass/test/__snapshots__/plugin.test.js.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`plugin-sass returns the compiled Sass result: App.sass 1`] = `
-"body {
+".child {
+  text-align: left;
+}
+
+body {
   font-family: Helvetica, sans-serif;
 }
 

--- a/plugins/plugin-sass/test/fixtures/sass/App.sass
+++ b/plugins/plugin-sass/test/fixtures/sass/App.sass
@@ -4,6 +4,6 @@
 body
     font-family: folder.$font-stack
 
-.App 
+.App
   text-align: center
   background: base.$primary-color

--- a/plugins/plugin-sass/test/fixtures/sass/folder/_child-partial.sass
+++ b/plugins/plugin-sass/test/fixtures/sass/folder/_child-partial.sass
@@ -1,0 +1,2 @@
+.child
+  text-align: left

--- a/plugins/plugin-sass/test/fixtures/sass/folder/_index.sass
+++ b/plugins/plugin-sass/test/fixtures/sass/folder/_index.sass
@@ -1,2 +1,4 @@
 // folder/_index.sass
+@use 'child-partial'
+
 $font-stack: Helvetica, sans-serif

--- a/plugins/plugin-sass/test/plugin.test.js
+++ b/plugins/plugin-sass/test/plugin.test.js
@@ -3,10 +3,11 @@ const path = require('path');
 
 const pathToSassApp = path.join(__dirname, 'fixtures/sass/App.sass');
 const pathToSassBase = path.join(__dirname, 'fixtures/sass/_base.sass');
+const pathToSassChild = path.join(__dirname, 'fixtures/sass/folder/_child-partial.sass');
 const pathToScssApp = path.join(__dirname, 'fixtures/scss/App.scss');
 const pathToBadCode = path.join(__dirname, 'fixtures/bad/bad.scss');
 
-describe('plugin-sass', () => {
+describe.only('plugin-sass', () => {
   test('returns the compiled Sass result', async () => {
     const p = plugin(null, {});
     const sassResult = await p.load({filePath: pathToSassApp, isDev: false});
@@ -39,6 +40,9 @@ describe('plugin-sass', () => {
     expect(p.markChanged.mock.calls).toEqual([]);
     p.onChange({filePath: pathToSassBase});
     expect(p.markChanged.mock.calls).toEqual([[pathToSassApp]]);
+    // p.markChanged.mockClear();
+    p.onChange({filePath: pathToSassChild});
+    expect(p.markChanged.mock.calls).toEqual([[pathToSassApp]]);
   });
 
   test('does not track dependant changes when isDev=false', async () => {
@@ -47,6 +51,7 @@ describe('plugin-sass', () => {
     await p.load({filePath: pathToSassApp, isDev: false});
     p.onChange({filePath: pathToSassApp});
     p.onChange({filePath: pathToSassBase});
+    p.onChange({filePath: pathToSassChild});
     expect(p.markChanged.mock.calls).toEqual([]);
   });
 

--- a/plugins/plugin-sass/test/plugin.test.js
+++ b/plugins/plugin-sass/test/plugin.test.js
@@ -3,11 +3,12 @@ const path = require('path');
 
 const pathToSassApp = path.join(__dirname, 'fixtures/sass/App.sass');
 const pathToSassBase = path.join(__dirname, 'fixtures/sass/_base.sass');
+const pathToSassIndex = path.join(__dirname, 'fixtures/sass/folder/_index.sass');
 const pathToSassChild = path.join(__dirname, 'fixtures/sass/folder/_child-partial.sass');
 const pathToScssApp = path.join(__dirname, 'fixtures/scss/App.scss');
 const pathToBadCode = path.join(__dirname, 'fixtures/bad/bad.scss');
 
-describe.only('plugin-sass', () => {
+describe('plugin-sass', () => {
   test('returns the compiled Sass result', async () => {
     const p = plugin(null, {});
     const sassResult = await p.load({filePath: pathToSassApp, isDev: false});
@@ -40,7 +41,10 @@ describe.only('plugin-sass', () => {
     expect(p.markChanged.mock.calls).toEqual([]);
     p.onChange({filePath: pathToSassBase});
     expect(p.markChanged.mock.calls).toEqual([[pathToSassApp]]);
-    // p.markChanged.mockClear();
+    p.markChanged.mockClear();
+    p.onChange({filePath: pathToSassIndex});
+    expect(p.markChanged.mock.calls).toEqual([[pathToSassApp]]);
+    p.markChanged.mockClear();
     p.onChange({filePath: pathToSassChild});
     expect(p.markChanged.mock.calls).toEqual([[pathToSassApp]]);
   });
@@ -51,7 +55,6 @@ describe.only('plugin-sass', () => {
     await p.load({filePath: pathToSassApp, isDev: false});
     p.onChange({filePath: pathToSassApp});
     p.onChange({filePath: pathToSassBase});
-    p.onChange({filePath: pathToSassChild});
     expect(p.markChanged.mock.calls).toEqual([]);
   });
 


### PR DESCRIPTION
## Changes

The @snowpack/plugin-sass plugin does not correctly trigger sass recompiling when partials past the first level of imports are changed during `snowpack dev`. Although Snowpack recognizes that the file has changed, it does not trigger the top file importing it as changed so nothing is recompiled.

The `scanSassImports()` function will now recursively find all the child imports. It will also reduce duplicates since it is possible that many partials are importing the same file like a `_variables.scss` partial. I also added support for `@forward` which is also used for importing partials https://sass-lang.com/documentation/at-rules/forward.

Related Discussions:
#1717
#2668

## Testing

I first updated the `marks a dependant as changed when an imported changes and isDev=true` test to look for a child of a child dependency. This proved the bug by causing the test to fail. I then wrote the code to allow the test to pass. I also manually tested in a large project with multiple levels of nesting.

## Docs

Bug fix only.
