### PR TITLE
[plugin-svelte] upgrade svelte-hmr to 0.13.2, fix remote source support

### DIFF
--- a/plugins/plugin-svelte/package.json
+++ b/plugins/plugin-svelte/package.json
@@ -18,7 +18,7 @@
   "gitHead": "a01616bb0787d56cd782f94cecf2daa12c7594e4",
   "dependencies": {
     "rollup-plugin-svelte": "^7.0.0",
-    "svelte-hmr": "^0.12.1",
+    "svelte-hmr": "^0.13.2",
     "svelte-preprocess": "^4.6.0"
   },
   "devDependencies": {

--- a/plugins/plugin-svelte/plugin.js
+++ b/plugins/plugin-svelte/plugin.js
@@ -4,11 +4,6 @@ const fs = require('fs');
 const path = require('path');
 const {createMakeHot} = require('svelte-hmr');
 
-let makeHot = (...args) => {
-  makeHot = createMakeHot({walk: svelte.walk});
-  return makeHot(...args);
-};
-
 module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
   const isDev = process.env.NODE_ENV !== 'production';
   const useSourceMaps =
@@ -100,6 +95,15 @@ module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
       importedByMap.set(imp, new Set([filePath]));
     }
   }
+
+  let makeHot = (...args) => {
+    makeHot = createMakeHot({
+      walk: svelte.walk,
+      absoluteImports: false,
+      versionNonAbsoluteImports: packageOptions.source === 'remote',
+    });
+    return makeHot(...args);
+  };
 
   return {
     name: '@snowpack/plugin-svelte',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5715,7 +5715,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-env@^7.0.2, cross-env@^7.0.3:
+cross-env@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
   integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
@@ -13835,10 +13835,10 @@ svelte-awesome@^2.3.0:
   dependencies:
     svelte "^3.15.0"
 
-svelte-hmr@^0.12.1:
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/svelte-hmr/-/svelte-hmr-0.12.2.tgz#689df7681f0461e7a2539b3fad1336ee1da84751"
-  integrity sha512-86fpj4Wjno7OREJsGxQwpVBtB3kmiKWwpOlvdZmfBZYankpL38lcVtAi1zvQXXcN4g8pRXUG68khwp6dYRwpYg==
+svelte-hmr@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/svelte-hmr/-/svelte-hmr-0.13.2.tgz#d17562a41a75cfefe15b850dea14e245aa60be95"
+  integrity sha512-abXnVyhjxrTuKKuHVLsNk8bkbk3cmbkBzfVbVDI1PeBBB/PlfzRpYwTGHGznXNRvlDAHab9GxPpAGoUFJLXBVg==
 
 "svelte-package-a@file:./test/build/plugin-build-svelte/packages/svelte-package-a":
   version "1.2.3"


### PR DESCRIPTION
## Changes

Update to `svelte-hmr@0.13.2` and adapt code to breaking changes in the new version.

This fixes support for `svelte-hmr` with `source: "remote"` option.

Without this fix, the Svelte plugin is using a given version of `svelte-hmr` (currently 0.12), but it pulls `@latest` from remote source. This can cause a mismatch between the versions of code transform that runs in Node, and the runtime that runs in the browser. The recent release of v0.13 of `svelte-hmr` created such a situation and revealed the bug.

See: https://github.com/rixo/svelte-hmr/issues/27#issuecomment-800142127

I have introduced an option to `svelte-hmr`, used in the Snowpack plugin in this PR, that makes the code transform write its current version to the runtime imports it adds to components code.

From all my tests, this approach seems to work, but there is still something strange in the logs:

```
[snowpack] import svelte@latest → https://pkg.snowpack.dev/svelte
[snowpack] import svelte-hmr@0.13.2@latest → https://pkg.snowpack.dev/svelte-hmr@0.13.2
```

Snowpack stills try to fetch `svelte-hmr@0.13.2@latest` apparently, even if this seems to pull the expected 0.13.2 runtime, so there is no impact. (I have verified that if the import mentioned another version, that's what we get according the the logs, not latest.)

As a side note, while doing this, I detected that the Svelte plugin didn't work with pnpm because of the transitive `svelte-hmr` dependency. I've try all my might to find a solution to this but couldn't. All I can think of would be for the Svelte plugin to add a mount for its runtime, but that seems a heavy weight solution. Any pointer about how to fix this would be appreciated. In other plugins, pnpm support is generally fixed with the use of absolute path for the `svelte-hmr` runtime imports.

## Testing

Manually tested that the plugin and HMR now work both with `source: "remote"` and without it.

## Docs

This is a bug fix.