### PR TITLE
only target actual imports (Regex Fix)

### DIFF
--- a/snowpack/src/scan-imports.ts
+++ b/snowpack/src/scan-imports.ts
@@ -26,7 +26,7 @@ const CONCURRENT_FILE_READS = 1000;
 // (?!.*(:\/\/)) - Ignore if previous match was a protocol (ex: http://)
 const BARE_SPECIFIER_REGEX = /^[@\w](?!.*(:\/\/))/;
 
-const ESM_IMPORT_REGEX = /(?<![^; \n])import(?:["'\s]*([\w*${}\n\r\t, ]+)\s*from\s*)?\s*["'](.*?)["']/gm;
+const ESM_IMPORT_REGEX = /(?<![^;\n])[ ]*import(?:["'\s]*([\w*${}\n\r\t, ]+)\s*from\s*)?\s*["'](.*?)["']/gm;
 const ESM_DYNAMIC_IMPORT_REGEX = /(?<!\.)\bimport\((?:['"].+['"]|`[^$]+`)\)/gm;
 const HAS_NAMED_IMPORTS_REGEX = /^[\w\s\,]*\{(.*)\}/s;
 const STRIP_AS = /\s+as\s+.*/; // for `import { foo as bar }`, strips “as bar”

--- a/snowpack/src/scan-imports.ts
+++ b/snowpack/src/scan-imports.ts
@@ -26,7 +26,7 @@ const CONCURRENT_FILE_READS = 1000;
 // (?!.*(:\/\/)) - Ignore if previous match was a protocol (ex: http://)
 const BARE_SPECIFIER_REGEX = /^[@\w](?!.*(:\/\/))/;
 
-const ESM_IMPORT_REGEX = /import(?:["'\s]*([\w*${}\n\r\t, ]+)\s*from\s*)?\s*["'](.*?)["']/gm;
+const ESM_IMPORT_REGEX = /^[ ]*import(?:["'\s]*([\w*${}\n\r\t, ]+)\s*from\s*)?\s*["'](.*?)["']/gm;
 const ESM_DYNAMIC_IMPORT_REGEX = /(?<!\.)\bimport\((?:['"].+['"]|`[^$]+`)\)/gm;
 const HAS_NAMED_IMPORTS_REGEX = /^[\w\s\,]*\{(.*)\}/s;
 const STRIP_AS = /\s+as\s+.*/; // for `import { foo as bar }`, strips “as bar”

--- a/snowpack/src/scan-imports.ts
+++ b/snowpack/src/scan-imports.ts
@@ -26,7 +26,7 @@ const CONCURRENT_FILE_READS = 1000;
 // (?!.*(:\/\/)) - Ignore if previous match was a protocol (ex: http://)
 const BARE_SPECIFIER_REGEX = /^[@\w](?!.*(:\/\/))/;
 
-const ESM_IMPORT_REGEX = /^[ ]*import(?:["'\s]*([\w*${}\n\r\t, ]+)\s*from\s*)?\s*["'](.*?)["']/gm;
+const ESM_IMPORT_REGEX = /(?<![^; \n])import(?:["'\s]*([\w*${}\n\r\t, ]+)\s*from\s*)?\s*["'](.*?)["']/gm;
 const ESM_DYNAMIC_IMPORT_REGEX = /(?<!\.)\bimport\((?:['"].+['"]|`[^$]+`)\)/gm;
 const HAS_NAMED_IMPORTS_REGEX = /^[\w\s\,]*\{(.*)\}/s;
 const STRIP_AS = /\s+as\s+.*/; // for `import { foo as bar }`, strips “as bar”


### PR DESCRIPTION
related to this issue:https://github.com/snowpackjs/snowpack/issues/2695

## Changes
improving regular expression to only target actual imports using ,change  `ESM_IMPORT_REGEX` 

### testing String:
```
import "a";import a from "b"; ;@import "c";@ import "c";
import "c";a=" import 'd'";
```
### results:
#### old regex : 
```
import "a"
import a from "b"
import "c"
import "c"
import "c"
import 'd'
```

#### new regex:
```
import "a"
import a from "b"
import "c"
```

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->
new regex: https://regexr.com/5o9ls
old regex :https://regexr.com/5o9m5
## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
