### PR TITLE
plugin-react-refresh: add custom babel config option

### DIFF
--- a/plugins/plugin-react-refresh/README.md
+++ b/plugins/plugin-react-refresh/README.md
@@ -17,9 +17,9 @@ npm install --save-dev @snowpack/plugin-react-refresh
 
 ## Plugin Options
 
-| Name    |   Type    | Description                                                                                                                                                                        |
-| :------ | :-------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `babel` | `boolean` | By default, this plugin uses Babel to add Fast-Refresh code to eligible JS files. If you want to configure & run this yourself, set `"babel": false"`. Most users won't need this. |
+| Name    |         Type          | Description                                                                                                                                                                                                                                                                             |
+| :------ | :-------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `babel` | `boolean` or `object` | By default, this plugin uses Babel to add Fast-Refresh code to eligible JS files. If you want to configure & run this yourself, set `"babel": false"`. Alternatively, you can pass a custom Babel configuration object to enhance or override the defaults. Most users won't need this. |
 
 ## How it Works
 


### PR DESCRIPTION
## Changes

Allow the `babel` option of plugin-react-refresh to be a custom Babel config object that will be merged into the defaults. This is useful, e.g. to support special syntax with additional plugins, like top-level await.

Discussion: https://github.com/snowpackjs/snowpack/discussions/2939

## Testing

Added unit test to check if the custom config object is passed to `babel.transformAsync`. 

## Docs

Updated the plugin's README.
