### PR TITLE
Add buildOptions.jsxInject to config

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -457,6 +457,15 @@ Set the name of the function used to create JSX elements.
 
 Set the name of the function used to create JSX fragments.
 
+### buildOptions.jsxInject
+
+**Type**: `string`  
+**Default**: `undefined`
+
+If set, this string can be used to automatically inject JSX imports for every JSX/TSX file.
+React users might use `import React from 'react'` whereas Preact users might use `import { h, Fragment } from 'preact'`.
+
+
 ## testOptions
 
 Configure your tests.

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -164,6 +164,7 @@ const configSchema = {
         htmlFragments: {type: 'boolean'},
         jsxFactory: {type: 'string'},
         jsxFragment: {type: 'string'},
+        jsxInject: {type: 'string'},
       },
     },
     testOptions: {

--- a/snowpack/src/plugins/plugin-esbuild.ts
+++ b/snowpack/src/plugins/plugin-esbuild.ts
@@ -29,12 +29,18 @@ export function esbuildPlugin(config: SnowpackConfig, {input}: {input: string[]}
     },
     async load({filePath}) {
       esbuildService = esbuildService || (await startService());
-      const contents = await fs.readFile(filePath, 'utf8');
+      let contents = await fs.readFile(filePath, 'utf8');
       const isPreact = checkIsPreact(filePath, contents);
+      const loader = getLoader(filePath);
       let jsxFactory = config.buildOptions.jsxFactory ?? (isPreact ? 'h' : undefined);
       let jsxFragment = config.buildOptions.jsxFragment ?? (isPreact ? 'Fragment' : undefined);
+
+      if (loader.endsWith('x') && config.buildOptions.jsxInject) {
+        contents = `${config.buildOptions.jsxInject}\n${contents}`;
+      }
+
       const {code, map, warnings} = await esbuildService!.transform(contents, {
-        loader: getLoader(filePath),
+        loader,
         jsxFactory,
         jsxFragment,
         sourcefile: filePath,

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -273,6 +273,7 @@ export interface SnowpackConfig {
     htmlFragments: boolean;
     jsxFactory: string | undefined;
     jsxFragment: string | undefined;
+    jsxInject: string | undefined;
     ssr: boolean;
     resolveProxyImports: boolean;
   };

--- a/test/build/jsx-inject/jsx-inject.test.js
+++ b/test/build/jsx-inject/jsx-inject.test.js
@@ -1,0 +1,29 @@
+const path = require('path');
+const {setupBuildTest, readFiles} = require('../../test-utils');
+
+const cwd = path.join(__dirname, 'build');
+
+let files = {};
+
+describe('config: buildOptions.jsxInject', () => {
+  beforeAll(() => {
+    setupBuildTest(__dirname);
+    files = readFiles(cwd);
+  });
+
+  it('injects jsxInject string in JSX file', () => {
+    expect(files['/_dist_/jsx-file.js']).toContain('import {h, Fragment} from "../_snowpack/pkg/preact.js"');
+  });
+
+  it('injects jsxInject string in TSX file', () => {
+    expect(files['/_dist_/tsx-file.js']).toContain('import {h, Fragment} from "../_snowpack/pkg/preact.js"');
+  });
+
+  it('does not inject jsxInject string into JS file', () => {
+    expect(files['/_dist_/js-file.js']).not.toContain('import {h, Fragment} from "../_snowpack/pkg/preact.js"');
+  });
+
+  it('does not inject jsxInject string into TS file', () => {
+    expect(files['/_dist_/ts-file.js']).not.toContain('import {h, Fragment} from "../_snowpack/pkg/preact.js"');
+  });
+});

--- a/test/build/jsx-inject/package.json
+++ b/test/build/jsx-inject/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "version": "1.0.1",
+  "name": "@snowpack/test-jsx-inject",
+  "scripts": {
+    "start": "snowpack dev",
+    "testbuild": "snowpack build"
+  },
+  "dependencies": {
+    "preact": "^10.5.13",
+    "snowpack": "^3.0.0"
+  }
+}

--- a/test/build/jsx-inject/snowpack.config.js
+++ b/test/build/jsx-inject/snowpack.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  mount: {
+    './src': '/_dist_',
+  },
+  buildOptions: {
+    jsxInject: 'import { h, Fragment } from "preact";'
+  }
+};

--- a/test/build/jsx-inject/src/index.html
+++ b/test/build/jsx-inject/src/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Web site created using create-snowpack-app" />
+    <title>Snowpack App</title>
+  </head>
+  <body>
+    <script type="module" src="%PUBLIC_URL%/_dist_/index.js"></script>
+  </body>
+</html>

--- a/test/build/jsx-inject/src/js-file.js
+++ b/test/build/jsx-inject/src/js-file.js
@@ -1,0 +1,1 @@
+export default 'no-jsx';

--- a/test/build/jsx-inject/src/jsx-file.jsx
+++ b/test/build/jsx-inject/src/jsx-file.jsx
@@ -1,0 +1,2 @@
+const Component = () => <><h1>Hello world!</h1></>;
+

--- a/test/build/jsx-inject/src/ts-file.ts
+++ b/test/build/jsx-inject/src/ts-file.ts
@@ -1,0 +1,1 @@
+export default 'no-jsx';

--- a/test/build/jsx-inject/src/tsx-file.tsx
+++ b/test/build/jsx-inject/src/tsx-file.tsx
@@ -1,0 +1,2 @@
+const Component = () => <><h1>Hello world!</h1></>;
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -11860,6 +11860,11 @@ preact@^10.0.0:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.9.tgz#8caba9288b4db1d593be2317467f8735e43cda0b"
   integrity sha512-X4m+4VMVINl/JFQKALOCwa3p8vhMAhBvle0hJ/W44w/WWfNb2TA7RNicDV3K2dNVs57f61GviEnVLiwN+fxiIg==
 
+preact@^10.5.13:
+  version "10.5.13"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.13.tgz#85f6c9197ecd736ce8e3bec044d08fd1330fa019"
+  integrity sha512-q/vlKIGNwzTLu+jCcvywgGrt+H/1P/oIRSD6mV4ln3hmlC+Aa34C7yfPI4+5bzW8pONyVXYS7SvXosy2dKKtWQ==
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"


### PR DESCRIPTION
## Changes

Adds `buildOptions.jsxInject` to configuration to remove the need for manually importing `React`/`h`/`Fragment` in every file if set. This is an opt-in feature that does not change the default requested in #2864.

## Testing

Tests have been added in `test/build/jsx-inject`!

## Docs

Yes, the configuration docs have been updated.
