### PR TITLE
Add execa dependency for esinstall

### DIFF
--- a/esinstall/package.json
+++ b/esinstall/package.json
@@ -47,6 +47,7 @@
     "builtin-modules": "^3.2.0",
     "cjs-module-lexer": "^1.0.0",
     "es-module-lexer": "^0.3.24",
+    "execa": "^5.0.0",
     "is-valid-identifier": "^2.0.2",
     "kleur": "^4.1.1",
     "mkdirp": "^1.0.3",


### PR DESCRIPTION
esinstall uses execa but doesn't have it as a dep. Breaks some uses.
