### PR TITLE
improve our CJS scanner

### DIFF
--- a/esinstall/package.json
+++ b/esinstall/package.json
@@ -54,7 +54,7 @@
     "resolve": "^1.20.0",
     "rimraf": "^3.0.0",
     "rollup": "2.37.1",
-    "rollup-plugin-polyfill-node": "^0.5.0",
+    "rollup-plugin-polyfill-node": "^0.6.2",
     "slash": "^3.0.0",
     "validate-npm-package-name": "^3.0.0",
     "vm2": "^3.9.2"

--- a/snowpack/src/commands/build.ts
+++ b/snowpack/src/commands/build.ts
@@ -222,7 +222,11 @@ export async function build(commandOptions: CommandOptions): Promise<SnowpackBui
     let onFileChangeCallback: OnFileChangeCallback = () => {};
     devServer.onFileChange(async ({filePath}) => {
       // First, do our own re-build logic
-      allFileUrlsToProcess.push(...getUrlsForFile(filePath, config)!);
+      const fileUrls = getUrlsForFile(filePath, config);
+      if (!fileUrls || fileUrls.length === 0) {
+        return;
+      }
+      allFileUrlsToProcess.push(fileUrls[0]);
       await flushFileQueue(false, {
         isSSR,
         isHMR,

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -726,7 +726,7 @@ export async function startServer(
     return http.createServer(responseHandler as http.RequestListener);
   };
 
-  let server: ReturnType<typeof createServer> | undefined;
+  let server: http.Server | http2.Http2Server | undefined;
   if (port) {
     server = createServer(async (req, res) => {
       // Attach a request logger.
@@ -829,6 +829,7 @@ export async function startServer(
   const sp = {
     port,
     hmrEngine,
+    rawServer: server,
     loadUrl,
     handleRequest,
     sendResponseFile,

--- a/snowpack/src/dev/hmr.ts
+++ b/snowpack/src/dev/hmr.ts
@@ -1,5 +1,5 @@
-import http from 'http';
-import http2 from 'http2';
+import type http from 'http';
+import type http2 from 'http2';
 import path from 'path';
 import onProcessExit from 'signal-exit';
 import {FileBuilder} from '../build/file-builder';
@@ -9,7 +9,7 @@ import {getCacheKey, hasExtension} from '../util';
 
 export function startHmrEngine(
   inMemoryBuildCache: Map<string, FileBuilder>,
-  server: http.Server | http2.Http2SecureServer | undefined,
+  server: http.Server | http2.Http2Server | undefined,
   serverPort: number | undefined,
   config: SnowpackConfig,
 ) {

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -1,5 +1,6 @@
 import type {InstallOptions as EsinstallOptions, InstallTarget} from 'esinstall';
 import type * as http from 'http';
+import type * as http2 from 'http2';
 import type {EsmHmrEngine} from './hmr-server-engine';
 
 // RawSourceMap is inlined here for bundle purposes.
@@ -55,6 +56,7 @@ export interface LoadUrlOptions {
 export interface SnowpackDevServer {
   port: number;
   hmrEngine?: EsmHmrEngine;
+  rawServer?: http.Server | http2.Http2Server | undefined;
   loadUrl: {
     (reqUrl: string, opt?: (LoadUrlOptions & {encoding?: undefined}) | undefined): Promise<
       LoadResult<Buffer | string>

--- a/test/esinstall/cjs-autodetect-exports/cjs-autodetect-exports.test.js
+++ b/test/esinstall/cjs-autodetect-exports/cjs-autodetect-exports.test.js
@@ -4,7 +4,7 @@ const {runTest} = require('../esinstall-test-utils.js');
 
 // This test simulates what keyboard-key is doing.
 describe('Auto-detecting CJS exports', () => {
-  it('should not attempt to convert package with invalid identifiers as exports', async () => {
+  it('should not convert invalid identifiers as exports', async () => {
     const cwd = __dirname;
     const dest = path.join(cwd, 'test-cjs-invalid-exports');
     const spec = 'cjs-invalid-exports';
@@ -18,8 +18,8 @@ describe('Auto-detecting CJS exports', () => {
 
     const output = fs.readFileSync(path.join(dest, `${spec}.js`), 'utf8');
     expect(output).toEqual(
-      // This shouldn't contain named exports
-      expect.not.stringContaining(`export {`),
+      // This shouldn't contain the ")" export
+      expect.stringContaining(`export { entrypoint as __moduleExports, a }`),
     );
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12812,10 +12812,10 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollup-plugin-polyfill-node@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-polyfill-node/-/rollup-plugin-polyfill-node-0.5.0.tgz#afa87f9105233963b89b0f74a2baaac53ab8a232"
-  integrity sha512-CYPf4vKeZG5w/Ut7TR1lEMKiBT2pHfj1RLnk92whXKFtT8IGkm+TydwgDNpgTXBCI4V528YijyFVMz4dKcR3AA==
+rollup-plugin-polyfill-node@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-polyfill-node/-/rollup-plugin-polyfill-node-0.6.2.tgz#dea62e00f5cc2c174e4b4654b5daab79b1a92fc3"
+  integrity sha512-gMCVuR0zsKq0jdBn8pSXN1Ejsc458k2QsFFvQdbHoM0Pot5hEnck+pBP/FDwFS6uAi77pD3rDTytsaUStsOMlA==
   dependencies:
     "@rollup/plugin-inject" "^4.0.0"
 


### PR DESCRIPTION
## Changes

- cjs-module-lexer isn't the magic bullet that we'd hoped it would be. Many popular packages continue to fail static analysis, and Rollup has recently made a backwards incompatible change that will cause all packages built with Rollup to fail scanning, going forward.
- Meanwhile our runtime analyzer continues to run well, with our `namedExports` opt-in support fixing most issues in the scanner.
- This change now runs the runtime `namedExports` scanner on all CJS packages. Because they're CJS, they are expected to run in Node.js without error. But, on the off chance that runtime analysis fails, we will silently continue and you won't be any worse off then you were before.
- This may make the installer a bit slower on large projects, but since installing is a one-time cost we're okay to pay it. And, we assume that the number of CJS packages will only continue to drop, meaning eventually this step can phase out of the installer entirely.

## Testing

- Tests updated.

## Docs

- Docs updated.