### PR TITLE
Revert snowpack version to 3.0.13

### DIFF
--- a/snowpack/package.json
+++ b/snowpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snowpack",
-  "version": "3.1.0-pre.12",
+  "version": "3.0.13",
   "description": "The ESM-powered frontend build tool. Fast, lightweight, unbundled.",
   "author": "Fred K. Schott <fkschott@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Changes

Reverts `snowpack`'s package.json `version` to `3.0.13`. Fixes issues with `yarn test`

## Testing

Running the existing test suite successfully

## Docs

Bug fix
