### PR TITLE
Allow srcPath fallback for older versions of Snowpack

### DIFF
--- a/plugins/plugin-postcss/plugin.js
+++ b/plugins/plugin-postcss/plugin.js
@@ -37,7 +37,7 @@ module.exports = function postcssPlugin(snowpackConfig, options) {
 
       const encodedResult = await worker.transformAsync(contents, {
         config,
-        filepath: srcPath,
+        filepath: srcPath || id, // note: srcPath will be undefined in snowpack@3.6.1 and older
         cwd: snowpackConfig.root || process.cwd(),
         map:
           snowpackConfig.buildOptions && snowpackConfig.buildOptions.sourceMaps


### PR DESCRIPTION
## Changes

Minor change; after merging #3483 I realized that if a user updated `@snowpack/plugin-postcss` without updating `snowpack`, it could result in different behavior. This PR allows the newer PostCSS plugin to use older versions of Snowpack seamlessly (of course with the existing bugs, which includes https://github.com/snowpackjs/astro/issues/481 but consistent behavior nonetheless). 

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Minor change; no test needed

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

No docs needed

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
