### PR TITLE
Add options to plugin-dotenv

### DIFF
--- a/plugins/plugin-dotenv/README.md
+++ b/plugins/plugin-dotenv/README.md
@@ -29,4 +29,7 @@ SNOWPACK_PUBLIC_ENABLE_FEATURE=true
 
 #### Plugin Options
 
-None
+| Name       | Type     | Description                                           |
+| :--------- | :------- | :---------------------------------------------------- |
+| `dir`      | `string` | (optional) Where to find `.env` files. Default is `.` |
+| `defaults` | `object` | (optional) Default environment variables.             |

--- a/plugins/plugin-dotenv/README.md
+++ b/plugins/plugin-dotenv/README.md
@@ -29,7 +29,6 @@ SNOWPACK_PUBLIC_ENABLE_FEATURE=true
 
 #### Plugin Options
 
-| Name       | Type     | Description                                           |
-| :--------- | :------- | :---------------------------------------------------- |
-| `dir`      | `string` | (optional) Where to find `.env` files. Default is `.` |
-| `defaults` | `object` | (optional) Default environment variables.             |
+| Name  | Type     | Description                                                                                        |
+| :---- | :------- | :------------------------------------------------------------------------------------------------- |
+| `dir` | `string` | (optional) Where to find `.env` files. Default is your current working directory (`process.cwd()`) |

--- a/plugins/plugin-dotenv/plugin.js
+++ b/plugins/plugin-dotenv/plugin.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
+const path = require('path');
 
-module.exports = function plugin() {
+module.exports = function plugin(snowpackConfig, options) {
   const NODE_ENV = process.env.NODE_ENV;
 
   // https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
@@ -14,12 +15,17 @@ module.exports = function plugin() {
     '.env',
   ].filter(Boolean);
 
+  const dir = (options && options.dir)
+    ? options.dir.toString()
+    : '.';
   // Load environment variables from .env* files. Suppress warnings using silent
   // if this file is missing. dotenv will never modify any environment variables
   // that have already been set.  Variable expansion is supported in .env files.
   // https://github.com/motdotla/dotenv
   // https://github.com/motdotla/dotenv-expand
   dotenvFiles.forEach((dotenvFile) => {
+    dotenvFile = path.resolve(process.cwd(), dir, dotenvFile);
+
     if (fs.existsSync(dotenvFile)) {
       require('dotenv-expand')(
         require('dotenv').config({

--- a/plugins/plugin-dotenv/test/__snapshots__/plugin.test.js.snap
+++ b/plugins/plugin-dotenv/test/__snapshots__/plugin.test.js.snap
@@ -55,3 +55,59 @@ Object {
   "__DOTENV_TEST_LOCAL": "LOCAL",
 }
 `;
+
+exports[`with dir NODE_ENV= development 1`] = `
+Object {
+  "__DOTENV_DEVELOPMENT": "DEVELOPMENT",
+  "__DOTENV_DEVELOPMENT_LOCAL": "DEVELOPMENT_LOCAL",
+  "__DOTENV_ENV": "ENV",
+  "__DOTENV_LOCAL": "LOCAL",
+  "__DOTENV_PRESET": "PRESET",
+  "__DOTENV_PRODUCTION": "ENV",
+  "__DOTENV_PRODUCTION_LOCAL": "LOCAL",
+  "__DOTENV_TEST": "ENV",
+  "__DOTENV_TEST_LOCAL": "LOCAL",
+}
+`;
+
+exports[`with dir NODE_ENV= production 1`] = `
+Object {
+  "__DOTENV_DEVELOPMENT": "ENV",
+  "__DOTENV_DEVELOPMENT_LOCAL": "LOCAL",
+  "__DOTENV_ENV": "ENV",
+  "__DOTENV_LOCAL": "LOCAL",
+  "__DOTENV_PRESET": "PRESET",
+  "__DOTENV_PRODUCTION": "PRODUCTION",
+  "__DOTENV_PRODUCTION_LOCAL": "PRODUCTION_LOCAL",
+  "__DOTENV_TEST": "ENV",
+  "__DOTENV_TEST_LOCAL": "LOCAL",
+}
+`;
+
+exports[`with dir NODE_ENV= test 1`] = `
+Object {
+  "__DOTENV_DEVELOPMENT": "ENV",
+  "__DOTENV_DEVELOPMENT_LOCAL": "ENV",
+  "__DOTENV_ENV": "ENV",
+  "__DOTENV_LOCAL": "TEST",
+  "__DOTENV_PRESET": "PRESET",
+  "__DOTENV_PRODUCTION": "ENV",
+  "__DOTENV_PRODUCTION_LOCAL": "ENV",
+  "__DOTENV_TEST": "TEST",
+  "__DOTENV_TEST_LOCAL": "TEST_LOCAL",
+}
+`;
+
+exports[`with dir NODE_ENV= undefined 1`] = `
+Object {
+  "__DOTENV_DEVELOPMENT": "ENV",
+  "__DOTENV_DEVELOPMENT_LOCAL": "LOCAL",
+  "__DOTENV_ENV": "ENV",
+  "__DOTENV_LOCAL": "LOCAL",
+  "__DOTENV_PRESET": "PRESET",
+  "__DOTENV_PRODUCTION": "ENV",
+  "__DOTENV_PRODUCTION_LOCAL": "LOCAL",
+  "__DOTENV_TEST": "ENV",
+  "__DOTENV_TEST_LOCAL": "LOCAL",
+}
+`;

--- a/plugins/plugin-dotenv/test/env/subdir/.env
+++ b/plugins/plugin-dotenv/test/env/subdir/.env
@@ -1,0 +1,19 @@
+# don't cover preset
+__DOTENV_PRESET=ENV
+
+# don't cover `.env.${NODE_ENV}.local`
+__DOTENV_DEVELOPMENT_LOCAL=ENV
+__DOTENV_TEST_LOCAL=ENV
+__DOTENV_PRODUCTION_LOCAL=ENV
+
+# don't cover `.env.local`
+__DOTENV_LOCAL=ENV
+
+# don't cover `.env.${NODE_ENV}`
+__DOTENV_DEVELOPMENT=ENV
+__DOTENV_TEST=ENV
+__DOTENV_PRODUCTION=ENV
+
+# new environment variable
+__DOTENV_ENV=ENV
+

--- a/plugins/plugin-dotenv/test/env/subdir/.env.development
+++ b/plugins/plugin-dotenv/test/env/subdir/.env.development
@@ -1,0 +1,11 @@
+# don't cover preset
+__DOTENV_PRESET=DEVELOPMENT
+
+# don't cover `.env.${NODE_ENV}.local`
+__DOTENV_DEVELOPMENT_LOCAL=DEVELOPMENT
+
+# don't cover `.env.local`
+__DOTENV_LOCAL=DEVELOPMENT
+
+# new environment variable
+__DOTENV_DEVELOPMENT=DEVELOPMENT

--- a/plugins/plugin-dotenv/test/env/subdir/.env.development.local
+++ b/plugins/plugin-dotenv/test/env/subdir/.env.development.local
@@ -1,0 +1,5 @@
+# don't cover preset
+__DOTENV_PRESET=DEVELOPMENT_LOCAL
+
+# new environment variable
+__DOTENV_DEVELOPMENT_LOCAL=DEVELOPMENT_LOCAL

--- a/plugins/plugin-dotenv/test/env/subdir/.env.local
+++ b/plugins/plugin-dotenv/test/env/subdir/.env.local
@@ -1,0 +1,10 @@
+# don't cover preset
+__DOTENV_PRESET=LOCAL
+
+# don't cover `.env.${NODE_ENV}.local`
+__DOTENV_DEVELOPMENT_LOCAL=LOCAL
+__DOTENV_TEST_LOCAL=LOCAL
+__DOTENV_PRODUCTION_LOCAL=LOCAL
+
+# new environment variable
+__DOTENV_LOCAL=LOCAL

--- a/plugins/plugin-dotenv/test/env/subdir/.env.production
+++ b/plugins/plugin-dotenv/test/env/subdir/.env.production
@@ -1,0 +1,11 @@
+# don't cover preset
+__DOTENV_PRESET=PRODUCTION
+
+# don't cover `.env.${NODE_ENV}.local`
+__DOTENV_PRODUCTION_LOCAL=PRODUCTION
+
+# don't cover `.env.local`
+__DOTENV_LOCAL=PRODUCTION
+
+# new environment variable
+__DOTENV_PRODUCTION=PRODUCTION

--- a/plugins/plugin-dotenv/test/env/subdir/.env.production.local
+++ b/plugins/plugin-dotenv/test/env/subdir/.env.production.local
@@ -1,0 +1,5 @@
+# don't cover preset
+__DOTENV_PRESET=PRODUCTION_LOCAL
+
+# new environment variable
+__DOTENV_PRODUCTION_LOCAL=PRODUCTION_LOCAL

--- a/plugins/plugin-dotenv/test/env/subdir/.env.test
+++ b/plugins/plugin-dotenv/test/env/subdir/.env.test
@@ -1,0 +1,12 @@
+# don't cover preset
+__DOTENV_PRESET=TEST
+
+# don't cover `.env.${NODE_ENV}.local`
+__DOTENV_TEST_LOCAL=TEST
+
+# new environment variable since
+# the plugin doesn't handle `.env.local` file when NODE_ENV=test
+__DOTENV_LOCAL=TEST
+
+# new environment variable
+__DOTENV_TEST=TEST

--- a/plugins/plugin-dotenv/test/env/subdir/.env.test.local
+++ b/plugins/plugin-dotenv/test/env/subdir/.env.test.local
@@ -1,0 +1,5 @@
+# don't cover preset
+__DOTENV_PRESET=TEST_LOCAL
+
+# new environment variable
+__DOTENV_TEST_LOCAL=TEST_LOCAL

--- a/plugins/plugin-dotenv/test/execPlugin.js
+++ b/plugins/plugin-dotenv/test/execPlugin.js
@@ -1,6 +1,7 @@
 const dotenvPlugin = require('../plugin');
+const params = JSON.parse(process.argv[2]);
 
-dotenvPlugin();
+dotenvPlugin(null, params);
 
 const testEnvs = Object.keys(process.env)
   .filter((key) => key.startsWith('__DOTENV_'))

--- a/plugins/plugin-dotenv/test/plugin.test.js
+++ b/plugins/plugin-dotenv/test/plugin.test.js
@@ -4,8 +4,8 @@ const execa = require('execa');
 const execPluginFilePath = require.resolve('./execPlugin');
 const testWorkDirectory = path.join(__dirname, 'env');
 
-function execPlugin(nodeEnv) {
-  const {stdout} = execa.sync('node', [execPluginFilePath], {
+function execPlugin(nodeEnv, params = null) {
+  const {stdout} = execa.sync('node', [execPluginFilePath, JSON.stringify(params)], {
     cwd: testWorkDirectory,
     env: {NODE_ENV: nodeEnv},
   });
@@ -22,6 +22,14 @@ describe('NODE_ENV=', () => {
   NODE_ENV_LIST.forEach((nodeEnv) => {
     test(`${nodeEnv}`, () => {
       expect(execPlugin(nodeEnv)).toMatchSnapshot();
+    });
+  });
+});
+
+describe('with dir NODE_ENV=', () => {
+  NODE_ENV_LIST.forEach((nodeEnv) => {
+    test(`${nodeEnv}`, () => {
+      expect(execPlugin(nodeEnv, {dir: 'subdir'})).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
## Changes

- Add `dir` option, we can put multiple `.env` files in a folder.
- Add `defaults` option, support set default value of env vars in config file.

## Testing

Added.

## Docs

Added.
