### PR TITLE
Properly find npm install sass when running outside of snowpack project

### DIFF
--- a/plugins/plugin-sass/plugin.js
+++ b/plugins/plugin-sass/plugin.js
@@ -28,7 +28,7 @@ function scanSassImports(fileContents, filePath, fileExt) {
     });
 }
 
-module.exports = function sassPlugin(_, {native, compilerOptions = {}} = {}) {
+module.exports = function sassPlugin({root}, {native, compilerOptions = {}} = {}) {
   /** A map of partially resolved imports to the files that imported them. */
   const importedByMap = new Map();
 
@@ -136,6 +136,8 @@ module.exports = function sassPlugin(_, {native, compilerOptions = {}} = {}) {
         input: contents,
         env: native ? undefined : npmRunPath.env(),
         extendEnv: native ? true : false,
+        preferLocal: native ? false : true,
+        localDir: native ? undefined : root
       });
       // Handle the output.
       if (stderr) throw new Error(stderr);

--- a/plugins/plugin-sass/plugin.js
+++ b/plugins/plugin-sass/plugin.js
@@ -28,7 +28,9 @@ function scanSassImports(fileContents, filePath, fileExt) {
     });
 }
 
-module.exports = function sassPlugin({root}, {native, compilerOptions = {}} = {}) {
+module.exports = function sassPlugin(snowpackConfig, {native, compilerOptions = {}} = {}) {
+  const {root} = snowpackConfig || {};
+
   /** A map of partially resolved imports to the files that imported them. */
   const importedByMap = new Map();
 
@@ -132,13 +134,23 @@ module.exports = function sassPlugin({root}, {native, compilerOptions = {}} = {}
       Object.entries(compilerOptions).forEach(parseCompilerOption);
 
       // Build the file.
-      const {stdout, stderr} = await execa('sass', args, {
+      const execaOptions = {
         input: contents,
+        // Adds the PATH param to the command so it can find local sass
         env: native ? undefined : npmRunPath.env(),
-        extendEnv: native ? true : false,
-        preferLocal: native ? false : true,
-        localDir: native ? undefined : root
-      });
+        extendEnv: native ? true : false
+      };
+
+      // If not using native them specify the project root so execa finds the right sass binary.
+      if(!native && root) {
+        // Prefer the node_modules/.bin
+        execaOptions.preferLocal = true;
+
+        // Specifies the local directory (which contains a .bin with sass)
+        execaOptions.localDir = root
+      }
+
+      const {stdout, stderr} = await execa('sass', args, execaOptions);
       // Handle the output.
       if (stderr) throw new Error(stderr);
       if (stdout) return stdout;


### PR DESCRIPTION
When the Node script is being run from a folder that doesn't contain the snowpack project `execa` isn't able to find the npm installed version of sass. Since it can always be installed in the snowpack root, passing `root` along to execa make it be able to find it.

## Changes

Configuration to the sass plugin. Added the path to find the `sass` binary in non-native scenario.

## Testing

This would be difficult to test within the project because `sass` is always findable with node_modules resolution. Creating a test might involve loading the plugin from somewhere else. Willing to give it a shot if wanted.

## Docs

Not an API change, no doc changes necessary.
