### PR TITLE
Add top-level await support for SSR

### DIFF
--- a/snowpack/package.json
+++ b/snowpack/package.json
@@ -59,6 +59,10 @@
   },
   "devDependencies": {
     "@types/cheerio": "0.22.22",
+    "acorn": "^8.1.0",
+    "acorn-class-fields": "^1.0.0",
+    "acorn-private-methods": "^1.0.0",
+    "acorn-static-class-features": "^1.0.0",
     "bufferutil": "^4.0.2",
     "cachedir": "^2.3.0",
     "cheerio": "1.0.0-rc.3",
@@ -81,7 +85,6 @@
     "isbinaryfile": "^4.0.6",
     "jsonschema": "~1.2.5",
     "kleur": "^4.1.1",
-    "meriyah": "^3.1.6",
     "mime-types": "^2.1.26",
     "mkdirp": "^1.0.3",
     "npm-run-path": "^4.0.1",

--- a/snowpack/src/ssr-loader/transform.ts
+++ b/snowpack/src/ssr-loader/transform.ts
@@ -1,14 +1,29 @@
-import * as meriyah from 'meriyah';
+import * as acorn from 'acorn';
+import acornPluginStage3ClassFields from 'acorn-class-fields';
+import acornPluginStage3PrivateMethods from 'acorn-private-methods';
+import acornPluginStage3ClassFeatures from 'acorn-static-class-features';
 import MagicString from 'magic-string';
 import {analyze, extract_names} from 'periscopic';
 import {walk} from 'estree-walker';
 import is_reference from 'is-reference';
 
+const acornParser = acorn.Parser.extend(
+  acornPluginStage3ClassFields,
+  acornPluginStage3PrivateMethods,
+  acornPluginStage3ClassFeatures,
+);
+
 export function transform(data) {
   const code = new MagicString(data);
-  const ast: any = meriyah.parseModule(data, {
-    ranges: true,
-    next: true,
+
+  // TODO: Bring back mariyah - https://github.com/meriyah/meriyah/issues/186
+  // const ast: any = meriyah.parseModule(data, {ranges: true, next: true});
+
+  const ast: any = acornParser.parse(data, {
+    sourceType: 'module',
+    ecmaVersion: 2021,
+    locations: true,
+    allowAwaitOutsideFunction: true,
   });
 
   const {map, scope} = analyze(ast);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3625,6 +3625,13 @@ accepts@^1.3.5, accepts@~1.3.4:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
+acorn-class-fields@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-class-fields/-/acorn-class-fields-1.0.0.tgz#b413793e6b3ddfcd17a02f9c7a850f4bbfdc1c7a"
+  integrity sha512-l+1FokF34AeCXGBHkrXFmml9nOIRI+2yBnBpO5MaVAaTIJ96irWLtcCxX+7hAp6USHFCe+iyyBB4ZhxV807wmA==
+  dependencies:
+    acorn-private-class-elements "^1.0.0"
+
 acorn-globals@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-3.1.0.tgz#fd8270f71fbb4996b004fa880ee5d46573a731bf"
@@ -3639,6 +3646,25 @@ acorn-globals@^6.0.0:
   dependencies:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
+
+acorn-private-class-elements@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-private-class-elements/-/acorn-private-class-elements-1.0.0.tgz#c5805bf8a46cd065dc9b3513bfebb504c88cd706"
+  integrity sha512-zYNcZtxKgVCg1brS39BEou86mIao1EV7eeREG+6WMwKbuYTeivRRs6S2XdWnboRde6G9wKh2w+WBydEyJsJ6mg==
+
+acorn-private-methods@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-private-methods/-/acorn-private-methods-1.0.0.tgz#b48f4c03a151cc8262f6f5ca8f57f7c5ac245184"
+  integrity sha512-Jou2L3nfwfPpFdmmHObI3yUpVPM1bPohTUAZCyVDw5Efyn9LSS6E36neRLCRfIr8QjskAfdxRdABOrvP4c/gwQ==
+  dependencies:
+    acorn-private-class-elements "^1.0.0"
+
+acorn-static-class-features@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-static-class-features/-/acorn-static-class-features-1.0.0.tgz#ab9d862d5b184007ed509f5a8d031b837694ace2"
+  integrity sha512-XZJECjbmMOKvMHiNzbiPXuXpLAJfN3dAKtfIYbk1eHiWdsutlek+gS7ND4B8yJ3oqvHo1NxfafnezVmq7NXK0A==
+  dependencies:
+    acorn-private-class-elements "^1.0.0"
 
 acorn-walk@^7.1.1:
   version "7.2.0"
@@ -3669,6 +3695,11 @@ acorn@^8.0.4:
   version "8.0.4"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.0.4.tgz#7a3ae4191466a6984eee0fe3407a4f3aa9db8354"
   integrity sha512-XNP0PqF1XD19ZlLKvB7cMmnZswW4C/03pRHgirB30uSJTaS3A3V1/P4sS3HPvFmjoriPCJQs+JDSbm4bL1TxGQ==
+
+acorn@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.1.0.tgz#52311fd7037ae119cbb134309e901aa46295b3fe"
+  integrity sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==
 
 address@^1.0.1:
   version "1.1.2"
@@ -10058,11 +10089,6 @@ merge2@^1.2.3, merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
-
-meriyah@^3.1.6:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/meriyah/-/meriyah-3.1.6.tgz#56c9c0edb63f9640c7609a39a413c60b038e4451"
-  integrity sha512-JDOSi6DIItDc33U5N52UdV6P8v+gn+fqZKfbAfHzdWApRQyQWdcvxPvAr9t01bI2rBxGvSrKRQSCg3SkZC1qeg==
 
 micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"


### PR DESCRIPTION
## Changes

- Top level await support exists in Node.js (14+) and browsers (Chrome)
- This fixes an issue where our SSR parser would error on top-level await due to a parser bug: https://github.com/meriyah/meriyah/issues/186
- Acorn is slower than meriyah, but feature completeness and stability should be our first priority here. I'd love to add meriyah back as soon as that issue is resolved. And, lets hold off on merging a bit in case they're able to fix the issue.

## Testing

- TODO: Test needed

## Docs

- N/A
