### PR TITLE
refactor: update to esbuild 0.9

### DIFF
--- a/plugins/plugin-optimize/package.json
+++ b/plugins/plugin-optimize/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "csso": "^4.1.0",
     "es-module-lexer": "^0.3.25",
-    "esbuild": "^0.8.0",
+    "esbuild": "^0.9.3",
     "glob": "^7.1.6",
     "html-minifier": "^4.0.0",
     "hypertag": "^0.0.3",

--- a/plugins/plugin-optimize/plugin.js
+++ b/plugins/plugin-optimize/plugin.js
@@ -28,7 +28,7 @@ exports.default = function plugin(config, userDefinedOptions) {
 
   const CONCURRENT_WORKERS = require('os').cpus().length;
 
-  async function optimizeFile({esbuildService, file, preloadCSS, target, rootDir}) {
+  async function optimizeFile({file, preloadCSS, target, rootDir}) {
     const baseExt = path.extname(file).toLowerCase();
 
     // TODO: add debug in plugins?
@@ -60,7 +60,7 @@ exports.default = function plugin(config, userDefinedOptions) {
 
         // minify if enabled
         if (options.minifyJS) {
-          const minified = await esbuildService.transform(code, {
+          const minified = await esbuild.transform(code, {
             minify: true,
             charset: 'utf8',
             target,
@@ -109,7 +109,6 @@ exports.default = function plugin(config, userDefinedOptions) {
     name: '@snowpack/plugin-optimize',
     async optimize({buildDirectory}) {
       // 0. setup
-      const esbuildService = await esbuild.startService();
       await init;
       let generatedFiles = {};
 
@@ -150,7 +149,6 @@ exports.default = function plugin(config, userDefinedOptions) {
           parallelWorkQueue.add(() =>
             optimizeFile({
               file,
-              esbuildService,
               preloadCSS,
               rootDir: buildDirectory,
               target: options.target,
@@ -160,7 +158,6 @@ exports.default = function plugin(config, userDefinedOptions) {
           );
         });
       await parallelWorkQueue.onIdle();
-      esbuildService.stop();
 
       // 5. build CSS file
       if (preloadCSS) {

--- a/snowpack/package.json
+++ b/snowpack/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "cli-spinners": "^2.5.0",
     "default-browser-id": "^2.0.0",
-    "esbuild": "^0.8.7",
+    "esbuild": "^0.9.3",
     "fdir": "^5.0.0",
     "micromatch": "^4.0.2",
     "open": "^7.0.4",

--- a/snowpack/src/build/optimize.ts
+++ b/snowpack/src/build/optimize.ts
@@ -18,22 +18,6 @@ import {
 } from '../util';
 import {getUrlsForFile} from './file-urls';
 
-interface ESBuildMetaInput {
-  bytes: number;
-  imports: {path: string}[];
-}
-interface ESBuildMetaOutput {
-  imports: [];
-  exports?: [];
-  // unclear what this exact interface is, and we don't use it
-  inputs: any;
-  bytes: number;
-}
-interface ESBuildMetaManifest {
-  inputs: Record<string, ESBuildMetaInput>;
-  outputs?: Record<string, ESBuildMetaOutput>;
-}
-
 interface ScannedHtmlEntrypoint {
   file: string;
   root: cheerio.Root;
@@ -42,6 +26,9 @@ interface ScannedHtmlEntrypoint {
   getLinks: (rel: 'stylesheet') => cheerio.Cheerio;
 }
 
+// The manifest type is the one from ESBuild, but we might delete the outputs key
+type SnowpackMetaManifest = Omit<esbuild.Metafile, 'outputs'> & Partial<esbuild.Metafile>;
+
 // We want to output our bundled build directly into our build directory, but esbuild
 // has a bug where it complains about overwriting source files even when write: false.
 // We create a fake bundle directory for now. Nothing ever actually gets written here.
@@ -49,7 +36,7 @@ const FAKE_BUILD_DIRECTORY = path.join(process.cwd(), '~~bundle~~');
 const FAKE_BUILD_DIRECTORY_REGEX = /.*\~\~bundle\~\~[\\\/]/;
 
 /** Collect deep imports in the given set, recursively. */
-function collectDeepImports(url: string, manifest: ESBuildMetaManifest, set: Set<string>): void {
+function collectDeepImports(url: string, manifest: SnowpackMetaManifest, set: Set<string>): void {
   if (set.has(url)) {
     return;
   }
@@ -190,7 +177,7 @@ async function restitchInlineScripts(htmlData: ScannedHtmlEntrypoint): Promise<v
 /** Add new bundled CSS files to the HTML entrypoint file, if not already there. */
 function addNewBundledCss(
   htmlData: ScannedHtmlEntrypoint,
-  manifest: ESBuildMetaManifest,
+  manifest: SnowpackMetaManifest,
   baseUrl: string,
 ): void {
   if (!manifest.outputs) {
@@ -226,7 +213,7 @@ function addNewBundledCss(
  */
 function preloadEntrypoint(
   htmlData: ScannedHtmlEntrypoint,
-  manifest: ESBuildMetaManifest,
+  manifest: SnowpackMetaManifest,
   config: SnowpackConfig,
 ): void {
   const {root, getScripts} = htmlData;
@@ -383,9 +370,8 @@ async function runEsbuildOnBuildDirectory(
   bundleEntrypoints: string[],
   allFiles: string[],
   config: SnowpackConfig,
-  esbuildService: esbuild.Service,
-): Promise<{manifest: ESBuildMetaManifest; outputFiles: esbuild.OutputFile[]}> {
-  const {outputFiles, warnings} = await esbuildService.build({
+): Promise<{manifest: SnowpackMetaManifest; outputFiles: esbuild.OutputFile[]}> {
+  const {outputFiles, warnings, metafile} = await esbuild.build({
     entryPoints: bundleEntrypoints,
     outdir: FAKE_BUILD_DIRECTORY,
     outbase: config.buildOptions.out,
@@ -395,7 +381,7 @@ async function runEsbuildOnBuildDirectory(
     splitting: config.optimize!.splitting,
     format: 'esm',
     platform: 'browser',
-    metafile: path.join(config.buildOptions.out, 'build-manifest.json'),
+    metafile: true,
     publicPath: config.buildOptions.baseUrl,
     minify: config.optimize!.minify,
     target: config.optimize!.target,
@@ -404,9 +390,7 @@ async function runEsbuildOnBuildDirectory(
     ),
     charset: 'utf8',
   });
-  const manifestFile = outputFiles!.find((f) => f.path.endsWith('build-manifest.json'))!;
-  const manifestContents = manifestFile.text;
-  const manifest = JSON.parse(manifestContents);
+
   if (!outputFiles) {
     throw new Error('EMPTY BUILD');
   }
@@ -420,8 +404,9 @@ async function runEsbuildOnBuildDirectory(
         addTrailingSlash(config.buildOptions.out),
       )),
   );
+  const manifest = metafile!;
   if (!config.optimize?.bundle) {
-    delete manifest.outputs;
+    delete (manifest as SnowpackMetaManifest).outputs;
   } else {
     Object.entries(manifest.outputs).forEach(([f, val]) => {
       const newKey = f.replace(FAKE_BUILD_DIRECTORY_REGEX, '/');
@@ -487,12 +472,10 @@ export async function runBuiltInOptimize(config: SnowpackConfig) {
   // * Run esbuild on the entire build directory. Even if you are not writing the result
   // to disk (bundle: false), we still use the bundle manifest as an in-memory representation
   // of our import graph, saved to disk.
-  const esbuildService = await esbuild.startService();
   const {manifest, outputFiles} = await runEsbuildOnBuildDirectory(
     bundleEntrypoints,
     allBuildFiles,
     config,
-    esbuildService,
   );
 
   // * BUNDLE: TRUE - Save the bundle result to the build directory, and clean up to remove all original
@@ -501,9 +484,12 @@ export async function runBuiltInOptimize(config: SnowpackConfig) {
     for (const bundledInput of Object.keys(manifest.inputs)) {
       if (!manifest.outputs![bundledInput]) {
         logger.debug(
-          `Removing bundled source file: ${path.resolve(buildDirectoryLoc, bundledInput)}`,
+          `Removing bundled source file: ${path.resolve(
+            buildDirectoryLoc,
+            path.basename(bundledInput),
+          )}`,
         );
-        await fs.unlink(path.resolve(buildDirectoryLoc, bundledInput));
+        await fs.unlink(path.resolve(buildDirectoryLoc, path.basename(bundledInput)));
       }
     }
     deleteFromBuildSafe(
@@ -528,7 +514,7 @@ export async function runBuiltInOptimize(config: SnowpackConfig) {
     for (const f of allBuildFiles) {
       if (['.js', '.css'].includes(path.extname(f))) {
         let code = await fs.readFile(f, 'utf8');
-        const minified = await esbuildService.transform(code, {
+        const minified = await esbuild.transform(code, {
           sourcefile: path.basename(f),
           loader: path.extname(f).slice(1) as 'js' | 'css',
           minify: options.minify,
@@ -585,9 +571,6 @@ export async function runBuiltInOptimize(config: SnowpackConfig) {
       JSON.stringify(manifest),
     );
   }
-
-  // Cleanup and exit.
-  esbuildService.stop();
   process.chdir(originalCwd);
   return;
 }

--- a/snowpack/src/plugins/plugin-esbuild.ts
+++ b/snowpack/src/plugins/plugin-esbuild.ts
@@ -1,11 +1,9 @@
-import {Service, startService} from 'esbuild';
+import * as esbuild from 'esbuild';
 import * as colors from 'kleur/colors';
 import path from 'path';
 import {promises as fs} from 'fs';
 import {SnowpackPlugin, SnowpackConfig} from '../types';
 import {logger} from '../logger';
-
-let esbuildService: Service | null = null;
 
 const IS_PREACT = /from\s+['"]preact['"]/;
 function checkIsPreact(contents: string) {
@@ -29,7 +27,6 @@ export function esbuildPlugin(config: SnowpackConfig, {input}: {input: string[]}
       output: ['.js'],
     },
     async load({filePath}) {
-      esbuildService = esbuildService || (await startService());
       let contents = await fs.readFile(filePath, 'utf8');
       const {loader, isJSX} = getLoader(filePath);
       if (isJSX) {
@@ -40,7 +37,7 @@ export function esbuildPlugin(config: SnowpackConfig, {input}: {input: string[]}
       let jsxFactory = config.buildOptions.jsxFactory ?? (isPreact ? 'h' : undefined);
       let jsxFragment = config.buildOptions.jsxFragment ?? (isPreact ? 'Fragment' : undefined);
 
-      const {code, map, warnings} = await esbuildService!.transform(contents, {
+      const {code, map, warnings} = await esbuild.transform(contents, {
         loader: loader,
         jsxFactory,
         jsxFragment,
@@ -59,8 +56,6 @@ export function esbuildPlugin(config: SnowpackConfig, {input}: {input: string[]}
         },
       };
     },
-    cleanup() {
-      esbuildService && esbuildService.stop();
-    },
+    cleanup() {},
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5303,12 +5303,7 @@ color@^3.0.0:
     color-convert "^1.9.1"
     color-string "^1.5.4"
 
-colorette@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
-  integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
-
-colorette@^1.2.2:
+colorette@^1.2.1, colorette@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
@@ -6770,10 +6765,10 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
-esbuild@^0.8.0, esbuild@^0.8.7:
-  version "0.8.31"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.8.31.tgz#c21e7adb3ad283c951a53de7ad64a5ae2df2ed34"
-  integrity sha512-7EIU0VdUxltwivjVezX3HgeNzeIVR1snkrAo57WdUnuBMykdzin5rTrxwCDM6xQqj0RL/HjOEm3wFr2ijHKeaA==
+esbuild@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.9.3.tgz#09293a0b824159c6aa2488d1c6c22f57d8448f74"
+  integrity sha512-G8k0olucZp3LJ7I/p8y388t+IEyb2Y78nHrLeIxuqZqh6TYqDYP/B/7drAvYKfh83CGwKal9txVP+FTypsPJug==
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -8396,7 +8391,7 @@ is-color-stop@^1.0.0:
     rgb-regex "^1.0.1"
     rgba-regex "^1.0.0"
 
-is-core-module@^2.1.0, is-core-module@^2.2.0:
+is-core-module@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
   integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
@@ -12721,15 +12716,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.3.2, resolve@^1.8.1, resolve@^1.9.0:
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
-  integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
-  dependencies:
-    is-core-module "^2.1.0"
-    path-parse "^1.0.6"
-
-resolve@^1.20.0:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.3.2, resolve@^1.8.1, resolve@^1.9.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -12844,17 +12831,10 @@ rollup-pluginutils@^2.8.2:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@2.37.1:
+rollup@2.37.1, rollup@^2.23.0, rollup@^2.34.0, rollup@^2.35.1:
   version "2.37.1"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.37.1.tgz#aa7aadffd75c80393f9314f9857e851b0ffd34e7"
   integrity sha512-V3ojEeyGeSdrMSuhP3diBb06P+qV4gKQeanbDv+Qh/BZbhdZ7kHV0xAt8Yjk4GFshq/WjO7R4c7DFM20AwTFVQ==
-  optionalDependencies:
-    fsevents "~2.1.2"
-
-rollup@^2.23.0, rollup@^2.34.0, rollup@^2.35.1:
-  version "2.36.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.36.1.tgz#2174f0c25c7b400d57b05628d0e732c7ae8d2178"
-  integrity sha512-eAfqho8dyzuVvrGqpR0ITgEdq0zG2QJeWYh+HeuTbpcaXk8vNFc48B7bJa1xYosTCKx0CuW+447oQOW8HgBIZQ==
   optionalDependencies:
     fsevents "~2.1.2"
 
@@ -13890,15 +13870,10 @@ svelte-routing@^1.4.0:
   resolved "https://registry.yarnpkg.com/svelte-routing/-/svelte-routing-1.5.0.tgz#a518cf67d8c09dd30a04cf6f9473ce5612fd4c8b"
   integrity sha512-4ftcSO2x5kzCUWQKm9Td6/C+t7lRjMEo72utRO0liS/aWZuRwAXOBl3y+hWZw8tV+DTGElqaAAyi44AuWXcVBg==
 
-svelte@^3.15.0:
+svelte@^3.15.0, svelte@^3.18.2, svelte@^3.21.0, svelte@^3.24.0:
   version "3.32.3"
   resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.32.3.tgz#db0c50c65573ecffe4e2f4924e4862d8f9feda74"
   integrity sha512-5etu/wDwtewhnYO/631KKTjSmFrKohFLWNm1sWErVHXqGZ8eJLqrW0qivDSyYTcN8GbUqsR4LkIhftNFsjNehg==
-
-svelte@^3.18.2, svelte@^3.21.0, svelte@^3.24.0:
-  version "3.31.2"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.31.2.tgz#d2ddf6cacbb95e4cc3796207510b660a25586324"
-  integrity sha512-TxZGrXzX2ggFH3BIKY5fmbeMdJuZrMIMDYPMX6R9255bueuYIuVaBQSLUeY2oD7W4IdeqRZiAVGCjDw2POKBRA==
 
 svgo@^1.0.0:
   version "1.3.2"
@@ -14758,10 +14733,14 @@ vue-router@^3.0.0:
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.4.9.tgz#c016f42030ae2932f14e4748b39a1d9a0e250e66"
   integrity sha512-CGAKWN44RqXW06oC+u4mPgHLQQi2t6vLD/JbGRDAXm0YpMv0bgpKuU5bBd7AvMgfTz9kXVRIWKHqRwGEb8xFkA==
 
-vue@*, vue@^2.0.0, vue@^2.6.12:
-  version "2.6.12"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.12.tgz#f5ebd4fa6bd2869403e29a896aed4904456c9123"
-  integrity sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==
+vue@*, vue@^3.0.0:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-3.0.5.tgz#de1b82eba24abfe71e0970fc9b8d4b2babdc3fe1"
+  integrity sha512-TfaprOmtsAfhQau7WsomXZ8d9op/dkQLNIq8qPV3A0Vxs6GR5E+c1rfJS1SDkXRQj+dFyfnec7+U0Be1huiScg==
+  dependencies:
+    "@vue/compiler-dom" "3.0.5"
+    "@vue/runtime-dom" "3.0.5"
+    "@vue/shared" "3.0.5"
 
 vue@3.0.0:
   version "3.0.0"
@@ -14772,14 +14751,10 @@ vue@3.0.0:
     "@vue/runtime-dom" "3.0.0"
     "@vue/shared" "3.0.0"
 
-vue@^3.0.0:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-3.0.5.tgz#de1b82eba24abfe71e0970fc9b8d4b2babdc3fe1"
-  integrity sha512-TfaprOmtsAfhQau7WsomXZ8d9op/dkQLNIq8qPV3A0Vxs6GR5E+c1rfJS1SDkXRQj+dFyfnec7+U0Be1huiScg==
-  dependencies:
-    "@vue/compiler-dom" "3.0.5"
-    "@vue/runtime-dom" "3.0.5"
-    "@vue/shared" "3.0.5"
+vue@^2.0.0, vue@^2.6.12:
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.12.tgz#f5ebd4fa6bd2869403e29a896aed4904456c9123"
+  integrity sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"
@@ -15076,12 +15051,7 @@ worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-workerpool@^6.0.0:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.0.3.tgz#3f80ba4d914fe7bb8d933628c26e5d7ff820c703"
-  integrity sha512-meU8ZzO+ipcx/njxtKUcbu2K95085q5WYDo8fR6PMW3hCY4driteIsNsEowYV7dzOtvq0HotUKsReJkK8gKXgg==
-
-workerpool@^6.1.2:
+workerpool@^6.0.0, workerpool@^6.1.2:
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.1.2.tgz#52bb8c05d89e9b699b68d39f9687419cb2f6ca5c"
   integrity sha512-I/gDW4LwV3bslk4Yiqd4XoNYlnvV03LON7KuIjmQ90yDnKND1sR2LK/JA1g1tmd71oe6KPSvN0JpBzXIH6xAgA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -14378,9 +14378,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@^4.0.0, typescript@^4.0.2, typescript@^4.0.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Changes
* Replace esbuild.startService() API
* Use in-memory metadata returned by esbuild
* Fix input file path in manifest

esbuild 0.9 release notes: https://github.com/evanw/esbuild/releases/tag/v0.9.0

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->
All current tests pass, since this is an internal refactoring only there is no need to add new tests.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
No documentation updates, as updating esbuild should cause no change in behavior except for bug fixes.