### PR TITLE
SSR fixes

### DIFF
--- a/snowpack/src/ssr-loader/transform.ts
+++ b/snowpack/src/ssr-loader/transform.ts
@@ -157,6 +157,7 @@ export function transform(data) {
 
         if (!is_reference(node, parent)) return;
         if (!replacements.has(node.name)) return;
+        if(parent.type === 'ExportSpecifier') return;
 
         if (current_scope.find_owner(node.name) === scope) {
           let replacement = replacements.get(node.name);


### PR DESCRIPTION
These SSR fixes all relate with the ability to run Vue SSR through snowpack. A few things this fixes:

* Export star support depends on the modules being enumerable, and real module namespace objects are, so this fixes that.
* Export statements get updated, so don't then try to update export identifiers that happen to match import identifiers.
* Use REQUIRE_OR_IMPORT to import a module, so that ESM modules can be imported.
