### PR TITLE
Add missing await in the loadConfiguration docs

### DIFF
--- a/www/_template/reference/javascript-interface.md
+++ b/www/_template/reference/javascript-interface.md
@@ -27,7 +27,7 @@ The easiest way to think about the difference is that `SnowpackUserConfig` is th
 
 ```js
 import {loadConfiguration} from 'snowpack';
-const config = loadConfiguration({...}, '/path/to/snowpack.config.js');
+const config = await loadConfiguration({...}, '/path/to/snowpack.config.js');
 ```
 
 Similar to `createConfiguration`, but this function will actually check the file system to load a configuration file from disk.


### PR DESCRIPTION
## Changes

Very small docs improvement.

## Testing

N/A

## Docs

loadConfiguration returns a Promise but the code example was missing an await.
