### PR TITLE
Add `openUrl` option to config

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -199,6 +199,13 @@ The hostname that the dev server is running on. Snowpack uses this information t
 
 The port the dev server runs on.
 
+### devOptions.urlpath
+
+**Type**: `string`
+**Default**: ``
+
+Optional path to append to dev server url.
+
 ### devOptions.fallback
 
 **Type**: `string`  

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -202,9 +202,8 @@ The port the dev server runs on.
 ### devOptions.urlpath
 
 **Type**: `string`
-**Default**: ``
 
-Optional path to append to dev server url.
+Optional path to append to dev server url. May also include querystring parameters, example: `test/foo.html?bar=123`.
 
 ### devOptions.fallback
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -199,7 +199,7 @@ The hostname that the dev server is running on. Snowpack uses this information t
 
 The port the dev server runs on.
 
-### devOptions.urlpath
+### devOptions.openUrl
 
 **Type**: `string`
 

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -257,7 +257,7 @@ export async function startServer(
     await pkgSource.prepare(commandOptions);
   }
   let serverStart = performance.now();
-  const {port: defaultPort, hostname, open} = config.devOptions;
+  const {port: defaultPort, hostname, open, urlpath} = config.devOptions;
   const messageBus = new EventEmitter();
   const PACKAGE_PATH_PREFIX = path.posix.join(config.buildOptions.metaUrlPath, 'pkg/');
   const PACKAGE_LINK_PATH_PREFIX = path.posix.join(config.buildOptions.metaUrlPath, 'link/');
@@ -830,7 +830,7 @@ export async function startServer(
   // Open the user's browser (ignore if failed)
   if (server && port && open && open !== 'none') {
     const protocol = config.devOptions.secure ? 'https:' : 'http:';
-    await openInBrowser(protocol, hostname, port, open).catch((err) => {
+    await openInBrowser(protocol, hostname, port, open, urlpath).catch((err) => {
       logger.debug(`Browser open error: ${err}`);
     });
   }

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -257,7 +257,7 @@ export async function startServer(
     await pkgSource.prepare(commandOptions);
   }
   let serverStart = performance.now();
-  const {port: defaultPort, hostname, open, urlpath} = config.devOptions;
+  const {port: defaultPort, hostname, open, openUrl} = config.devOptions;
   const messageBus = new EventEmitter();
   const PACKAGE_PATH_PREFIX = path.posix.join(config.buildOptions.metaUrlPath, 'pkg/');
   const PACKAGE_LINK_PATH_PREFIX = path.posix.join(config.buildOptions.metaUrlPath, 'link/');
@@ -830,7 +830,7 @@ export async function startServer(
   // Open the user's browser (ignore if failed)
   if (server && port && open && open !== 'none') {
     const protocol = config.devOptions.secure ? 'https:' : 'http:';
-    await openInBrowser(protocol, hostname, port, open, urlpath).catch((err) => {
+    await openInBrowser(protocol, hostname, port, open, openUrl).catch((err) => {
       logger.debug(`Browser open error: ${err}`);
     });
   }

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -125,6 +125,7 @@ const configSchema = {
           ],
         },
         port: {type: 'number'},
+        urlpath: {type: 'string'},
         open: {type: 'string'},
         output: {type: 'string', enum: ['stream', 'dashboard']},
         hmr: {type: 'boolean'},

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -125,7 +125,7 @@ const configSchema = {
           ],
         },
         port: {type: 'number'},
-        urlpath: {type: 'string'},
+        openUrl: {type: 'string'},
         open: {type: 'string'},
         output: {type: 'string', enum: ['stream', 'dashboard']},
         hmr: {type: 'boolean'},

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -258,6 +258,7 @@ export interface SnowpackConfig {
     secure: boolean | {cert: string | Buffer; key: string | Buffer};
     hostname: string;
     port: number;
+    urlpath?: string;
     open?: string;
     output?: 'stream' | 'dashboard';
     hmr?: boolean;

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -258,7 +258,7 @@ export interface SnowpackConfig {
     secure: boolean | {cert: string | Buffer; key: string | Buffer};
     hostname: string;
     port: number;
-    urlpath?: string;
+    openUrl?: string;
     open?: string;
     output?: 'stream' | 'dashboard';
     hmr?: boolean;

--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -278,9 +278,9 @@ export async function openInBrowser(
   hostname: string,
   port: number,
   browser: string,
-  urlpath?: string,
+  openUrl?: string,
 ): Promise<void> {
-  const url = new URL(urlpath || '', `${protocol}//${hostname}:${port}`).toString();
+  const url = new URL(openUrl || '', `${protocol}//${hostname}:${port}`).toString();
   browser = /chrome/i.test(browser)
     ? appNames[process.platform]['chrome']
     : /brave/i.test(browser)

--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -278,8 +278,9 @@ export async function openInBrowser(
   hostname: string,
   port: number,
   browser: string,
+  urlpath?: string,
 ): Promise<void> {
-  const url = `${protocol}//${hostname}:${port}`;
+  const url = new URL(urlpath || '', `${protocol}//${hostname}:${port}`).toString();
   browser = /chrome/i.test(browser)
     ? appNames[process.platform]['chrome']
     : /brave/i.test(browser)


### PR DESCRIPTION
## Changes

This adds `openUrl` to devOptions, such that you can start a dev server at a specific url:
```
snowpack dev --openUrl test/foo.html?bar=123
```
Which will open this url:
http://localhost:8080/test/foo.html?bar=123

## Use case
My project is a library. I want my library files built from the `src` folder, but I need to run Snowpack from the `test` folder, which I do not want to get bundled.

Another user has also requested it for use with React Router: https://github.com/snowpackjs/snowpack/discussions/2415#discussioncomment-368640

## Testing

Tested using [Run local snowpack in another project](https://github.com/snowpackjs/snowpack/blob/main/CONTRIBUTING.md#run-local-snowpack-in-another-project)

## Docs

Config option added to docs/reference/configuration.md
