### PR TITLE
Fix: Type number trivially inferred from a number literal, remove typ…

### DIFF
--- a/create-snowpack-app/app-template-svelte-typescript/src/App.svelte
+++ b/create-snowpack-app/app-template-svelte-typescript/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang='typescript'>
 	import {onMount} from 'svelte';
-	let count: number = 0;
+	let count = 0;
 	onMount(() => {
 	  const interval = setInterval(() => count++, 1000);
 	  return () => {


### PR DESCRIPTION
## Changes

Fix: Type number trivially inferred from a number literal, remove type annotation. (eslint: @typescript-eslint/no-inferrable-types)