### PR TITLE
Resolve missing extensions

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,6 @@
 vendor
 dist
-test/**/build
+test/build/**/build
 create-snowpack-app/**/build
 packages
 pkg

--- a/snowpack/src/build/file-builder.ts
+++ b/snowpack/src/build/file-builder.ts
@@ -86,7 +86,7 @@ export class FileBuilder {
 
   private verifyRequestFromBuild(type: string): SnowpackBuiltFile {
     // Verify that the requested file exists in the build output map.
-    if (!this.resolvedOutput[type] || !Object.keys(this.resolvedOutput)) {
+    if (!this.resolvedOutput[type] || !Object.keys(this.resolvedOutput).length) {
       throw new Error(
         `${this.loc} - Requested content "${type}" but built ${
           Object.keys(this.resolvedOutput).toString() || 'none'

--- a/snowpack/src/build/import-resolver.ts
+++ b/snowpack/src/build/import-resolver.ts
@@ -22,7 +22,10 @@ export function getFsStat(importedFileOnDisk: string): fs.Stats | false {
 }
 
 /** Resolve an import based on the state of the file/folder found on disk. */
-function resolveSourceSpecifier(lazyFileLoc: string, config: SnowpackConfig) {
+function resolveSourceSpecifier(
+  lazyFileLoc: string,
+  {parentFile, config}: {parentFile: string; config: SnowpackConfig},
+) {
   const lazyFileStat = getFsStat(lazyFileLoc);
 
   // Handle directory imports (ex: "./components" -> "./components/index.js")
@@ -44,7 +47,24 @@ function resolveSourceSpecifier(lazyFileLoc: string, config: SnowpackConfig) {
       lazyFileLoc = tsWorkaroundImportFileLoc;
     }
   } else {
-    lazyFileLoc = lazyFileLoc + '.js';
+    // missing extension
+    if (getFsStat(lazyFileLoc + path.extname(parentFile))) {
+      // first, try parent file’s extension
+      lazyFileLoc = lazyFileLoc + path.extname(parentFile);
+    } else {
+      // otherwise, try and match any extension from the extension map
+      for (const ext of Object.keys(config._extensionMap)) {
+        if (getFsStat(lazyFileLoc + ext)) {
+          lazyFileLoc = lazyFileLoc + ext;
+          break;
+        }
+      }
+    }
+
+    // if still no extension match, fall back to .js
+    if (!path.extname(lazyFileLoc)) {
+      lazyFileLoc = lazyFileLoc + '.js';
+    }
   }
 
   // Transform the file extension (from input to output)
@@ -83,7 +103,7 @@ export function createImportResolver({fileLoc, config}: {fileLoc: string; config
     }
     if (spec.startsWith('./') || spec.startsWith('../') || spec === '.') {
       const importedFileLoc = path.resolve(path.dirname(fileLoc), spec);
-      return resolveSourceSpecifier(importedFileLoc, config) || spec;
+      return resolveSourceSpecifier(importedFileLoc, {parentFile: fileLoc, config}) || spec;
     }
     const aliasEntry = findMatchingAliasEntry(config, spec);
     if (aliasEntry && (aliasEntry.type === 'path' || aliasEntry.type === 'url')) {
@@ -93,7 +113,7 @@ export function createImportResolver({fileLoc, config}: {fileLoc: string; config
         return result;
       }
       const importedFileLoc = path.resolve(config.root, result);
-      return resolveSourceSpecifier(importedFileLoc, config) || spec;
+      return resolveSourceSpecifier(importedFileLoc, {parentFile: fileLoc, config}) || spec;
     }
     return false;
   };

--- a/snowpack/src/build/import-resolver.ts
+++ b/snowpack/src/build/import-resolver.ts
@@ -53,7 +53,8 @@ function resolveSourceSpecifier(
       lazyFileLoc = lazyFileLoc + path.extname(parentFile);
     } else {
       // otherwise, try and match any extension from the extension map
-      for (const ext of Object.keys(config._extensionMap)) {
+      for (const [ext, outputExts] of Object.entries(config._extensionMap)) {
+        if (!outputExts.includes('.js')) continue; // only look through .js-friendly extensions
         if (getFsStat(lazyFileLoc + ext)) {
           lazyFileLoc = lazyFileLoc + ext;
           break;

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -370,18 +370,6 @@ export async function startServer(
     }
   }
 
-  function loadUrl(
-    reqUrl: string,
-    opt?: (LoadUrlOptions & {encoding?: undefined}) | undefined,
-  ): Promise<LoadResult<Buffer | string>>;
-  function loadUrl(
-    reqUrl: string,
-    opt: LoadUrlOptions & {encoding: BufferEncoding},
-  ): Promise<LoadResult<string>>;
-  function loadUrl(
-    reqUrl: string,
-    opt: LoadUrlOptions & {encoding: null},
-  ): Promise<LoadResult<Buffer>>;
   async function loadUrl(
     reqUrl: string,
     {

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -28,7 +28,7 @@ import {
 import type {Awaited} from './util';
 
 const CONFIG_NAME = 'snowpack';
-const ALWAYS_EXCLUDE = ['**/node_modules/**/*', '**/*.d.ts'];
+const ALWAYS_EXCLUDE = ['**/node_modules/**/*', '**/_*.{sass,scss}', '**/*.d.ts'];
 
 // default settings
 const DEFAULT_ROOT = process.cwd();

--- a/test/build/plugin-sass/package.json
+++ b/test/build/plugin-sass/package.json
@@ -1,0 +1,16 @@
+{
+  "private": true,
+  "version": "1.0.1",
+  "name": "@snowpack/test-plugin-sass",
+  "description": "A test to make sure @snowpack/plugin-sass builds",
+  "scripts": {
+    "testbuild": "snowpack build"
+  },
+  "devDependencies": {
+    "@snowpack/plugin-sass": "^1.0.0",
+    "snowpack": "^3.0.0"
+  },
+  "dependencies": {
+    "@snowpack/plugin-sass": "^1.3.0"
+  }
+}

--- a/test/build/plugin-sass/plugin-sass.test.js
+++ b/test/build/plugin-sass/plugin-sass.test.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+const {setupBuildTest} = require('../../test-utils');
+
+const cwd = path.join(__dirname, 'build');
+
+describe('@snowpack/plugin-sass', () => {
+  beforeAll(() => {
+    setupBuildTest(__dirname);
+  });
+
+  it('ignores partials', () => {
+    const buildContents = fs.readdirSync(path.join(cwd, '_dist_'));
+    expect(buildContents).toEqual(['index.css']); // assert index.css AND ONLY index.css is output (ignore _partial.scss)
+  });
+});

--- a/test/build/plugin-sass/snowpack.config.js
+++ b/test/build/plugin-sass/snowpack.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  "mount": {
+    "src": "/_dist_"
+  },
+  "plugins": [
+    "@snowpack/plugin-sass"
+  ]
+}

--- a/test/build/plugin-sass/src/_partial.scss
+++ b/test/build/plugin-sass/src/_partial.scss
@@ -1,0 +1,5 @@
+// this shouldn’t be included!
+
+body {
+  color: blue;
+}

--- a/test/build/plugin-sass/src/index.scss
+++ b/test/build/plugin-sass/src/index.scss
@@ -1,0 +1,1 @@
+@use "partial"

--- a/test/build/plugin-vue/package.json
+++ b/test/build/plugin-vue/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "version": "1.0.0",
+  "name": "@snowpack/test-plugin-vue",
+  "description": "A test to make sure @snowpack/plugin-vue builds",
+  "scripts": {
+    "testbuild": "snowpack build"
+  },
+  "devDependencies": {
+    "@snowpack/plugin-vue": "^2.3.0",
+    "snowpack": "^3.0.0"
+  }
+}

--- a/test/build/plugin-vue/plugin-vue.test.js
+++ b/test/build/plugin-vue/plugin-vue.test.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+const {setupBuildTest} = require('../../test-utils');
+
+const cwd = path.join(__dirname, 'build');
+
+describe('@snowpack/plugin-vue', () => {
+  beforeAll(() => {
+    setupBuildTest(__dirname);
+  });
+
+  it('assumes .vue.js', () => {
+    const index = fs.readFileSync(path.join(cwd, '_dist_', 'index.vue.js'), 'utf8');
+    expect(index).toEqual(
+      expect.stringContaining(`import MyComponent from './MyComponent.vue.js'`),
+    );
+  });
+});

--- a/test/build/plugin-vue/snowpack.config.js
+++ b/test/build/plugin-vue/snowpack.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  "mount": {
+    "src": "/_dist_"
+  },
+  "plugins": [
+    "@snowpack/plugin-vue"
+  ]
+}

--- a/test/build/plugin-vue/src/MyComponent.vue
+++ b/test/build/plugin-vue/src/MyComponent.vue
@@ -1,0 +1,5 @@
+<script>
+export default {
+  props: {}
+}
+</script>

--- a/test/build/plugin-vue/src/index.vue
+++ b/test/build/plugin-vue/src/index.vue
@@ -1,0 +1,7 @@
+<script>
+import MyComponent from './MyComponent';
+
+export default {
+  components: { MyComponent }
+}
+</script>


### PR DESCRIPTION
## Changes

Part of #2695. When Snowpack encounters no extension in a file, it assumes `.js` when that may not be the case. For example, in Vue:

```vue
<script>
import MyComponent from '../components/MyComponent';
```

This won’t compile at all. Snowpack resolves this to `MyComponent.js`, which doesn’t exist. Which means much framework/preprocessing will fail in `main`.

This PR doesn’t change resolution logic; it just adds 2 additional steps in resolving (#1 and #2):

1. **New** See if the same extension as the parent file exists (e.g. if in a `.vue` file, check if `.vue` exists first)
2. **New** If that fails, look through `config._extensionMap` and see if there are any matches
3. (original fallback) add `.js` as we were doing before 

The end result is:

```diff
- import MyComponent from '../components/MyComponent.js';
+ import MyComponent from '../components/MyComponent.vue.js';
```

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

New tests:

- ✅ Vue test
- ✅ Sass test (that tests for ignoring partials)

Also tested locally with a Vue + Snowpack app. It was broken with `main`, but this PR fixes it.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

No docs changes necessary; this is a change deep in the bowels of Snowpack

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
