### PR TITLE
feat: support specifying sourcemap type in config.optimize.sourcemap

### DIFF
--- a/snowpack/src/build/optimize.ts
+++ b/snowpack/src/build/optimize.ts
@@ -391,6 +391,7 @@ async function runEsbuildOnBuildDirectory(
     outbase: config.buildOptions.out,
     write: false,
     bundle: true,
+    sourcemap: config.optimize!.sourcemap,
     splitting: config.optimize!.splitting,
     format: 'esm',
     platform: 'browser',

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -407,6 +407,7 @@ function normalizeConfig(_config: SnowpackUserConfig): SnowpackConfig {
       entrypoints: config.optimize.entrypoints ?? 'auto',
       preload: config.optimize.preload ?? false,
       bundle: config.optimize.bundle ?? false,
+      sourcemap: config.optimize.splitting ?? true,
       splitting: config.optimize.splitting ?? false,
       treeshake: config.optimize.treeshake ?? true,
       manifest: config.optimize.manifest ?? false,

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -213,6 +213,7 @@ export interface OptimizeOptions {
   entrypoints: 'auto' | string[] | ((options: {files: string[]}) => string[]);
   preload: boolean;
   bundle: boolean;
+  sourcemap: boolean | 'both' | 'inline' | 'external';
   splitting: boolean;
   treeshake: boolean;
   manifest: boolean;

--- a/www/_template/guides/optimize-and-bundle.md
+++ b/www/_template/guides/optimize-and-bundle.md
@@ -34,6 +34,7 @@ export interface OptimizeOptions {
   entrypoints: 'auto' | string[] | ((options: { files: string[] }) => string[]);
   preload: boolean;
   bundle: boolean;
+  sourcemap: boolean | 'external' | 'inline' | 'both';
   splitting: boolean;
   treeshake: boolean;
   manifest: boolean;

--- a/www/_template/guides/upgrade-guide.md
+++ b/www/_template/guides/upgrade-guide.md
@@ -56,6 +56,7 @@ export interface OptimizeOptions {
   entrypoints: 'auto' | string[] | ((options: { files: string[] }) => string[]);
   preload: boolean;
   bundle: boolean;
+  sourcemap: boolean | 'external' | 'inline' | 'both';
   splitting: boolean;
   treeshake: boolean;
   manifest: boolean;


### PR DESCRIPTION
# feat: support specifying sourcemap type in config.optimize.sourcemap

chrome devtool don't support to load resources in `chrome-extension://` protocol
chrome extension has to use inline sourcemap to solve this

https://stackoverflow.com/a/60512870/5671288

---

## Changes

add support for specifying config.optimize.sourcemap in config file

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Didn't add any test against this.
Just grep any `splitting` and add `sourcemap` logic above it.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

Documentation is updated.

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
