### PR TITLE
add back CJS<>CJS compatability from an earlier pr

### DIFF
--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -334,10 +334,9 @@ ${colors.dim(
       rollupPluginReplace(generateReplacements(env)),
       rollupPluginCommonjs({
         extensions: ['.js', '.cjs'],
-        esmExternals: (id) =>
-          Array.isArray(externalEsm)
-            ? externalEsm.some((packageName) => isImportOfPackage(id, packageName))
-            : externalEsm,
+        esmExternals: Array.isArray(externalEsm)
+          ? (id) => externalEsm.some((packageName) => isImportOfPackage(id, packageName))
+          : externalEsm,
         requireReturnsDefault: 'auto',
       } as RollupCommonJSOptions),
       rollupPluginWrapInstallTargets(!!isTreeshake, installTargets, logger),


### PR DESCRIPTION
## Changes

- We thought that this may not be needed, so it had been removed before merging #2707 
- However, we've found a case where this is required: A CJS package exports its entire namespace as a function AND attaches properties to that function. This is something that is really hard to represent in ESM, since the `module.export` result is both the `default` function and the namespace itself.
- Add back support with a basic check for CJS<>CJS package imports to always use the `default` import.

## Testing

- N/A (we should add a test for React v16.14, but I want to get this out first so that its not broken overnight)

## Docs

- N/A