### PR TITLE
Honor devOptions.hmr option, fixes #3105

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -963,7 +963,7 @@ export async function command(commandOptions: CommandOptions) {
     commandOptions.config.devOptions.output =
       commandOptions.config.devOptions.output || 'dashboard';
     commandOptions.config.devOptions.open = commandOptions.config.devOptions.open || 'default';
-    commandOptions.config.devOptions.hmr = true;
+    commandOptions.config.devOptions.hmr = commandOptions.config.devOptions.hmr !== false;
     // Start the server
     await startServer(commandOptions, {isWatch: true});
   } catch (err) {


### PR DESCRIPTION
## Changes

Currently `devOptions.hmr` is hardcoded to `true` in https://github.com/snowpackjs/snowpack/blob/af1680e8fd6fcdf0a683cb0a06f87bfeea882a44/snowpack/src/commands/dev.ts#L966

This PR uses the value specified in config, defaulting to `true`.

## Testing

Existing tests pass.

## Docs

Updates code to match [current docs](https://www.snowpack.dev/reference/configuration#devoptions.hmr).