### PR TITLE
Updated links to Diátaxis documentation framework

### DIFF
--- a/docs/guides/hmr.md
+++ b/docs/guides/hmr.md
@@ -6,7 +6,7 @@ published: false
 ---
 
 <div class="stub">
-This article is a stub, you can help fix it by removing duplicate content from /concepts/hot-module-replacement and writing it in a <a href="https://documentation.divio.com/how-to-guides/">guide format</a>
+This article is a stub, you can help fix it by removing duplicate content from /concepts/hot-module-replacement and writing it in a <a href="https://diataxis.fr/how-to-guides/">how-to guide format</a>
 </div>
 
 Hot Module Replacement (HMR) is the ability for Snowpack to push file changes to the browser without triggering a full page refresh. This article is about enabling HMR and connecting to the HMR dev server.

--- a/docs/guides/sass.md
+++ b/docs/guides/sass.md
@@ -9,7 +9,7 @@ description: How to use SASS with Snowpack using the Snowpack SASS plugin
 ---
 
 <div class="stub">
-This article is a stub, you can help expand it into <a href="https://documentation.divio.com/how-to-guides/">guide format</a>
+This article is a stub, you can help expand it into <a href="https://diataxis.fr/how-to-guides/">how-to guide format</a>
 </div>
 
 [Sass](https://www.sass-lang.com/) is a stylesheet language that’s compiled to CSS. It allows you to use variables, nested rules, mixins, functions, and more, all with a fully CSS-compatible syntax. Sass helps keep large stylesheets well-organized and makes it easy to share design within and across projects.

--- a/docs/guides/vue.md
+++ b/docs/guides/vue.md
@@ -8,7 +8,7 @@ description: How to use Vue with Snowpack using the Vue Plugin.
 ---
 
 <div class="stub">
-This article is a stub, you can help expand it into <a href="https://documentation.divio.com/how-to-guides/">guide format</a>
+This article is a stub, you can help expand it into <a href="https://diataxis.fr/how-to-guides/">how-to guide format</a>
 </div>
 
 To support `.vue` files you will need the [Vue Plugin](https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-vue), which uses Vue 3.

--- a/docs/guides/workbox.md
+++ b/docs/guides/workbox.md
@@ -6,7 +6,7 @@ description: The Workbox CLI integrates well with Snowpack.
 ---
 
 <div class="stub">
-This article is a stub, you can help expand it into <a href="https://documentation.divio.com/how-to-guides/">guide format</a>
+This article is a stub, you can help expand it into <a href="https://diataxis.fr/how-to-guides/">how-to guide format</a>
 </div>
 
 The [Workbox CLI](https://developers.google.com/web/tools/workbox/modules/workbox-cli) integrates well with Snowpack. Run the wizard to bootstrap your first configuration file, and then run `workbox generateSW` to generate your service worker.

--- a/www/README.md
+++ b/www/README.md
@@ -1,6 +1,6 @@
 # Snowpack docs
 
-We aim to follow the [Divio documentation system](https://documentation.divio.com/introduction/) though a lot of our docs are legacy and don't necessarily fit it yet.
+We aim to follow the [Diátaxis documentation system](https://diataxis.fr/) though a lot of our docs are legacy and don't necessarily fit it yet.
 
 ## Architecture
 


### PR DESCRIPTION
## Changes

The documentation framework mentioned in the documentation is now maintained at a different address.

## Testing

No code changes were made.

## Docs

Only documentation was updated, to replace old links.
