### PR TITLE
Improve @snowpack/plugin-sass resolution

### DIFF
--- a/plugins/plugin-sass/package.json
+++ b/plugins/plugin-sass/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "execa": "^5.0.0",
+    "find-up": "^5.0.0",
     "npm-run-path": "^4.0.1",
     "sass": "^1.3.0"
   }

--- a/plugins/plugin-sass/plugin.js
+++ b/plugins/plugin-sass/plugin.js
@@ -2,10 +2,10 @@ const fs = require('fs');
 const path = require('path');
 const execa = require('execa');
 const npmRunPath = require('npm-run-path');
+const findUp = require('find-up');
 
 const IMPORT_REGEX = /\@(use|import|forward)\s*['"](.*?)['"]/g;
 const PARTIAL_REGEX = /([\/\\])_(.+)(?![\/\\])/;
-const NODE_MODULES_PATH = path.join(__dirname, '..', '..'); // 2 dirs up from node_modules/@snowpack/plugin-sass/. This is a guess, but it’s a last-resort guess, so it’s OK if it’s wrong.
 
 function stripFileExtension(filename) {
   return filename.split('.').slice(0, -1).join('.');
@@ -158,7 +158,12 @@ module.exports = function sassPlugin(snowpackConfig, {native, compilerOptions = 
 
       // keep track of load paths later
       const loadPaths = new Set([path.dirname(filePath)]);
-      const DEFAULT_LOAD_PATHS = new Set([root, process.cwd(), NODE_MODULES_PATH]);
+      const DEFAULT_LOAD_PATHS = new Set([root, process.cwd()]);
+      const nodeModulesPath = await findUp('node_modules', {
+        type: 'directory',
+        cwd: root || __dirname,
+      });
+      if (nodeModulesPath) DEFAULT_LOAD_PATHS.add(nodeModulesPath);
 
       // Pass in user-defined options
       function parseCompilerOption([flag, value]) {


### PR DESCRIPTION
## Changes

This improves resolution for @snowpack/plugin-sass by giving it more directories to look through (including `node_modules`! 🎉).

This enhances the plugin without changing behavior. Before, it would look in one directory, and give up. Now, we give it a few fallbacks to check after the first check fails. But the first check remains the same.

```scss
// Before
@import "bootstrap/scss/bootstrap"; // ❌ Can’t find stylesheet

// After
@import "bootstrap/scss/bootstrap"; // ✅ Import successful
```

This still works with the existing `loadPaths` user-config option, and doesn’t change their priority, either.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Tested locally.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
