### PR TITLE
Fix CSS Modules + baseUrl

### DIFF
--- a/snowpack/src/build/build-import-proxy.ts
+++ b/snowpack/src/build/build-import-proxy.ts
@@ -244,9 +244,10 @@ async function generateCssModuleImportProxy({
   hmr: boolean;
   config: SnowpackConfig;
 }) {
+  const reqUrl = url.replace(new RegExp(`^${config.buildOptions.baseUrl}`), '/'); // note: in build, buildOptions.baseUrl gets prepended. Remove that for looking up CSS Module code
   return `
 export let code = ${JSON.stringify(code)};
-let json = ${cssModuleJSON(url)};
+let json = ${cssModuleJSON(reqUrl)};
 export default json;
 ${
   hmr

--- a/test/snowpack/cssModules/index.test.js
+++ b/test/snowpack/cssModules/index.test.js
@@ -162,4 +162,18 @@ describe('cssModules', () => {
     expect(result['_dist_/App.module.css']).not.toContain(`.App {`);
     expect(result['_dist_/App.module.css.json']).toBeDefined();
   });
+
+  it('Works with buildOptions.baseUrl set', async () => {
+    const result = await testFixture({
+      ...files(),
+      'snowpack.config.js': dedent`
+        module.exports = {
+          buildOptions: {
+            baseUrl: '/subdir/'
+          }
+        };
+      `,
+    });
+    expect(result['src/App.module.css.proxy.js']).toContain(`let json = {"App":"_App_`);
+  });
 });


### PR DESCRIPTION
## Changes

Fixes #3500. If a user supplies a `buildUrl`, it accidentally throws off the CSS Modules lookup.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Test added

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

No docs needed

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
