### PR TITLE
finalize picomatch config

### DIFF
--- a/esinstall/src/entrypoints.ts
+++ b/esinstall/src/entrypoints.ts
@@ -5,7 +5,7 @@ import validatePackageName from 'validate-npm-package-name';
 import {ExportField, ExportMapEntry, PackageManifestWithExports, PackageManifest} from './types';
 import {parsePackageImportSpecifier, resolveDependencyManifest} from './util';
 import resolve from 'resolve';
-import pm from 'picomatch';
+import picomatch from 'picomatch';
 
 export const MAIN_FIELDS = [
   'browser:module',
@@ -277,7 +277,7 @@ function* forEachWildcardEntry(
   cwd: string,
 ): Generator<[string, string], any, undefined> {
   // Creates a regex from a pattern like ./src/extras/*
-  let expr = pm.makeRe(value, picoMatchGlobalOptions);
+  let expr = picomatch.makeRe(value, picoMatchGlobalOptions);
 
   // The directory, ie ./src/extras
   let valueDirectoryName = path.dirname(value);

--- a/snowpack/src/commands/build.ts
+++ b/snowpack/src/commands/build.ts
@@ -107,7 +107,7 @@ export async function build(commandOptions: CommandOptions): Promise<SnowpackBui
     const excludeGlobs = [...config.exclude, ...config.testOptions.files];
     const foundExcludeMatch = picomatch(excludeGlobs);
     for (const f of files) {
-      if (foundExcludeMatch(f) || excludePrivate.test(f)) {
+      if (excludePrivate.test(f) || foundExcludeMatch(f)) {
         continue;
       }
       const fileUrls = getUrlsForFile(f, config)!;

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -29,7 +29,7 @@ import {
 import type {Awaited} from './util';
 
 const CONFIG_NAME = 'snowpack';
-const ALWAYS_EXCLUDE = ['**/node_modules/**/*', '**/_*.{sass,scss}', '**/*.d.ts'];
+const ALWAYS_EXCLUDE = ['**/node_modules/**', '**/_*.{sass,scss}', '**.d.ts'];
 
 // default settings
 const DEFAULT_ROOT = process.cwd();
@@ -408,7 +408,7 @@ function normalizeConfig(_config: SnowpackUserConfig): SnowpackConfig {
     config.packageOptions.rollup.plugins = config.packageOptions.rollup.plugins || [];
   }
   config.exclude = Array.from(
-    new Set([...ALWAYS_EXCLUDE, `${config.buildOptions.out}/**/*`, ...config.exclude]),
+    new Set([...ALWAYS_EXCLUDE, `${config.buildOptions.out}/**`, ...config.exclude]),
   );
   // normalize config URL/path values
   config.buildOptions.out = removeTrailingSlash(config.buildOptions.out);

--- a/snowpack/src/scan-imports.ts
+++ b/snowpack/src/scan-imports.ts
@@ -289,7 +289,7 @@ export async function scanImports(
   const loadedFiles: (SnowpackSourceFile | null)[] = await Promise.all(
     includeFiles.map(
       async (filePath: string): Promise<SnowpackSourceFile | null> => {
-        if (foundExcludeMatch(filePath) || excludePrivate.test(filePath)) {
+        if (excludePrivate.test(filePath) || foundExcludeMatch(filePath)) {
           return null;
         }
         return {


### PR DESCRIPTION
## Changes

- Building on https://github.com/snowpackjs/snowpack/pull/2904 (/cc @ismail-syed)
- Cleans up our `ALWAYS_EXCLUDE` config for picomatch (`**` matches all characters, so no need to combine with `**/*`)
- ~Adds dotfile check to `ALWAYS_EXCLUDE`, so that we don't need a separate regex~ reverted
- relaxes picomatch usage in dev (not required, and perfect usage impacts critical startup time)

## Testing

- N/A

## Docs

- N/A

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
