### PR TITLE
Fix undefined accessor errors using @snowpack/plugin-babel with snowpack 3.1.x

### DIFF
--- a/plugins/plugin-babel/plugin.js
+++ b/plugins/plugin-babel/plugin.js
@@ -19,7 +19,7 @@ module.exports = function plugin(snowpackConfig, options = {}) {
       input: options.input || ['.js', '.mjs', '.jsx', '.ts', '.tsx'],
       output: ['.js'], // always export JS
     },
-    async load({filePath}) {
+    async load({filePath, isPackage}) {
       if (!filePath) {
         return;
       }
@@ -41,11 +41,14 @@ module.exports = function plugin(snowpackConfig, options = {}) {
       });
       let {code, map} = JSON.parse(encodedResult);
 
-      if (code) {
+      if (code && !isPackage) {
         // Some Babel plugins assume process.env exists, but Snowpack
         // uses import.meta.env instead. Handle this here since it
-        // seems to be pretty common.
-        // See: https://www.pika.dev/npm/snowpack/discuss/496
+        // seems to be pretty common. Don't apply this transformation
+        // to packages since import.meta.env is not available at
+        // compile time.
+        // See: https://www.pika.dev/npm/snowpack/discuss/496 and
+        // https://github.com/snowpackjs/snowpack/discussions/2978
         code = code.replace(/process\.env/g, 'import.meta.env');
       }
       return {

--- a/plugins/plugin-babel/test/plugin-babel.test.js
+++ b/plugins/plugin-babel/test/plugin-babel.test.js
@@ -184,7 +184,7 @@ describe('plugin-babel', () => {
       }
     `);
   });
-  test('process.env not converted for package files', async () => {
+  test('package files include shim for import.meta.env', async () => {
     // Modify transformFileAsync mock to include a dummy `process.env`
     babel.transformFileAsync = jest.fn(() =>
       Promise.resolve({code: 'code [process.env.test]', map: 'map'}),
@@ -196,11 +196,12 @@ describe('plugin-babel', () => {
       filePath: 'test.js',
       isPackage: true, // testing a package file
     });
-    // Expect process.env to be unchanged
+    // Expect output to include import.meta.env default snippet
     expect(result).toMatchInlineSnapshot(`
       Object {
         ".js": Object {
-          "code": "code [process.env.test]",
+          "code": "import.meta.env = import.meta.env || process.env || {};
+      code [import.meta.env.test]",
           "map": "map",
         },
       }

--- a/plugins/plugin-babel/test/plugin-babel.test.js
+++ b/plugins/plugin-babel/test/plugin-babel.test.js
@@ -162,4 +162,48 @@ describe('plugin-babel', () => {
       ...transformOptions,
     });
   });
+  test('process.env will be converted for source files', async () => {
+    // Modify transformFileAsync mock to include a dummy `process.env`
+    babel.transformFileAsync = jest.fn(() =>
+      Promise.resolve({code: 'code [process.env.test]', map: 'map'}),
+    );
+    const p = plugin({
+      buildOptions: {},
+    });
+    const result = await p.load({
+      filePath: 'test.js',
+      isPackage: false, // testing a source file
+    });
+    // Expect process.env to be converted to import.meta.env
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        ".js": Object {
+          "code": "code [import.meta.env.test]",
+          "map": "map",
+        },
+      }
+    `);
+  });
+  test('process.env not converted for package files', async () => {
+    // Modify transformFileAsync mock to include a dummy `process.env`
+    babel.transformFileAsync = jest.fn(() =>
+      Promise.resolve({code: 'code [process.env.test]', map: 'map'}),
+    );
+    const p = plugin({
+      buildOptions: {},
+    });
+    const result = await p.load({
+      filePath: 'test.js',
+      isPackage: true, // testing a package file
+    });
+    // Expect process.env to be unchanged
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        ".js": Object {
+          "code": "code [process.env.test]",
+          "map": "map",
+        },
+      }
+    `);
+  });
 });

--- a/test/create-snowpack-app/__snapshots__/create-snowpack-app.test.js.snap
+++ b/test/create-snowpack-app/__snapshots__/create-snowpack-app.test.js.snap
@@ -1667,7 +1667,217 @@ exports[`create-snowpack-app app-template-lit-element > build: _snowpack/pkg/imp
 `;
 
 exports[`create-snowpack-app app-template-lit-element > build: _snowpack/pkg/lit-element.js 1`] = `
-"/**
+"/* SNOWPACK PROCESS POLYFILL (based on https://github.com/calvinmetcalf/node-process-es6) */
+function defaultSetTimout() {
+    throw new Error('setTimeout has not been defined');
+}
+function defaultClearTimeout () {
+    throw new Error('clearTimeout has not been defined');
+}
+var cachedSetTimeout = defaultSetTimout;
+var cachedClearTimeout = defaultClearTimeout;
+var globalContext;
+if (typeof window !== 'undefined') {
+    globalContext = window;
+} else if (typeof self !== 'undefined') {
+    globalContext = self;
+} else {
+    globalContext = {};
+}
+if (typeof globalContext.setTimeout === 'function') {
+    cachedSetTimeout = setTimeout;
+}
+if (typeof globalContext.clearTimeout === 'function') {
+    cachedClearTimeout = clearTimeout;
+}
+function runTimeout(fun) {
+    if (cachedSetTimeout === setTimeout) {
+        //normal enviroments in sane situations
+        return setTimeout(fun, 0);
+    }
+    // if setTimeout wasn't available but was latter defined
+    if ((cachedSetTimeout === defaultSetTimout || !cachedSetTimeout) && setTimeout) {
+        cachedSetTimeout = setTimeout;
+        return setTimeout(fun, 0);
+    }
+    try {
+        // when when somebody has screwed with setTimeout but no I.E. maddness
+        return cachedSetTimeout(fun, 0);
+    } catch(e){
+        try {
+            // When we are in I.E. but the script has been evaled so I.E. doesn't trust the global object when called normally
+            return cachedSetTimeout.call(null, fun, 0);
+        } catch(e){
+            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error
+            return cachedSetTimeout.call(this, fun, 0);
+        }
+    }
+}
+function runClearTimeout(marker) {
+    if (cachedClearTimeout === clearTimeout) {
+        //normal enviroments in sane situations
+        return clearTimeout(marker);
+    }
+    // if clearTimeout wasn't available but was latter defined
+    if ((cachedClearTimeout === defaultClearTimeout || !cachedClearTimeout) && clearTimeout) {
+        cachedClearTimeout = clearTimeout;
+        return clearTimeout(marker);
+    }
+    try {
+        // when when somebody has screwed with setTimeout but no I.E. maddness
+        return cachedClearTimeout(marker);
+    } catch (e){
+        try {
+            // When we are in I.E. but the script has been evaled so I.E. doesn't  trust the global object when called normally
+            return cachedClearTimeout.call(null, marker);
+        } catch (e){
+            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error.
+            // Some versions of I.E. have different rules for clearTimeout vs setTimeout
+            return cachedClearTimeout.call(this, marker);
+        }
+    }
+}
+var queue = [];
+var draining = false;
+var currentQueue;
+var queueIndex = -1;
+function cleanUpNextTick() {
+    if (!draining || !currentQueue) {
+        return;
+    }
+    draining = false;
+    if (currentQueue.length) {
+        queue = currentQueue.concat(queue);
+    } else {
+        queueIndex = -1;
+    }
+    if (queue.length) {
+        drainQueue();
+    }
+}
+function drainQueue() {
+    if (draining) {
+        return;
+    }
+    var timeout = runTimeout(cleanUpNextTick);
+    draining = true;
+    var len = queue.length;
+    while(len) {
+        currentQueue = queue;
+        queue = [];
+        while (++queueIndex < len) {
+            if (currentQueue) {
+                currentQueue[queueIndex].run();
+            }
+        }
+        queueIndex = -1;
+        len = queue.length;
+    }
+    currentQueue = null;
+    draining = false;
+    runClearTimeout(timeout);
+}
+function nextTick(fun) {
+    var args = new Array(arguments.length - 1);
+    if (arguments.length > 1) {
+        for (var i = 1; i < arguments.length; i++) {
+            args[i - 1] = arguments[i];
+        }
+    }
+    queue.push(new Item(fun, args));
+    if (queue.length === 1 && !draining) {
+        runTimeout(drainQueue);
+    }
+}
+// v8 likes predictible objects
+function Item(fun, array) {
+    this.fun = fun;
+    this.array = array;
+}
+Item.prototype.run = function () {
+    this.fun.apply(null, this.array);
+};
+var title = 'browser';
+var platform = 'browser';
+var browser = true;
+var argv = [];
+var version = ''; // empty string to avoid regexp issues
+var versions = {};
+var release = {};
+var config = {};
+function noop() {}
+var on = noop;
+var addListener = noop;
+var once = noop;
+var off = noop;
+var removeListener = noop;
+var removeAllListeners = noop;
+var emit = noop;
+function binding(name) {
+    throw new Error('process.binding is not supported');
+}
+function cwd () { return '/' }
+function chdir (dir) {
+    throw new Error('process.chdir is not supported');
+}function umask() { return 0; }
+// from https://github.com/kumavis/browser-process-hrtime/blob/master/index.js
+var performance = globalContext.performance || {};
+var performanceNow =
+  performance.now        ||
+  performance.mozNow     ||
+  performance.msNow      ||
+  performance.oNow       ||
+  performance.webkitNow  ||
+  function(){ return (new Date()).getTime() };
+// generate timestamp or delta
+// see http://nodejs.org/api/process.html#process_process_hrtime
+function hrtime(previousTimestamp){
+  var clocktime = performanceNow.call(performance)*1e-3;
+  var seconds = Math.floor(clocktime);
+  var nanoseconds = Math.floor((clocktime%1)*1e9);
+  if (previousTimestamp) {
+    seconds = seconds - previousTimestamp[0];
+    nanoseconds = nanoseconds - previousTimestamp[1];
+    if (nanoseconds<0) {
+      seconds--;
+      nanoseconds += 1e9;
+    }
+  }
+  return [seconds,nanoseconds]
+}
+var startTime = new Date();
+function uptime() {
+  var currentTime = new Date();
+  var dif = currentTime - startTime;
+  return dif / 1000;
+}
+var process = {
+  nextTick: nextTick,
+  title: title,
+  browser: browser,
+  env: {\\"NODE_ENV\\":\\"production\\"},
+  argv: argv,
+  version: version,
+  versions: versions,
+  on: on,
+  addListener: addListener,
+  once: once,
+  off: off,
+  removeListener: removeListener,
+  removeAllListeners: removeAllListeners,
+  emit: emit,
+  binding: binding,
+  cwd: cwd,
+  chdir: chdir,
+  umask: umask,
+  hrtime: hrtime,
+  platform: platform,
+  release: release,
+  config: config,
+  uptime: uptime
+};
+import.meta.env = import.meta.env || process.env || {};
+/**
  * @license
  * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
  * This code may only be used under the BSD style license found at
@@ -1695,6 +1905,7 @@ const removeNodes = (container, start, end = null) => {
     start = n;
   }
 };
+import.meta.env = import.meta.env || process.env || {};
 /**
  * @license
  * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -1914,19 +2125,7 @@ const createMarker = () => document.createComment('');
  */
 const lastAttributeNameRegex = // eslint-disable-next-line no-control-regex
 /([ \\\\x09\\\\x0a\\\\x0c\\\\x0d])([^\\\\0-\\\\x1F\\\\x7F-\\\\x9F \\"'>=/]+)([ \\\\x09\\\\x0a\\\\x0c\\\\x0d]*=[ \\\\x09\\\\x0a\\\\x0c\\\\x0d]*(?:[^ \\\\x09\\\\x0a\\\\x0c\\\\x0d\\"'\`<>=]*|\\"[^\\"]*|'[^']*))$/;
-/**
- * @license
- * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
+import.meta.env = import.meta.env || process.env || {};
 const walkerNodeFilter = 133
 ;
 /**
@@ -2043,6 +2242,7 @@ function insertNodeIntoTemplate(template, node, refNode = null) {
     }
   }
 }
+import.meta.env = import.meta.env || process.env || {};
 /**
  * @license
  * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -2060,6 +2260,7 @@ const directives = new WeakMap();
 const isDirective = o => {
   return typeof o === 'function' && directives.has(o);
 };
+import.meta.env = import.meta.env || process.env || {};
 /**
  * @license
  * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
@@ -2082,19 +2283,7 @@ const noChange = {};
  * A sentinel value that signals a NodePart to fully clear its content.
  */
 const nothing = {};
-/**
- * @license
- * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
+import.meta.env = import.meta.env || process.env || {};
 /**
  * An instance of a \`Template\` that can be attached to the DOM and updated
  * with new values.
@@ -2207,19 +2396,7 @@ class TemplateInstance {
     return fragment;
   }
 }
-/**
- * @license
- * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
+import.meta.env = import.meta.env || process.env || {};
 /**
  * Our TrustedTypePolicy for HTML which is declared using the html template
  * tag function.
@@ -2306,19 +2483,7 @@ class TemplateResult {
     return template;
   }
 }
-/**
- * @license
- * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
+import.meta.env = import.meta.env || process.env || {};
 const isPrimitive = value => {
   return value === null || !(typeof value === 'object' || typeof value === 'function');
 };
@@ -2743,19 +2908,7 @@ const getOptions = o => o && (eventOptionsSupported ? {
   passive: o.passive,
   once: o.once
 } : o.capture);
-/**
- * @license
- * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
+import.meta.env = import.meta.env || process.env || {};
 /**
  * The default TemplateFactory which caches Templates keyed on
  * result.type and result.strings.
@@ -2785,19 +2938,7 @@ function templateFactory(result) {
   return template;
 }
 const templateCaches = new Map();
-/**
- * @license
- * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
+import.meta.env = import.meta.env || process.env || {};
 const parts = new WeakMap();
 /**
  * Renders a template result or other value to a container.
@@ -2826,19 +2967,7 @@ const render = (result, container, options) => {
   part.setValue(result);
   part.commit();
 };
-/**
- * @license
- * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
+import.meta.env = import.meta.env || process.env || {};
 /**
  * Creates Parts when a template is instantiated.
  */
@@ -2876,19 +3005,7 @@ class DefaultTemplateProcessor {
   }
 }
 const defaultTemplateProcessor = new DefaultTemplateProcessor();
-/**
- * @license
- * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
+import.meta.env = import.meta.env || process.env || {};
 // This line will be used in regexes to search for lit-html usage.
 // TODO(justinfagnani): inject version number at build time
 if (typeof window !== 'undefined') {
@@ -2899,19 +3016,7 @@ if (typeof window !== 'undefined') {
  * render to and update a container.
  */
 const html = (strings, ...values) => new TemplateResult(strings, values, 'html', defaultTemplateProcessor);
-/**
- * @license
- * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
+import.meta.env = import.meta.env || process.env || {};
 const getTemplateCacheKey = (type, scopeName) => \`\${type}--\${scopeName}\`;
 let compatibleShadyCSSVersion = true;
 if (typeof window.ShadyCSS === 'undefined') {
@@ -3153,6 +3258,7 @@ const render$1 = (result, container, options) => {
     window.ShadyCSS.styleElement(container.host);
   }
 };
+import.meta.env = import.meta.env || process.env || {};
 /**
  * @license
  * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -3779,6 +3885,7 @@ _a = finalized;
  * Marks class as having finished creating properties.
  */
 UpdatingElement[_a] = true;
+import.meta.env = import.meta.env || process.env || {};
 /**
  * @license
  * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -3894,6 +4001,7 @@ function property(options) {
   // tslint:disable-next-line:no-any decorator
   return (protoOrDescriptor, name) => name !== undefined ? legacyProperty(options, protoOrDescriptor, name) : standardProperty(options, protoOrDescriptor);
 }
+import.meta.env = import.meta.env || process.env || {};
 /**
 @license
 Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
@@ -3964,19 +4072,7 @@ const css = (strings, ...values) => {
   const cssText = values.reduce((acc, v, idx) => acc + textFromCSSResult(v) + strings[idx + 1], strings[0]);
   return new CSSResult(cssText, constructionToken);
 };
-/**
- * @license
- * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
+import.meta.env = import.meta.env || process.env || {};
 // This line will be used in regexes to search for LitElement usage.
 // TODO(justinfagnani): inject version number at build time
 (window['litElementVersions'] || (window['litElementVersions'] = [])).push('2.4.0');
@@ -4321,7 +4417,217 @@ exports[`create-snowpack-app app-template-lit-element-typescript > build: _snowp
 `;
 
 exports[`create-snowpack-app app-template-lit-element-typescript > build: _snowpack/pkg/lit-element.js 1`] = `
-"/**
+"/* SNOWPACK PROCESS POLYFILL (based on https://github.com/calvinmetcalf/node-process-es6) */
+function defaultSetTimout() {
+    throw new Error('setTimeout has not been defined');
+}
+function defaultClearTimeout () {
+    throw new Error('clearTimeout has not been defined');
+}
+var cachedSetTimeout = defaultSetTimout;
+var cachedClearTimeout = defaultClearTimeout;
+var globalContext;
+if (typeof window !== 'undefined') {
+    globalContext = window;
+} else if (typeof self !== 'undefined') {
+    globalContext = self;
+} else {
+    globalContext = {};
+}
+if (typeof globalContext.setTimeout === 'function') {
+    cachedSetTimeout = setTimeout;
+}
+if (typeof globalContext.clearTimeout === 'function') {
+    cachedClearTimeout = clearTimeout;
+}
+function runTimeout(fun) {
+    if (cachedSetTimeout === setTimeout) {
+        //normal enviroments in sane situations
+        return setTimeout(fun, 0);
+    }
+    // if setTimeout wasn't available but was latter defined
+    if ((cachedSetTimeout === defaultSetTimout || !cachedSetTimeout) && setTimeout) {
+        cachedSetTimeout = setTimeout;
+        return setTimeout(fun, 0);
+    }
+    try {
+        // when when somebody has screwed with setTimeout but no I.E. maddness
+        return cachedSetTimeout(fun, 0);
+    } catch(e){
+        try {
+            // When we are in I.E. but the script has been evaled so I.E. doesn't trust the global object when called normally
+            return cachedSetTimeout.call(null, fun, 0);
+        } catch(e){
+            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error
+            return cachedSetTimeout.call(this, fun, 0);
+        }
+    }
+}
+function runClearTimeout(marker) {
+    if (cachedClearTimeout === clearTimeout) {
+        //normal enviroments in sane situations
+        return clearTimeout(marker);
+    }
+    // if clearTimeout wasn't available but was latter defined
+    if ((cachedClearTimeout === defaultClearTimeout || !cachedClearTimeout) && clearTimeout) {
+        cachedClearTimeout = clearTimeout;
+        return clearTimeout(marker);
+    }
+    try {
+        // when when somebody has screwed with setTimeout but no I.E. maddness
+        return cachedClearTimeout(marker);
+    } catch (e){
+        try {
+            // When we are in I.E. but the script has been evaled so I.E. doesn't  trust the global object when called normally
+            return cachedClearTimeout.call(null, marker);
+        } catch (e){
+            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error.
+            // Some versions of I.E. have different rules for clearTimeout vs setTimeout
+            return cachedClearTimeout.call(this, marker);
+        }
+    }
+}
+var queue = [];
+var draining = false;
+var currentQueue;
+var queueIndex = -1;
+function cleanUpNextTick() {
+    if (!draining || !currentQueue) {
+        return;
+    }
+    draining = false;
+    if (currentQueue.length) {
+        queue = currentQueue.concat(queue);
+    } else {
+        queueIndex = -1;
+    }
+    if (queue.length) {
+        drainQueue();
+    }
+}
+function drainQueue() {
+    if (draining) {
+        return;
+    }
+    var timeout = runTimeout(cleanUpNextTick);
+    draining = true;
+    var len = queue.length;
+    while(len) {
+        currentQueue = queue;
+        queue = [];
+        while (++queueIndex < len) {
+            if (currentQueue) {
+                currentQueue[queueIndex].run();
+            }
+        }
+        queueIndex = -1;
+        len = queue.length;
+    }
+    currentQueue = null;
+    draining = false;
+    runClearTimeout(timeout);
+}
+function nextTick(fun) {
+    var args = new Array(arguments.length - 1);
+    if (arguments.length > 1) {
+        for (var i = 1; i < arguments.length; i++) {
+            args[i - 1] = arguments[i];
+        }
+    }
+    queue.push(new Item(fun, args));
+    if (queue.length === 1 && !draining) {
+        runTimeout(drainQueue);
+    }
+}
+// v8 likes predictible objects
+function Item(fun, array) {
+    this.fun = fun;
+    this.array = array;
+}
+Item.prototype.run = function () {
+    this.fun.apply(null, this.array);
+};
+var title = 'browser';
+var platform = 'browser';
+var browser = true;
+var argv = [];
+var version = ''; // empty string to avoid regexp issues
+var versions = {};
+var release = {};
+var config = {};
+function noop() {}
+var on = noop;
+var addListener = noop;
+var once = noop;
+var off = noop;
+var removeListener = noop;
+var removeAllListeners = noop;
+var emit = noop;
+function binding(name) {
+    throw new Error('process.binding is not supported');
+}
+function cwd () { return '/' }
+function chdir (dir) {
+    throw new Error('process.chdir is not supported');
+}function umask() { return 0; }
+// from https://github.com/kumavis/browser-process-hrtime/blob/master/index.js
+var performance = globalContext.performance || {};
+var performanceNow =
+  performance.now        ||
+  performance.mozNow     ||
+  performance.msNow      ||
+  performance.oNow       ||
+  performance.webkitNow  ||
+  function(){ return (new Date()).getTime() };
+// generate timestamp or delta
+// see http://nodejs.org/api/process.html#process_process_hrtime
+function hrtime(previousTimestamp){
+  var clocktime = performanceNow.call(performance)*1e-3;
+  var seconds = Math.floor(clocktime);
+  var nanoseconds = Math.floor((clocktime%1)*1e9);
+  if (previousTimestamp) {
+    seconds = seconds - previousTimestamp[0];
+    nanoseconds = nanoseconds - previousTimestamp[1];
+    if (nanoseconds<0) {
+      seconds--;
+      nanoseconds += 1e9;
+    }
+  }
+  return [seconds,nanoseconds]
+}
+var startTime = new Date();
+function uptime() {
+  var currentTime = new Date();
+  var dif = currentTime - startTime;
+  return dif / 1000;
+}
+var process = {
+  nextTick: nextTick,
+  title: title,
+  browser: browser,
+  env: {\\"NODE_ENV\\":\\"production\\"},
+  argv: argv,
+  version: version,
+  versions: versions,
+  on: on,
+  addListener: addListener,
+  once: once,
+  off: off,
+  removeListener: removeListener,
+  removeAllListeners: removeAllListeners,
+  emit: emit,
+  binding: binding,
+  cwd: cwd,
+  chdir: chdir,
+  umask: umask,
+  hrtime: hrtime,
+  platform: platform,
+  release: release,
+  config: config,
+  uptime: uptime
+};
+import.meta.env = import.meta.env || process.env || {};
+/**
  * @license
  * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
  * This code may only be used under the BSD style license found at
@@ -4349,6 +4655,7 @@ const removeNodes = (container, start, end = null) => {
     start = n;
   }
 };
+import.meta.env = import.meta.env || process.env || {};
 /**
  * @license
  * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -4568,19 +4875,7 @@ const createMarker = () => document.createComment('');
  */
 const lastAttributeNameRegex = // eslint-disable-next-line no-control-regex
 /([ \\\\x09\\\\x0a\\\\x0c\\\\x0d])([^\\\\0-\\\\x1F\\\\x7F-\\\\x9F \\"'>=/]+)([ \\\\x09\\\\x0a\\\\x0c\\\\x0d]*=[ \\\\x09\\\\x0a\\\\x0c\\\\x0d]*(?:[^ \\\\x09\\\\x0a\\\\x0c\\\\x0d\\"'\`<>=]*|\\"[^\\"]*|'[^']*))$/;
-/**
- * @license
- * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
+import.meta.env = import.meta.env || process.env || {};
 const walkerNodeFilter = 133
 ;
 /**
@@ -4697,6 +4992,7 @@ function insertNodeIntoTemplate(template, node, refNode = null) {
     }
   }
 }
+import.meta.env = import.meta.env || process.env || {};
 /**
  * @license
  * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -4714,6 +5010,7 @@ const directives = new WeakMap();
 const isDirective = o => {
   return typeof o === 'function' && directives.has(o);
 };
+import.meta.env = import.meta.env || process.env || {};
 /**
  * @license
  * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
@@ -4736,19 +5033,7 @@ const noChange = {};
  * A sentinel value that signals a NodePart to fully clear its content.
  */
 const nothing = {};
-/**
- * @license
- * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
+import.meta.env = import.meta.env || process.env || {};
 /**
  * An instance of a \`Template\` that can be attached to the DOM and updated
  * with new values.
@@ -4861,19 +5146,7 @@ class TemplateInstance {
     return fragment;
   }
 }
-/**
- * @license
- * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
+import.meta.env = import.meta.env || process.env || {};
 /**
  * Our TrustedTypePolicy for HTML which is declared using the html template
  * tag function.
@@ -4960,19 +5233,7 @@ class TemplateResult {
     return template;
   }
 }
-/**
- * @license
- * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
+import.meta.env = import.meta.env || process.env || {};
 const isPrimitive = value => {
   return value === null || !(typeof value === 'object' || typeof value === 'function');
 };
@@ -5397,19 +5658,7 @@ const getOptions = o => o && (eventOptionsSupported ? {
   passive: o.passive,
   once: o.once
 } : o.capture);
-/**
- * @license
- * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
+import.meta.env = import.meta.env || process.env || {};
 /**
  * The default TemplateFactory which caches Templates keyed on
  * result.type and result.strings.
@@ -5439,19 +5688,7 @@ function templateFactory(result) {
   return template;
 }
 const templateCaches = new Map();
-/**
- * @license
- * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
+import.meta.env = import.meta.env || process.env || {};
 const parts = new WeakMap();
 /**
  * Renders a template result or other value to a container.
@@ -5480,19 +5717,7 @@ const render = (result, container, options) => {
   part.setValue(result);
   part.commit();
 };
-/**
- * @license
- * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
+import.meta.env = import.meta.env || process.env || {};
 /**
  * Creates Parts when a template is instantiated.
  */
@@ -5530,19 +5755,7 @@ class DefaultTemplateProcessor {
   }
 }
 const defaultTemplateProcessor = new DefaultTemplateProcessor();
-/**
- * @license
- * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
+import.meta.env = import.meta.env || process.env || {};
 // This line will be used in regexes to search for lit-html usage.
 // TODO(justinfagnani): inject version number at build time
 if (typeof window !== 'undefined') {
@@ -5553,19 +5766,7 @@ if (typeof window !== 'undefined') {
  * render to and update a container.
  */
 const html = (strings, ...values) => new TemplateResult(strings, values, 'html', defaultTemplateProcessor);
-/**
- * @license
- * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
+import.meta.env = import.meta.env || process.env || {};
 const getTemplateCacheKey = (type, scopeName) => \`\${type}--\${scopeName}\`;
 let compatibleShadyCSSVersion = true;
 if (typeof window.ShadyCSS === 'undefined') {
@@ -5807,6 +6008,7 @@ const render$1 = (result, container, options) => {
     window.ShadyCSS.styleElement(container.host);
   }
 };
+import.meta.env = import.meta.env || process.env || {};
 /**
  * @license
  * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -6433,6 +6635,7 @@ _a = finalized;
  * Marks class as having finished creating properties.
  */
 UpdatingElement[_a] = true;
+import.meta.env = import.meta.env || process.env || {};
 /**
  * @license
  * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -6548,6 +6751,7 @@ function property(options) {
   // tslint:disable-next-line:no-any decorator
   return (protoOrDescriptor, name) => name !== undefined ? legacyProperty(options, protoOrDescriptor, name) : standardProperty(options, protoOrDescriptor);
 }
+import.meta.env = import.meta.env || process.env || {};
 /**
 @license
 Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
@@ -6618,19 +6822,7 @@ const css = (strings, ...values) => {
   const cssText = values.reduce((acc, v, idx) => acc + textFromCSSResult(v) + strings[idx + 1], strings[0]);
   return new CSSResult(cssText, constructionToken);
 };
-/**
- * @license
- * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
+import.meta.env = import.meta.env || process.env || {};
 // This line will be used in regexes to search for LitElement usage.
 // TODO(justinfagnani): inject version number at build time
 (window['litElementVersions'] || (window['litElementVersions'] = [])).push('2.4.0');


### PR DESCRIPTION
## Changes

Previously, #649 added a hardcoded transform to `@snowpack/plugin-babel` that replaced all code instances of `process.env` with `import.meta.env`. After upgrading to snowpack 3.1.x, this change results in runtime errors when using `@snowpack/plugin-babel` (see #2979 and #2978).

The error seems to stem from a combination of package compilation changes in snowpack 3.1 and the way that this manual transform modifies package code. The end result is that `import.meta.env.SOME_PROP` is injected into package code (e.g. React initializer) and results in a runtime error since `import.meta.env` is `undefined` for package files.

This change adds a shim to the top of package files that are transformed by `@snowpack/plugin-babel`, as suggested in #2979:

```javascript
import.meta.env = import.meta.env || process.env || {};
```

There is no change for source files as snowpack already handles import.meta.env setup for them. I believe this is the optimal fix since the issue only arises when using `@snowpack/plugin-babel`.

## Testing

I added two unit tests for `@snowpack/plugin-babel` to:

1. Check that `process.env` is transformed to `import.meta.env` for source files, and
2. Check that the `import.meta.env` shim is added to package files

Additionally, I tested this locally to ensure it fixes the undefined access exception. I also tested with a `@babel/preset-env` config to make sure it's still getting loaded properly, and it is.

## Docs

No change to user-facing docs as this is a bug fix.
