### PR TITLE
Fix env.js always having MODE and NODE_ENV as development

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -451,7 +451,7 @@ export async function startServer(
     if (reqPath === getMetaUrlPath('/env.js', config)) {
       return {
         contents: encodeResponse(
-          generateEnvModule({mode: 'development', isSSR, configEnv: config.env}),
+          generateEnvModule({mode: isDev ? 'development' : 'production', isSSR, configEnv: config.env}),
           encoding,
         ),
         imports: [],

--- a/test/create-snowpack-app/__snapshots__/create-snowpack-app.test.js.snap
+++ b/test/create-snowpack-app/__snapshots__/create-snowpack-app.test.js.snap
@@ -7458,8 +7458,8 @@ exports[`create-snowpack-app app-template-preact-typescript > build: index.html 
 `;
 
 exports[`create-snowpack-app app-template-react > build: _snowpack/env.js 1`] = `
-"export const MODE = \\"development\\";
-export const NODE_ENV = \\"development\\";
+"export const MODE = \\"production\\";
+export const NODE_ENV = \\"production\\";
 export const SSR = false;"
 `;
 
@@ -8000,8 +8000,8 @@ exports[`create-snowpack-app app-template-react > build: index.html 1`] = `
 `;
 
 exports[`create-snowpack-app app-template-react-typescript > build: _snowpack/env.js 1`] = `
-"export const MODE = \\"development\\";
-export const NODE_ENV = \\"development\\";
+"export const MODE = \\"production\\";
+export const NODE_ENV = \\"production\\";
 export const SSR = false;"
 `;
 
@@ -8542,8 +8542,8 @@ exports[`create-snowpack-app app-template-react-typescript > build: index.html 1
 `;
 
 exports[`create-snowpack-app app-template-svelte > build: _snowpack/env.js 1`] = `
-"export const MODE = \\"development\\";
-export const NODE_ENV = \\"development\\";
+"export const MODE = \\"production\\";
+export const NODE_ENV = \\"production\\";
 export const SSR = false;"
 `;
 
@@ -8738,8 +8738,8 @@ exports[`create-snowpack-app app-template-svelte > build: index.html 1`] = `
 `;
 
 exports[`create-snowpack-app app-template-svelte-typescript > build: _snowpack/env.js 1`] = `
-"export const MODE = \\"development\\";
-export const NODE_ENV = \\"development\\";
+"export const MODE = \\"production\\";
+export const NODE_ENV = \\"production\\";
 export const SSR = false;"
 `;
 
@@ -8932,8 +8932,8 @@ exports[`create-snowpack-app app-template-svelte-typescript > build: index.html 
 `;
 
 exports[`create-snowpack-app app-template-vue > build: _snowpack/env.js 1`] = `
-"export const MODE = \\"development\\";
-export const NODE_ENV = \\"development\\";
+"export const MODE = \\"production\\";
+export const NODE_ENV = \\"production\\";
 export const SSR = false;"
 `;
 
@@ -14103,8 +14103,8 @@ exports[`create-snowpack-app app-template-vue > build: index.html 1`] = `
 `;
 
 exports[`create-snowpack-app app-template-vue-typescript > build: _snowpack/env.js 1`] = `
-"export const MODE = \\"development\\";
-export const NODE_ENV = \\"development\\";
+"export const MODE = \\"production\\";
+export const NODE_ENV = \\"production\\";
 export const SSR = false;"
 `;
 


### PR DESCRIPTION
## Changes

Trying to fix this https://github.com/snowpackjs/snowpack/issues/3053

Essentially the `loadUrl` function on `dev.ts`, which is also used in `build.ts` is forcing a `development` mode on all environments. This PR makes use of the `isDev` variable to correctly set the generated env.

## Testing

Run `yarn build` and check `NODE_ENV` or the `build/_snowpack/env.js` file. That should be `production` on `yarn build` and `development` on `yarn dev`.

## Docs

Only a bug fix.
