### PR TITLE
feature: make git repository initialization optional

### DIFF
--- a/create-snowpack-app/cli/README.md
+++ b/create-snowpack-app/cli/README.md
@@ -1,7 +1,7 @@
 # Create Snowpack App (CSA)
 
-```
-npx create-snowpack-app new-dir --template @snowpack/app-template-NAME [--use-yarn | --use-pnpm | --no-install]
+```sh
+npx create-snowpack-app new-dir --template @snowpack/app-template-NAME [--use-yarn | --use-pnpm | --no-install | --no-git]
 ```
 
 ## Official App Templates


### PR DESCRIPTION
## Changes

This will make git repository initialization optional. This should not affect previous uses, as it initializes git repository by default like before (defaults to `true`), but for users that do not want a git repository gets initialized for them, they can pass `--no-git` option to `create-snowpack-app` to prevent git repository initialization.

## Testing

No tests were added, but the logic is exactly like `install`/`--no-install` option, except adding a default value to behave like before in order to prevent a breaking change (plus, some code formatting and cleanups).

## Docs

`--no-git` option was added to README as an option to `create-snowpack-app`.