### PR TITLE
readFileSync is destructured

### DIFF
--- a/docs/guides/server-side-render.md
+++ b/docs/guides/server-side-render.md
@@ -76,7 +76,7 @@ app.use(async (req, res, next) => {
   // Render your react component to HTML
   const html = ReactDOMServer.renderToString(React.createElement(MyReactComponent, null));
   // Load contents of index.html
-  const htmlFile = fs.readFileSync('./index.html', 'utf8');
+  const htmlFile = readFileSync('./index.html', 'utf8');
   // Inserts the rendered React HTML into our main div
   const document = htmlFile.replace(/<div id="app"><\/div>/, `<div id="app">${html}</div>`);
   // Sends the response back to the client


### PR DESCRIPTION
The `fs` import destructures readFileSync. Using the code verbatim throws an error.

## Changes
The `fs` import destructures readFileSync. Using the code verbatim throws an error.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
