### PR TITLE
Update jest.md, fix name of required root-level config file

### DIFF
--- a/docs/guides/jest.md
+++ b/docs/guides/jest.md
@@ -16,7 +16,7 @@ Snowpack ships pre-built Jest configuration files for several popular frameworks
 - Preact: [@snowpack/app-scripts-preact](https://www.npmjs.com/package/@snowpack/app-scripts-preact)
 - Svelte: [@snowpack/app-scripts-svelte](https://www.npmjs.com/package/@snowpack/app-scripts-svelte)
 
-Note: You will need a `jest.setup.js` file in the root directory of your project.
+Note: You will need a `jest.config.js` file in the root directory of your project.
 
 ### Example
 


### PR DESCRIPTION
Unless I am missing something, I struggled mightily to get Jest to work with TS and JSX until I came back to this page for the 10th-or-so time and thought maybe there was a typo in the name of the necessary root-level config file. This seems to have fixed all of my issues.

## Changes

<!-- What does this change, in plain language? -->
Updates the name of the required, root-level config file for enabling Jest, specifically in projects with React/Preact and TypeScript.
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- How was this change tested? -->
Things began to work after I made this change in my project. Prior to that, with a root-level config named `jest.setup.js`, my attempts to run jest failed on TypeScript and JSX syntax.
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
Public documentation is proposed to be updated.
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
