### PR TITLE
Update routing.md with accurate socket.io instructions

### DIFF
--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -61,10 +61,16 @@ Proxied requests can be upgraded to a WebSocket connection via the "upgrade" eve
 ```js
 // snowpack.config.js
 const httpProxy = require('http-proxy');
-const proxy = httpProxy.createServer({target: 'http://localhost:3001'});
+const proxy = httpProxy.createServer({target: 'http://localhost:3001', ws: true});
 
 module.exports = {
   routes: [
+    { 
+      src: '/socket.io/*',
+      res: (req, res) => {
+        proxy.web(req,res);
+      }
+    },
     {
       src: '/socket.io/.*',
       upgrade: (req, socket, head) => {


### PR DESCRIPTION
http-proxy and socket.io don't together without both a)turning on websockets in the proxy and b) handling the negotiation urls

## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
