### PR TITLE
[plugin-react-refresh] Solve the problem with MobX observer() HOC

### DIFF
--- a/plugins/plugin-react-refresh/plugin.js
+++ b/plugins/plugin-react-refresh/plugin.js
@@ -13,22 +13,21 @@ const reactRefreshCode = fs
   .replace(`process.env.NODE_ENV`, JSON.stringify('development'));
 
 function transformHtml(contents) {
-  return contents.replace(
-    /<body.*?>/s,
-    `$&
-<script>
-  function debounce(e,t){let u;return()=>{clearTimeout(u),u=setTimeout(e,t)}}
-  {
-    const exports = {};
-    ${reactRefreshCode}
-    exports.performReactRefresh = debounce(exports.performReactRefresh, 30);
-    window.$RefreshRuntime$ = exports;
-    window.$RefreshRuntime$.injectIntoGlobalHook(window);
-    window.$RefreshReg$ = () => {};
-    window.$RefreshSig$ = () => (type) => type;
-  }
-</script>`,
-  );
+  // Here just append the react-refresh code to the bottom of html content, instead of using contents.replace().
+  // To solve the problem with MobX observer() HOC. see: https://github.com/facebook/react/issues/20417#issuecomment-808429848
+  return `${contents}
+  <script>
+    function debounce(e,t){let u;return()=>{clearTimeout(u),u=setTimeout(e,t)}}
+    {
+      const exports = {};
+      ${reactRefreshCode}
+      exports.performReactRefresh = debounce(exports.performReactRefresh, 30);
+      window.$RefreshRuntime$ = exports;
+      window.$RefreshRuntime$.injectIntoGlobalHook(window);
+      window.$RefreshReg$ = () => {};
+      window.$RefreshSig$ = () => (type) => type;
+    }
+  </script>`;
 }
 
 const babel = require('@babel/core');


### PR DESCRIPTION
## Changes

It's all start with a bug of react-refresh. react-refresh doesn't work with MobX observer HOC. so @gaearon makes a fix on it. But the fix is not work with snowpack. After I checked all the babel plugins and transformers, I found out it's problem with plugin-react-refresh.
The story: [https://github.com/facebook/react/issues/20417#issuecomment-808429848](https://github.com/facebook/react/issues/20417#issuecomment-808429848)

The function `transformHtml()` in plugin-react-refresh insert the react-refresh code using `contents.replace()`, so the `$` will have meaning in the replaced content. The code of `node_modules/react-refresh/cjs/react-refresh-runtime.development.js` has these lines:

```js
if (typeof type === 'object' && type !== null) {
      switch (getProperty(type, '$$typeof')) {
```

After replace, become:

```js
if (typeof type === 'object' && type !== null) {
  switch (getProperty(type, '$typeof')) { // NOTE: ONLY ONE $
```

That's the reason why @gaearon's fx not working. So I make a fix just like below:

![image](https://user-images.githubusercontent.com/259410/112705041-ff767c00-8ed7-11eb-829a-3d0b774051ab.png)


## Testing

For testing this issue, I create a sample project to test it. Here is the repo: [https://github.com/yuhongda/repro-react-issues-20417](https://github.com/yuhongda/repro-react-issues-20417)

## Docs

bug fix only
