### PR TITLE
handle legacy package urls

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -744,10 +744,6 @@ export async function startServer(
       }
       return;
     } catch (err) {
-
-      logger.error(err.message);
-
-
       // Some consumers may want to handle/ignore errors themselves.
       if (handleError === false) {
         throw err;

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -441,7 +441,7 @@ export async function startServer(
       // (ex: /_snowpack/pkg/react.js) then we need to redirect and warn to use our new API in the future.
       if (reqUrl.split('.').length <= 2) {
         if (!warnedDeprecatedPackageImport.has(reqUrl)) {
-          logger.warn(`(${reqUrl}) Deprecated manual package import. Please use getUrlForPackage() to create package URLs instead.`);
+          logger.warn(`(${reqUrl}) Deprecated manual package import. Please use snowpack.getUrlForPackage() to create package URLs instead.`);
           warnedDeprecatedPackageImport.add(reqUrl);
         }
         const redirectUrl = await pkgSource.resolvePackageImport(
@@ -717,7 +717,7 @@ export async function startServer(
     // (ex: /_snowpack/pkg/react.js) then we need to redirect and warn to use our new API in the future.
     if (reqUrl.startsWith(PACKAGE_PATH_PREFIX) && reqUrl.split('.').length <= 2) {
       if (!warnedDeprecatedPackageImport.has(reqUrl)) {
-          logger.warn(`(${reqUrl}) Deprecated manual package import. Please use getUrlForPackage() to create package URLs instead.`);
+          logger.warn(`(${reqUrl}) Deprecated manual package import. Please use snowpack.getUrlForPackage() to create package URLs instead.`);
           warnedDeprecatedPackageImport.add(reqUrl);
       }
       const redirectUrl = await pkgSource.resolvePackageImport(


### PR DESCRIPTION
## Changes

- Builds on https://github.com/snowpackjs/snowpack/pull/2913
- Backwards compatible handling of old package imports, with a warning.

## Testing

- Hard to test dev-only stuff, and I don't think this totally deserves a test

## Docs

- N/A