### PR TITLE
Fix minor typo on WASM guide

### DIFF
--- a/www/_template/guides/wasm.md
+++ b/www/_template/guides/wasm.md
@@ -25,7 +25,7 @@ In the future, we may add `import "/example.wasm"` ESM import support to automat
 In any case, WASM import support would just be a shortcut or wrapper around the code snippet above. You can recreate this helper today in your own project:
 
 ```js
-// Example: WASM Loader (move this into some utilility/helper file for reuse)
+// Example: WASM Loader (move this into some utility/helper file for reuse)
 export function loadWasm(url, importObject = {module: {}, env: {abort() {}}}) => {
   const result = await WebAssembly.instantiateStreaming(fetch(url), importObject);
   return result.instance; // or, return result;


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Fixed typo on the Snowpack WASM guide. utilility -> utility

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->
Not tested, it's a typo fix.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

Typo change only
