### PR TITLE
add a angular-app-scripts package

### DIFF
--- a/create-snowpack-app/app-scripts-angular/package.json
+++ b/create-snowpack-app/app-scripts-angular/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@snowpack/app-scripts-angular",
+  "version": "2.0.0",
+  "main": "snowpack.config.js",
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/snowpackjs/snowpack/tree/main/create-snowpack-app/app-scripts-angular#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
+    "directory": "create-snowpack-app/app-scripts-angular"
+  },
+  "peerDependencies": {
+    "@snowpack/plugin-angular": "^2.0.0"
+  }
+}

--- a/create-snowpack-app/app-scripts-angular/snowpack.config.js
+++ b/create-snowpack-app/app-scripts-angular/snowpack.config.js
@@ -1,0 +1,7 @@
+/** @type {import("snowpack").SnowpackUserConfig } */
+module.exports = {
+	buildOptions: { clean: true },
+	mount: { public: '/' },
+	plugins: ['snowpack-plugin-angular'],
+	routes: [{ match: 'routes', src: '.*', dest: '/index.html' }],
+};

--- a/create-snowpack-app/app-scripts-angular/tsconfig.json
+++ b/create-snowpack-app/app-scripts-angular/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compileOnSave": false,
+	"compilerOptions": {
+		"allowSyntheticDefaultImports": true,
+		"declaration": false,
+		"experimentalDecorators": true,
+		"forceConsistentCasingInFileNames": true,
+		"importHelpers": true,
+		"lib": ["ESNext", "dom"],
+		"module": "ESNext",
+		"moduleResolution": "node",
+		"resolveJsonModule": true,
+		"sourceMap": true,
+		"strict": true,
+		"target": "ESNext"
+	}
+}


### PR DESCRIPTION
## Changes

This adds an angular-app-scripts package, and is a first step towards adding an official Angular support to Snowpack.

## Testing

It's not connected to any template yet, so no tests are yet needed.

## Docs

Not yet, it will be documented after the plugin & template packages will be added to.
