### PR TITLE
Type!==srcFilesExtensions

### DIFF
--- a/snowpack/src/build/file-builder.ts
+++ b/snowpack/src/build/file-builder.ts
@@ -165,7 +165,7 @@ export class FileBuilder {
       const scannedImports = await scanImportsFromFiles(
         [
           {
-            baseExt: type,
+            baseExt: path.extname(this.loc).toLowerCase(),
             root: this.config.root,
             locOnDisk: this.loc,
             contents,


### PR DESCRIPTION
type !== source files Extensions
When run build loadedFiles in parseFileForInstallTargets()[scan-imports.ts](this https://github.com/snowpackjs/snowpack/blob/fc6c141NXdoFLzA23zDrNQSjtSAEUdv4RmGwWd97/snowpack/src/scan-imports.ts#L170 ) have wrong `baseExt` compare to the received file extension `lockOnDisk`, eg: 'sass'  extension is received as 'css', `tsx` =>`js`
its not clear why type(Extension after build?) was used here instead of actual file extension name.

## Changes
change `baseExt` from type(build file Extension?) to `This.loc`(source file extension) extension
## Testing
need discussion
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
