### PR TITLE
Detect Sass partial changes in dev

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -891,7 +891,7 @@ export async function startServer(
     // Defer "chokidar" loading to here, to reduce impact on overall startup time
     const chokidar = await import('chokidar');
     watcher = chokidar.watch(Object.keys(config.mount), {
-      ignored: config.exclude,
+      ignored: config.exclude.filter((k) => k !== '**/_*.{sass,scss}'), // Sass partials ignored for builds, but not for dev changes
       persistent: true,
       ignoreInitial: true,
       disableGlobbing: false,

--- a/test/build/plugin-sass/package.json
+++ b/test/build/plugin-sass/package.json
@@ -7,7 +7,7 @@
     "testbuild": "snowpack build"
   },
   "devDependencies": {
-    "@snowpack/plugin-sass": "^1.0.0",
+    "@snowpack/plugin-sass": "^1.4.0",
     "snowpack": "^3.0.0"
   },
   "dependencies": {

--- a/test/build/plugin-sass/src/index.scss
+++ b/test/build/plugin-sass/src/index.scss
@@ -1,1 +1,1 @@
-@use "partial"
+@use "partial";


### PR DESCRIPTION
## Changes

Fixes #3042. The original intent of the code was to prevent Sass partial files from ending up in the final build. But it had the side-effect of preventing dev server changes. This keeps that change, but adds it back to the dev server watch list.

![Screen Shot 2021-03-31 at 14 19 22](https://user-images.githubusercontent.com/1369770/113206019-2e6c5500-922c-11eb-9879-71c9d16a645e.png)


<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Tested locally

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
