### PR TITLE
Remove enumerability of converted ESM in SSR

### DIFF
--- a/snowpack/src/ssr-loader/index.ts
+++ b/snowpack/src/ssr-loader/index.ts
@@ -77,18 +77,15 @@ export function createLoader({load}: ServerRuntimeConfig): ServerRuntime {
       {
         name: names.__export,
         value: (name, get) => {
-          Object.defineProperty(exports, name, {get, enumerable: true});
+          Object.defineProperty(exports, name, {get});
         },
       },
       {
         name: names.__export_all,
         value: (mod) => {
-          for (const name in mod) {
-            Object.defineProperty(exports, name, {
-              get: () => mod[name],
-              enumerable: true,
-            });
-          }
+          // Copy over all of the descriptors.
+          const descriptors = Object.getOwnPropertyDescriptors(mod);
+          Object.defineProperties(exports, descriptors);
         },
       },
       {


### PR DESCRIPTION
This fixes #2918

The behavior of Rollup's CommonJS plugin to allow CommonJS modules to treat the default export as a function relied on named exports being non-enumerable. This was regressed in 689f58e to fix another bug related to re-exporting everything from another module.

That code was using enumerability to re-export. We can fix both cases by not using enumerability in the export star code, but rather grabbing the property descriptors.
