### PR TITLE
[RFC] Dev server plugin API

### DIFF
--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -157,6 +157,12 @@ export interface PluginOptimizeOptions {
   buildDirectory: string;
 }
 
+export type DevServerResponseHeaders = Record<string, string | number | string[]>
+
+export interface PluginDevServerHooks {
+  beforeWriteHead?(statusCode: number, headers: DevServerResponseHeaders): void;
+}
+
 export interface SnowpackPlugin {
   /** name of the plugin */
   name: string;
@@ -192,6 +198,7 @@ export interface SnowpackPlugin {
   onChange?({filePath}: {filePath: string}): void;
   /** (internal interface, not set by the user) Mark a file as changed. */
   markChanged?(file: string): void;
+  devServer?: PluginDevServerHooks;
 }
 
 /** Snowpack Build Plugin type */


### PR DESCRIPTION
Adds a plugin API for hooking into the snowpack dev server.

```ts
export type DevServerResponseHeaders = Record<string, string | number | string[]>

export interface PluginDevServerHooks {
  beforeWriteHead?(statusCode: number, headers: DevServerResponseHeaders): void;
}

export interface SnowpackPlugin {
  // (other keys omitted)
  devServer?: PluginDevServerHooks;
}
```

This lets plugins customize response headers for files served by the dev server.

This enables me to use [SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer); I needed my index.html served with additional response headers.

This also resolves @denis-sokolov's request:  
https://github.com/snowpackjs/snowpack/discussions/2420

I can also see its being useful for [serving WebAssembly assets with the appropriate headers](https://emscripten.org/docs/compiling/WebAssembly.html?highlight=fastcomp#web-server-setup).

I was wondering whether it'd make sense to pass _more information_ into the hook. For example some information about the request (e.g. the resource that was requested, and/or the request headers)?

## Changes

Changed every use of `res.writeHead()` such that it iterates through all plugins, and invokes the new `beforeWriteHead(statusCode, headers)` hook upon each such plugin.

`handleRequest`, `handleResponseError`, `sendResponseFile`, `sendResponseError` now take a mandatory `config: SnowpackConfig` argument. This does not change the external-facing `SnowpackDevServer` interface.

## Testing

I've written a [plugin](https://github.com/Birch-san/snowpack-dev-server-hooks-plugin/blob/master/src/index.ts) that integrates against this API.

It's just a passthrough that enables a user to write their own hook implementations in snowpack.config.js (whereas a more opinionated plugin would implement the hook itself):

```js
/** @type {import("snowpack-dev-server-hooks-plugin").DevServerHooksPluginOptions} */
const devServerHooksPluginOptions = {
  devServer: {
    beforeWriteHead (statusCode, headers) {
      if (statusCode === 200 && headers['Content-Type'] === 'text/html') {
        Object.assign(headers, {
          'Cross-Origin-Opener-Policy': 'same-origin',
          'Cross-Origin-Embedder-Policy': 'require-corp'
        })
      }
    }
  }
}

/** @type {import("snowpack").SnowpackUserConfig } */
module.exports = {
  plugins: [
    ['snowpack-dev-server-hooks-plugin', devServerHooksPluginOptions]
  ]
}
```

With that change made to my [liquidfun-play](https://github.com/Birch-san/liquidfun-play) repository: my `index.html` is served with served with `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy` headers, which changes `window.crossOriginIsolated` to true.

## Docs

No documentation added — first looking for feedback on whether this is the right shape for such an API.

The TypeScript types do mean that its interface can be discovered via the existing prompt on the [Plugin API](https://www.snowpack.dev/reference/plugins) docs:

> Looking for a good summary? Check out our “SnowpackPlugin” TypeScript definition for a fully documented and up-to-date overview of the Plugin API and all supported options.