### PR TITLE
speed up mount scanning with fdir

### DIFF
--- a/snowpack/package.json
+++ b/snowpack/package.json
@@ -48,6 +48,8 @@
     "cli-spinners": "^2.5.0",
     "default-browser-id": "^2.0.0",
     "esbuild": "^0.8.7",
+    "fdir": "^5.0.0",
+    "micromatch": "^4.0.2",
     "open": "^7.0.4",
     "resolve": "^1.20.0",
     "rollup": "^2.34.0"

--- a/snowpack/src/build/build-pipeline.ts
+++ b/snowpack/src/build/build-pipeline.ts
@@ -84,7 +84,7 @@ async function runPipelineLoadStep(
 
   return {
     [srcExt]: {
-      code: await readFile(url.pathToFileURL(srcPath)),
+      code: await readFile(srcPath),
     },
   };
 }

--- a/snowpack/src/build/optimize.ts
+++ b/snowpack/src/build/optimize.ts
@@ -1,7 +1,7 @@
 import cheerio from 'cheerio';
 import * as esbuild from 'esbuild';
 import {promises as fs, readFileSync, unlinkSync, writeFileSync} from 'fs';
-import {glob} from 'glob';
+import {fdir} from 'fdir';
 import mkdirp from 'mkdirp';
 import path from 'path';
 import {logger} from '../logger';
@@ -445,11 +445,10 @@ export async function runBuiltInOptimize(config: SnowpackConfig) {
   }
 
   // * Scan to collect all build files: We'll need this throughout.
-  const allBuildFiles = glob.sync('**/*', {
-    cwd: buildDirectoryLoc,
-    nodir: true,
-    absolute: true,
-  });
+  const allBuildFiles = (await new fdir()
+    .withFullPaths()
+    .crawl(buildDirectoryLoc)
+    .withPromise()) as string[];
 
   // * Resolve and validate your entrypoints: they may be JS or HTML
   const userEntrypoints = await getEntrypoints(options.entrypoints, allBuildFiles);

--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -71,8 +71,8 @@ export function deleteFromBuildSafe(dir: string, config: SnowpackConfig) {
 }
 
 /** Read file from disk; return a string if it’s a code file */
-export async function readFile(filepath: URL): Promise<string | Buffer> {
-  const data = await fs.promises.readFile(url.fileURLToPath(filepath));
+export async function readFile(filepath: string): Promise<string | Buffer> {
+  const data = await fs.promises.readFile(filepath);
   const isBinary = await isBinaryFile(data);
   return isBinary ? data : data.toString('utf8');
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7144,6 +7144,11 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
+fdir@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-5.0.0.tgz#a40b5d9adfb530daeca55558e8ad87ec14a44769"
+  integrity sha512-cteqwWMA43lEmgwOg5HSdvhVFD39vHjQDhZkRMlKmeoNPtSSgUw1nUypydiY2upMdGiBFBZvNBDbnoBh0yCzaQ==
+
 figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.2.tgz#b4eee8148abb01dcf1d1ac34367d59e12fa61d6e"
@@ -7346,17 +7351,7 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
-  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
-  dependencies:
-    at-least-node "^1.0.0"
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
-
-fs-extra@^9.1.0:
+fs-extra@^9.0.0, fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==


### PR DESCRIPTION
## Changes

- Improve performance for large (50k+ file) applications by switching out glob (notoriously slow) for fdir (notoriously speedy) when all that's needed is recursive directory walking. Learn more: https://dev.to/thecodrr/how-i-wrote-the-fastest-directory-crawler-ever-3p9c

## Testing

- N/A

## Docs

- N/A