### PR TITLE
Add comment that can fix TypeScript errors with Yarn

### DIFF
--- a/create-snowpack-app/app-template-react-typescript/README.md
+++ b/create-snowpack-app/app-template-react-typescript/README.md
@@ -12,6 +12,21 @@ Open http://localhost:8080 to view it in the browser.
 The page will reload if you make edits.
 You will also see any lint errors in the console.
 
+> In case you use yarn version 2 (berry) and have "file not found" errors in the console.
+Typescript does not support yarn 2 folder structure directly (yet).
+The workaround is to replace the loading of the typescript plugin in snowpack.config.js with a call to [phpify](https://yarnpkg.com/advanced/pnpify).
+
+```json
+plugins: [
+  // '@snowpack/plugin-typescript',
+  ['@snowpack/plugin-typescript', { tsc: 'yarn pnpify tsc' }],
+]
+```
+
+Issue: [microsoft/TypeScript#28289](https://github.com/microsoft/TypeScript/issues/28289)
+
+More info: https://medium.com/swlh/getting-started-with-yarn-2-and-typescript-43321a3acdee
+
 ### npm run build
 
 Builds a static copy of your site to the `build/` folder.

--- a/create-snowpack-app/app-template-react-typescript/snowpack.config.js
+++ b/create-snowpack-app/app-template-react-typescript/snowpack.config.js
@@ -8,6 +8,8 @@ module.exports = {
     '@snowpack/plugin-react-refresh',
     '@snowpack/plugin-dotenv',
     '@snowpack/plugin-typescript',
+    // if using yarn v2 and have 27+ TypeScript errors replace with
+    // ['@snowpack/plugin-typescript', { tsc: 'yarn pnpify tsc' }],
   ],
   routes: [
     /* Enable an SPA Fallback in development: */


### PR DESCRIPTION
With Yarn 2 TypeScript can't find @types/... files in node_modules (because it does not exist). This is a workaround for such situation.

## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
