### PR TITLE
Fix Mac OS devOptions.open bug

### DIFF
--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -264,7 +264,8 @@ export async function openInBrowser(
     : browser;
   const isMacChrome =
     process.platform === 'darwin' &&
-    (/chrome/i.test(browser) || /chrome/i.test(await getDefaultBrowserId()));
+    (/chrome/i.test(browser) ||
+      (/default/i.test(browser) && /chrome/i.test(await getDefaultBrowserId())));
   if (!isMacChrome) {
     await (browser === 'default' ? open(url) : open(url, {app: browser}));
     return;


### PR DESCRIPTION
If `devOptions.open` is set (to something other than `'chrome'` or `'default'`) and Chrome is the default system browser, Chrome will be launched anyway.
    
It worked in snowpack 3.0.11 but not in 3.0.13, so it was probably introduced in https://github.com/snowpackjs/snowpack/pull/2364

## Changes

Only use default system browser (for Mac OS + Chrome case) if `devOptions.open === 'default'`.

## Testing

No tests. Too environmental specific.

## Docs

Bug fix only.
