### PR TITLE
Add `getUrlForPackage` utility

### DIFF
--- a/docs/reference/javascript-interface.md
+++ b/docs/reference/javascript-interface.md
@@ -79,6 +79,17 @@ const {contents} = server.loadUrl(fileUrl, {...});
 
 A helper function to find the final hosted URL for any source file. Useful when combined with `loadUrl`, since you may only know a file's location on disk without knowing it's final hosted URL.
 
+#### SnowpackDevServer.getUrlForPackage()
+
+`getUrlForPackage(packageSpec: string) => Promise<string>`
+
+```ts
+const server = await startServer({config});
+const pkgUrl = await server.getUrlForPackage('preact');
+```
+
+A helper function to find the final hosted URL of any dependency.
+
 #### SnowpackDevServer.sendResponseError()
 
 `sendResponseError(req: http.IncomingMessage, res: http.ServerResponse, status: number) => void;`

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -834,6 +834,9 @@ export async function startServer(
     handleRequest,
     sendResponseFile,
     sendResponseError,
+    getUrlForPackage: (pkgSpec: string) => {
+      return pkgSource.resolvePackageImport(path.join(config.root, 'package.json'), pkgSpec, config)
+    },
     getUrlForFile: (fileLoc: string) => {
       const result = getUrlsForFile(fileLoc, config);
       return result ? result[0] : result;

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -77,6 +77,7 @@ export interface SnowpackDevServer {
   getServerRuntime: (options?: {invalidateOnChange?: boolean}) => ServerRuntime;
   sendResponseError: (req: http.IncomingMessage, res: http.ServerResponse, status: number) => void;
   getUrlForFile: (fileLoc: string) => string | null;
+  getUrlForPackage: (packageSpec: string) => Promise<string>;
   onFileChange: (callback: OnFileChangeCallback) => void;
   shutdown(): Promise<void>;
 }

--- a/test/build/get-url/get-url-for-package.test.js
+++ b/test/build/get-url/get-url-for-package.test.js
@@ -1,0 +1,49 @@
+const { startServer, createConfiguration } = require('snowpack');
+const { version: pkgVersion } = require('preact/package.json');
+
+describe('getUrlForPackage', () => {
+  beforeAll(() => {
+    require('snowpack').logger.level = 'warn';
+  });
+
+  it('resolves pkg with version number', async () => {
+    const config = createConfiguration({
+      root: __dirname,
+      devOptions: {
+        port: 0
+      },
+      mount: {
+        ['src']: '/_dist_'
+      }
+    });
+    const sp = await startServer({ config, lockfile: null })
+    const preact = await sp.getUrlForPackage('preact');
+    const preactHooks = await sp.getUrlForPackage('preact/hooks');
+    
+    expect(preact).toBe(`/_snowpack/pkg/preact.v${pkgVersion}.js`)
+    expect(preactHooks).toBe(`/_snowpack/pkg/preact.hooks.v${pkgVersion}.js`)
+    return sp.shutdown()
+  });
+
+  it('resolves pkg with version number when metaDir is set', async () => {
+    const config = createConfiguration({
+      root: __dirname,
+      devOptions: {
+        port: 0
+      },
+      mount: {
+        ['src']: '/_dist_'
+      },
+      buildOptions: {
+        metaUrlPath: '/_test'
+      }
+    });
+    const sp = await startServer({ config, lockfile: null })
+    const preact = await sp.getUrlForPackage('preact');
+    const preactHooks = await sp.getUrlForPackage('preact/hooks');
+    
+    expect(preact).toBe(`/_test/pkg/preact.v${pkgVersion}.js`)
+    expect(preactHooks).toBe(`/_test/pkg/preact.hooks.v${pkgVersion}.js`)
+    return sp.shutdown()
+  });
+});

--- a/test/build/get-url/package.json
+++ b/test/build/get-url/package.json
@@ -1,0 +1,15 @@
+{
+  "private": true,
+  "version": "1.0.0",
+  "name": "@snowpack/test-get-url",
+  "scripts": {
+    "testbuild": "snowpack build"
+  },
+  "dependencies": {
+    "chalk": "4.1.0",
+    "ansi-styles": "*"
+  },
+  "devDependencies": {
+    "snowpack": "^3.0.0"
+  }
+}

--- a/test/build/get-url/src/index.jsx
+++ b/test/build/get-url/src/index.jsx
@@ -1,0 +1,9 @@
+import { h } from 'preact';
+import { useState } from 'preact/hooks';
+
+export default () => {
+  const [count, setCount] = useState(0);
+  return (
+    <div onClick={() => setCount(i => i + 1)}>{count}</div>
+  )
+};


### PR DESCRIPTION
## Changes

Adds a utility for resolving import specifiers, as requested in [#2871](https://github.com/snowpackjs/snowpack/issues/2871).

## Testing

Tests added in `test/build/get-url`, though these should definitely be refactored to the new testing format.

## Docs

Updated!