### PR TITLE
Fix doctype code block in documentation

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -492,7 +492,7 @@ Run Snowpack's build pipeline through a file watcher. This option works best for
 
 Toggles whether HTML fragments are transformed like full HTML pages.
 
-HTML fragments are HTML files not starting with "<!doctype html>".
+HTML fragments are HTML files not starting with `<!doctype html>`.
 
 ### buildOptions.jsxFactory
 


### PR DESCRIPTION



## Changes

The inline `<!doctype html>` mention was being interpreted as literal HTML which was then (presumably) being sanitised by the tool building. This issue isn't apparent when viewing the markdown in Github because github just escapes and preserves the HTML.

## Testing

~I wasn't able to build the documentation locally to verify this fixed it, because I don't have astro (??) installed locally (??), but I think this should do the trick.~

Actually, the build preview let me test it 🎉

[Before:](https://www.snowpack.dev/reference/configuration#buildoptionshtmlfragments)  
![image](https://user-images.githubusercontent.com/46142/123800214-f59e5380-d8e0-11eb-8a48-d9af6cd2c868.png)

[After:](https://snowpack-git-fork-joshhunt-patch-1-pikapkg.vercel.app/reference/configuration#buildoptionshtmlfragments)  
![image](https://user-images.githubusercontent.com/46142/123800049-c7b90f00-d8e0-11eb-89df-b66629d764b6.png)



## Docs

This is documentation :) :) 
