### PR TITLE
routes support upgrade event

### DIFF
--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -377,7 +377,7 @@ function normalizeMount(config: SnowpackConfig) {
 }
 
 function normalizeRoutes(routes: RouteConfigObject[]): RouteConfigObject[] {
-  return routes.map(({src, dest, match}, i) => {
+  return routes.map(({src, dest, upgrade, match}, i) => {
     // Normalize
     if (typeof dest === 'string') {
       dest = addLeadingSlash(dest);
@@ -390,7 +390,7 @@ function normalizeRoutes(routes: RouteConfigObject[]): RouteConfigObject[] {
     }
     // Validate
     try {
-      return {src, dest, match: match || 'all', _srcRegex: new RegExp(src)};
+      return {src, dest, upgrade, match: match || 'all', _srcRegex: new RegExp(src)};
     } catch (err) {
       throw new Error(`config.routes[${i}].src: invalid regular expression syntax "${src}"`);
     }

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -1,4 +1,5 @@
 import type {InstallOptions as EsinstallOptions, InstallTarget} from 'esinstall';
+import type * as net from 'net';
 import type * as http from 'http';
 import type * as http2 from 'http2';
 import type {EsmHmrEngine} from './hmr-server-engine';
@@ -219,7 +220,15 @@ export interface OptimizeOptions {
 
 export interface RouteConfigObject {
   src: string;
-  dest: string | ((req: http.IncomingMessage, res: http.ServerResponse) => void);
+  dest: string | ((
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ) => void) | undefined;
+  upgrade: ((
+    req: http.IncomingMessage,
+    socket: net.Socket,
+    head: Buffer,
+  ) => void) | undefined;
   match: 'routes' | 'all';
   _srcRegex: RegExp;
 }


### PR DESCRIPTION
In our new project, we need websockets proxy on local domain. Everything works perfectly until we upgrade snowpack to v3. After some investigation (https://github.com/snowpackjs/snowpack/discussions/2434, https://github.com/snowpackjs/snowpack/pull/2468), it seems it is currently not supported.

## Changes

Supports use `upgrade` in routes config.

## Testing

Not tested.
(I can't find where to add test.)

## Docs

```js
// snowpack.config.js
const httpProxy = require('http-proxy');
const proxy = httpProxy.createServer({target: 'http://localhost:3001'});

module.exports = {
  routes: [
    {
      src: '/socket.io/.*',
      upgrade: (req, socket, head) => {
        proxy.ws(req, socket);
      },
    },
  ],
};
```
