### PR TITLE
Fix: Only import directory/index.js as a fallback mechanism

### DIFF
--- a/snowpack/src/build/import-resolver.ts
+++ b/snowpack/src/build/import-resolver.ts
@@ -29,11 +29,7 @@ function resolveSourceSpecifier(
 ) {
   const lazyFileStat = getFsStat(lazyFileLoc);
 
-  // Handle directory imports (ex: "./components" -> "./components/index.js")
-  if (lazyFileStat && lazyFileStat.isDirectory()) {
-    const trailingSlash = lazyFileLoc.endsWith(path.sep) ? '' : path.sep;
-    lazyFileLoc = lazyFileLoc + trailingSlash + 'index.js';
-  } else if (lazyFileStat && lazyFileStat.isFile()) {
+  if (lazyFileStat && lazyFileStat.isFile()) {
     lazyFileLoc = lazyFileLoc;
   } else if (hasExtension(lazyFileLoc, '.css')) {
     lazyFileLoc = lazyFileLoc;
@@ -63,9 +59,15 @@ function resolveSourceSpecifier(
       }
     }
 
-    // if still no extension match, fall back to .js
     if (!path.extname(lazyFileLoc)) {
-      lazyFileLoc = lazyFileLoc + '.js';
+      if (lazyFileStat && lazyFileStat.isDirectory()) {
+        // Handle directory imports (ex: "./components" -> "./components/index.js")
+        const trailingSlash = lazyFileLoc.endsWith(path.sep) ? '' : path.sep;
+        lazyFileLoc = lazyFileLoc + trailingSlash + 'index.js';
+      } else {
+        // Fall back to .js.
+        lazyFileLoc = lazyFileLoc + '.js';
+      }
     }
   }
 

--- a/test/build/resolve-js/resolve-js.test.js
+++ b/test/build/resolve-js/resolve-js.test.js
@@ -22,5 +22,7 @@ describe('JS resolution', () => {
   it('resolves absolute URLs correctly', () => {
     // this tests that a URL-style import works
     expect(files['/a/a.js']).toEqual(expect.stringContaining(`import '../index.js';`));
+    // this ensures that we don't mistakenly import an index file from a directory with the same name
+    expect(files['/index.js']).toEqual(expect.stringContaining(`import b from './b.js';`));
   });
 });

--- a/test/build/resolve-js/src/b.ts
+++ b/test/build/resolve-js/src/b.ts
@@ -1,0 +1,1 @@
+import '/index.js'; // import root

--- a/test/build/resolve-js/src/b/index.js
+++ b/test/build/resolve-js/src/b/index.js
@@ -1,0 +1,1 @@
+throw new Error('Not me either!');

--- a/test/build/resolve-js/src/index.js
+++ b/test/build/resolve-js/src/index.js
@@ -1,2 +1,3 @@
 import isArray from 'is-array';
 import a from './a/a.js';
+import b from './b';


### PR DESCRIPTION
## Changes

This fixes #3017 by ensuring that we only import a directory's index file when there isn't another file with the same name as the directory.

## Testing

The `resolve-js` test suite was updated to have a conflicting file and directory which are both named `b`. This test failed before the change.

## Docs

This is only a bug fix.