### PR TITLE
Speed up exclusions with picomatch 

### DIFF
--- a/snowpack/package.json
+++ b/snowpack/package.json
@@ -49,8 +49,8 @@
     "default-browser-id": "^2.0.0",
     "esbuild": "^0.9.3",
     "fdir": "^5.0.0",
-    "micromatch": "^4.0.2",
     "open": "^7.0.4",
+    "picomatch": "^2.2.2",
     "resolve": "^1.20.0",
     "rollup": "^2.34.0"
   },

--- a/snowpack/src/commands/build.ts
+++ b/snowpack/src/commands/build.ts
@@ -1,7 +1,7 @@
 import {ImportMap, InstallTarget} from 'esinstall';
 import {promises as fs} from 'fs';
 import {fdir} from 'fdir';
-import micromatch from 'micromatch';
+import picomatch from 'picomatch';
 import * as colors from 'kleur/colors';
 import mkdirp from 'mkdirp';
 import path from 'path';
@@ -105,8 +105,9 @@ export async function build(commandOptions: CommandOptions): Promise<SnowpackBui
     const files = (await new fdir().withFullPaths().crawl(mountKey).withPromise()) as string[];
     const excludePrivate = new RegExp(`\\${path.sep}\\.`);
     const excludeGlobs = [...config.exclude, ...config.testOptions.files];
+    const foundExcludeMatch = picomatch(excludeGlobs);
     for (const f of files) {
-      if (micromatch.isMatch(f, excludeGlobs) || excludePrivate.test(f)) {
+      if (foundExcludeMatch(f) || excludePrivate.test(f)) {
         continue;
       }
       const fileUrls = getUrlsForFile(f, config)!;

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -301,12 +301,8 @@ export async function startServer(
     logger.debug(`Mounting directory: '${mountKey}' as URL '${mountEntry.url}'`);
     const files = (await new fdir()
       .withFullPaths()
-      .crawlWithOptions(mountKey, {
-        includeBasePath: true,
-        exclude: (_, dirPath) => {
-          return foundExcludeMatch(dirPath);
-        },
-      })
+      .filter((path) => !foundExcludeMatch(path))
+      .crawl(mountKey)
       .withPromise()) as string[];
 
     const excludePrivate = new RegExp(`\\${path.sep}\\.`);

--- a/snowpack/src/scan-imports.ts
+++ b/snowpack/src/scan-imports.ts
@@ -1,7 +1,7 @@
 import {ImportSpecifier, init as initESModuleLexer, parse} from 'es-module-lexer';
 import {InstallTarget} from 'esinstall';
 import glob from 'glob';
-import micromatch from 'micromatch';
+import picomatch from 'picomatch';
 import {fdir} from 'fdir';
 import path from 'path';
 import stripComments from 'strip-comments';
@@ -285,10 +285,11 @@ export async function scanImports(
   const excludeGlobs = includeTests
     ? config.exclude
     : [...config.exclude, ...config.testOptions.files];
+  const foundExcludeMatch = picomatch(excludeGlobs);
   const loadedFiles: (SnowpackSourceFile | null)[] = await Promise.all(
     includeFiles.map(
       async (filePath: string): Promise<SnowpackSourceFile | null> => {
-        if (micromatch.isMatch(filePath, excludeGlobs) || excludePrivate.test(filePath)) {
+        if (foundExcludeMatch(filePath) || excludePrivate.test(filePath)) {
           return null;
         }
         return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5715,7 +5715,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-env@^7.0.2, cross-env@^7.0.3:
+cross-env@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
   integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==


### PR DESCRIPTION
## Changes

In https://github.com/snowpackjs/snowpack/pull/2876, `fdir` was used to speed up mounting directories in large repos (+50k files) from +15s down to <500ms. However, the use of `micromatch` to [respect exclusions](https://github.com/snowpackjs/snowpack/pull/2876#discussion_r595622596) introduced a regressions where bootups shot up to +60s.

This PR replaces [micromatch](https://github.com/micromatch/micromatch) with [picomatch](https://github.com/micromatch/picomatch) to speed up glob pattern matching for file exclusions. 
 
### Before (+60s)
<img width="538" alt="Screen Shot 2021-03-18 at 2 19 57 AM" src="https://user-images.githubusercontent.com/6130700/111582215-e7dd1c00-8790-11eb-9487-d9ba525fc6da.png">


### After (~900ms)
<img width="509" alt="Screen Shot 2021-03-18 at 2 49 12 PM" src="https://user-images.githubusercontent.com/6130700/111685042-d67e2900-87fd-11eb-8189-b6787fb78103.png">

## Testing

- Build the project: `yarn  run build && yarn run bundle`
- Copy into local project: `cp  ./snowpack/lib/index.js ../../my-project/node_modules/snowpack/lib/index.js`
- Test bootup: `yarn run snowpack dev`

