### PR TITLE
fix: remove tailing slash in import specifier as esinstall do

### DIFF
--- a/snowpack/src/build/file-builder.ts
+++ b/snowpack/src/build/file-builder.ts
@@ -237,7 +237,7 @@ export class FileBuilder {
         const isHmrEnabled = contents.includes('import.meta.hot');
         const rawImports = await scanCodeImportsExports(contents);
         const resolvedImports = rawImports.map((imp) => {
-          let spec = contents.substring(imp.s, imp.e);
+          let spec = contents.substring(imp.s, imp.e).replace(/(\/|\\)+$/, '');
           if (imp.d > -1) {
             spec = matchDynamicImportValue(spec) || '';
           }

--- a/snowpack/src/rewrite-imports.ts
+++ b/snowpack/src/rewrite-imports.ts
@@ -48,7 +48,7 @@ export async function transformEsmImports(
   const collectedRewrites: RewriteInstruction[] = [];
   await Promise.all(
     imports.map(async (imp) => {
-      let spec = _code.substring(imp.s, imp.e);
+      let spec = _code.substring(imp.s, imp.e).replace(/(\/|\\)+$/, '');
       let webpackMagicCommentMatches;
       if (imp.d > -1) {
         // Extracting comments from spec as they are stripped in `matchDynamicImportValue`

--- a/snowpack/src/sources/local.ts
+++ b/snowpack/src/sources/local.ts
@@ -606,7 +606,7 @@ export class PackageSourceLocal implements PackageSource {
         const packageImports = new Set<string>();
         const code = loadedFile.toString('utf8');
         for (const imp of await scanCodeImportsExports(code)) {
-          const spec = code.substring(imp.s, imp.e);
+          const spec = code.substring(imp.s, imp.e).replace(/(\/|\\)+$/, ''); // remove trailing slash from end of specifier (easier for Node to resolve)
           if (isRemoteUrl(spec)) {
             continue;
           }


### PR DESCRIPTION
resolve #3098

---

## Changes

remove tailing slash in import specifier as esinstall do

check #3098 for detail

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

yarn test passed

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

bug fix only