### PR TITLE
Adding property expr to solve #2945

### DIFF
--- a/esinstall/src/rollup-plugins/rollup-plugin-wrap-install-targets.ts
+++ b/esinstall/src/rollup-plugins/rollup-plugin-wrap-install-targets.ts
@@ -28,6 +28,7 @@ const TRUSTED_CJS_PACKAGES = ['chai/index.js', 'events/events.js', 'uuid/index.j
 const UNSCANNABLE_CJS_PACKAGES = [
   'chai/index.js',
   'events/events.js',
+  'property-expr/index.js',
   // Note: resolved in v4.x release
   'react-transition-group/index.js',
 ];


### PR DESCRIPTION
## Changes

Adds `property-expr`, a  dependency of `yup` which make apps fail.

## Testing

Manually tested via an app suffering the #2945 issue. Not quite sure if there is any test covering this.

## Docs

bug fix only
<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
