### PR TITLE
Pass `external` modules through to `esbuild`.

### DIFF
--- a/snowpack/src/build/optimize.ts
+++ b/snowpack/src/build/optimize.ts
@@ -405,9 +405,9 @@ async function runEsbuildOnBuildDirectory(
     publicPath,
     minify: config.optimize!.minify,
     target: config.optimize!.target,
-    external: Array.from(new Set(allFiles.map((f) => '*' + path.extname(f)))).filter(
-      (ext) => ext !== '*.js' && ext !== '*.mjs' && ext !== '*.css' && ext !== '*',
-    ),
+    external: Array.from(new Set(allFiles.map((f) => '*' + path.extname(f))))
+      .filter((ext) => ext !== '*.js' && ext !== '*.mjs' && ext !== '*.css' && ext !== '*')
+      .concat(config.packageOptions?.external ?? []),
     charset: 'utf8',
   });
 


### PR DESCRIPTION
## Changes

This implements the fix from https://github.com/snowpackjs/snowpack/issues/3032 to pass `external` modules through to `esbuild`. There is currently no other way to tell the `esbuild` inside `snowpack` to ignore modules, which makes Snowpack impossible to use for code that has any imports of `node` modules (even if those modules are only imported dynamically in `node`, never in the browser).

## Testing

I've only tested this by hacking into the build. `yarn build` isn't working for me locally due to this error:

```
$ tsc --noUnusedLocals false --noUnusedParameters false
src/util.ts(306,20): error TS2339: Property 'apps' does not exist on type '(target: string, options?: Options | undefined) => Promise<ChildProcess>'.
src/util.ts(316,65): error TS2322: Type '{ name: string; }' is not assignable to type 'string | readonly string[] | undefined'.
  Object literal may only specify known properties, and 'name' does not exist in type 'readonly string[]'.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## Docs

bug fix only