### PR TITLE
clarify package install output

### DIFF
--- a/snowpack/src/sources/local.ts
+++ b/snowpack/src/sources/local.ts
@@ -331,12 +331,12 @@ export default {
           JSON.parse(await fs.readFile(existingImportMapLoc, 'utf8'));
         if (existingImportMap && existingImportMap.imports[spec]) {
           if (depth > 0) {
-            logger.info(`${lineBullet} ${packageFormatted} ${colors.dim(`(dedupe)`)}`);
+            logger.info(`${lineBullet} ${packageFormatted} ${colors.dim(`(dedupe)`)}`, {name: 'pkg'});
           }
           return existingImportMap;
         }
         // Otherwise, kick off a new build to generate a fresh import map.
-        logger.info(`${lineBullet} ${packageFormatted}`);
+        logger.info(`${lineBullet} ${packageFormatted}`, {name: 'pkg'});
 
         const installTargets = [...allKnownSpecs]
           .filter((spec) => spec.startsWith(packageUID))
@@ -376,9 +376,8 @@ export default {
           installTargets,
           installOptions,
         });
-        logger.debug(`${lineBullet} ${packageFormatted} DONE`);
         if (needsSsrBuild) {
-          logger.info(`${lineBullet} ${packageFormatted} ${colors.dim(`(ssr)`)}`);
+          logger.info(`${lineBullet} ${packageFormatted} ${colors.dim(`(ssr)`)}`, {name: 'pkg'});
           await installPackages({
             config,
             isDev: true,
@@ -389,7 +388,6 @@ export default {
               dest: installDest + '-ssr',
             },
           });
-          logger.debug(`${lineBullet} ${packageFormatted} (ssr) DONE`);
         }
         const dependencyFileLoc = path.join(installDest, newImportMap.imports[spec]);
         const loadedFile = await fs.readFile(dependencyFileLoc!);


### PR DESCRIPTION
## Changes

#### Before

```
$ snowpack dev --reload
[16:44:02] [snowpack] Welcome to Snowpack! Because this is your first time running
this project, Snowpack needs to prepare your dependencies. This is a one-time step
and the results will be cached for the lifetime of your project. Please wait...
[16:44:02] [snowpack] + @prefresh/snowpack/runtime@3.1.2
[16:44:02] [snowpack] └── @prefresh/core@1.3.1
[16:44:02] [snowpack]   └── preact@10.5.13
[16:44:02] [snowpack] Ready!
[16:44:02] [snowpack] Server started in 16ms.
[16:44:02] [snowpack] Local: http://localhost:8080
[16:44:02] [snowpack] Network: http://192.168.1.95:8080
[16:44:04] [snowpack] + @prefresh/utils@1.1.1
⠧ watching for file changes...
```

#### After

```
$ snowpack dev --reload
[16:45:39] [snowpack] Welcome to Snowpack! Because this is your first time running
this project, Snowpack needs to prepare your dependencies. This is a one-time step
and the results will be cached for the lifetime of your project. Please wait...
[16:45:39] [pkg] + @prefresh/snowpack/runtime@3.1.1
[16:45:39] [pkg] └── @prefresh/core@1.3.1
[16:45:39] [pkg]   └── preact@10.5.13
[16:45:39] [snowpack] Ready!
[16:45:42] [snowpack] Server started in 2ms.
[16:45:42] [snowpack] Local: http://localhost:8081
[16:45:42] [snowpack] Network: http://192.168.1.95:8081
[16:45:44] [pkg] + @prefresh/utils@1.1.1
⠏ watching for file changes...
```

- Sometimes, imports are added that couldn't have been scanned by Snowpack.
- This creates a new package installation, after startup has already happened.
- thoughts on the difference? Something besides `pkg`?
- thoughts on adding a message explainer in addition? Something like:

```diff
 [16:45:39] [snowpack] Ready!
 [16:45:42] [snowpack] Server started in 2ms.
 [16:45:42] [snowpack] Local: http://localhost:8081
 [16:45:42] [snowpack] Network: http://192.168.1.95:8081
+[16:45:42] [snowpack] New package import detected at runtime. Installing...
 [16:45:44] [pkg] + @prefresh/utils@1.1.1
 ⠏ watching for file changes...
```

## Testing

- N/A

## Docs

- N/A