### PR TITLE
Fix: Support HMR over localhost tunnel proxies

### DIFF
--- a/snowpack/src/build/build-import-proxy.ts
+++ b/snowpack/src/build/build-import-proxy.ts
@@ -102,7 +102,7 @@ Add the missing doctype, or set buildOptions.htmlFragments=true if HTML fragment
   if (hmr && isFullPage) {
     let hmrScript = ``;
     if (hmrPort) {
-      hmrScript += `<script type="text/javascript">window.HMR_WEBSOCKET_PORT=${hmrPort}</script>\n`;
+      hmrScript += `<script type="text/javascript">window.HMR_WEBSOCKET_PORT=window.location.port;</script>\n`;
     }
     hmrScript += `<script type="module" integrity="${SRI_CLIENT_HMR_SNOWPACK}" src="${getMetaUrlPath(
       'hmr-client.js',


### PR DESCRIPTION
## Changes

HMR websocket port was hardcoded to be the server port on which the HTTP server is running. This might not be the case if your development application is sitting behind a reverse proxy like ngrok, therefore breaking the HMR functionality as websocket connection never gets established.

This PR fixes it
## Testing

A simple change of hardcoded port number to the real port number of the webpage you're on. Without a reverse proxy, it'll be the same as the hmrEngine.port (as that is the port number on which the server starts anyway), but if it is behind a reverse proxy (like nginx or ngrok), it'll properly redirect websocket traffic.

## Docs

Bugfix only