### PR TITLE
Update release script

### DIFF
--- a/scripts/release-all.js
+++ b/scripts/release-all.js
@@ -1,16 +1,14 @@
 const release = require('./release.cjs');
 
-(async () => {
-  await release('esinstall', 'latest', 'patch');
-  await release('skypack', 'latest', 'patch');
-  await release('snowpack', 'latest', 'patch');
-  await release('app-template-blank-typescript', 'latest', 'patch');
-  await release('app-template-lit-element', 'latest', 'patch');
-  await release('app-template-preact-typescript', 'latest', 'patch');
-  await release('app-template-react-typescript', 'latest', 'patch');
-  await release('app-template-svelte-typescript', 'latest', 'patch');
-  await release('app-template-svelte-typescript', 'latest', 'patch');
-  await release('app-template-vue-typescript', 'latest', 'patch');
-  await release('plugins/plugin-optimize', 'latest', 'patch');
-  await release('plugins/web-test-runner-plugin', 'latest', 'patch');
-})();
+release('esinstall', 'latest', 'patch');
+release('skypack', 'latest', 'patch');
+release('snowpack', 'latest', 'patch');
+release('app-template-blank-typescript', 'latest', 'patch');
+release('app-template-lit-element', 'latest', 'patch');
+release('app-template-preact-typescript', 'latest', 'patch');
+release('app-template-react-typescript', 'latest', 'patch');
+release('app-template-svelte-typescript', 'latest', 'patch');
+release('app-template-svelte-typescript', 'latest', 'patch');
+release('app-template-vue-typescript', 'latest', 'patch');
+release('plugins/plugin-optimize', 'latest', 'patch');
+release('plugins/web-test-runner-plugin', 'latest', 'patch');

--- a/scripts/release.cjs
+++ b/scripts/release.cjs
@@ -6,12 +6,10 @@ const execa = require('execa');
 const root = path.resolve(__dirname, '..');
 
 /** Update  */
-function updateLocalDepVersions(dependencyName, newVersion) {
-  const pkgJsonLocs = glob.sync('**/*/package.json', {
-    cwd: root,
-    ignore: ['**/node_modules/**', 'create-snowpack-app/**'],
-    nodir: true,
-  });
+function updateLocalDepVersions(dependencyName, newVersion, tag) {
+  const ignore = ['**/node_modules/**'];
+  if (tag === 'latest') ignore.push('create-snowpack-app/**');
+  const pkgJsonLocs = glob.sync('**/*/package.json', {cwd: root, ignore, nodir: true});
   for (const pkgJsonLoc of pkgJsonLocs) {
     const pkgJson = JSON.parse(fs.readFileSync(path.join(root, pkgJsonLoc), 'utf8'));
     for (const depScope of ['dependencies', 'devDependencies']) {
@@ -75,7 +73,7 @@ module.exports = function release(pkgFolder, tag, bump, skipBuild) {
   const {version: newPkgVersion} = JSON.parse(fs.readFileSync(pkgJsonLoc, 'utf8'));
   const newPkgTag = `${pkgName}@${newPkgVersion}`;
 
-  updateLocalDepVersions(pkgFolder, newPkgVersion);
+  updateLocalDepVersions(pkgFolder, newPkgVersion, tag);
 
   if (!pkgFolder.startsWith('create-snowpack-app/')) {
     const changelogLoc = path.join(dir, 'CHANGELOG.md');

--- a/scripts/release.cjs
+++ b/scripts/release.cjs
@@ -1,6 +1,27 @@
 const fs = require('fs');
+const glob = require('glob');
 const path = require('path');
 const execa = require('execa');
+
+const root = path.resolve(__dirname, '..');
+
+/** Update  */
+function updateLocalDepVersions(dependencyName, newVersion) {
+  const pkgJsonLocs = glob.sync('**/*/package.json', {
+    cwd: root,
+    ignore: ['**/node_modules/**', 'create-snowpack-app/**'],
+    nodir: true,
+  });
+  for (const pkgJsonLoc of pkgJsonLocs) {
+    const pkgJson = JSON.parse(fs.readFileSync(path.join(root, pkgJsonLoc), 'utf8'));
+    for (const depScope of ['dependencies', 'devDependencies']) {
+      if (pkgJson[depScope] && pkgJson[depScope][dependencyName]) {
+        pkgJson[depScope][dependencyName] = `^${newVersion}`;
+      }
+    }
+    fs.writeFileSync(pkgJsonLoc, JSON.stringify(pkgJson, undefined, 2) + '\n', 'utf8');
+  }
+}
 
 function formatDate() {
   var d = new Date(),
@@ -33,7 +54,6 @@ function generateChangelogUpdate(dir, newTag, oldTag) {
 module.exports = function release(pkgFolder, tag, bump, skipBuild) {
   console.log(`# release(${pkgFolder}, ${tag}, ${bump})`);
 
-  const root = path.resolve(__dirname, '..');
   const dir = path.resolve(root, pkgFolder);
   if (execa.sync('git', ['status', '--porcelain'], {cwd: dir}).stdout) {
     console.error('working directory not clean!');
@@ -54,6 +74,8 @@ module.exports = function release(pkgFolder, tag, bump, skipBuild) {
   console.log(execa.sync('npm', ['version', bump], {cwd: dir}));
   const {version: newPkgVersion} = JSON.parse(fs.readFileSync(pkgJsonLoc, 'utf8'));
   const newPkgTag = `${pkgName}@${newPkgVersion}`;
+
+  updateLocalDepVersions(pkgFolder, newPkgVersion);
 
   if (!pkgFolder.startsWith('create-snowpack-app/')) {
     const changelogLoc = path.join(dir, 'CHANGELOG.md');


### PR DESCRIPTION
## Changes

When releasing a prerelease, all our tests stop working because `yarn` will no longer match a `x.x.x-pre.x` tag to semver. This means when you run `yarn` in CI, it will pull the versions from npm rather than locally.

This changes the release script to update all local `package.json`s to use the new version for every package. Proof of it working locally:

<img width="1006" alt="Screen Shot 2021-03-12 at 14 45 21" src="https://user-images.githubusercontent.com/1369770/111001849-c8359600-8341-11eb-8824-5a1c00376c02.png">

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Tested locally (offline, of course)

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
