### PR TITLE
Fix indentation in configuration docs

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -76,7 +76,7 @@ Mount local directories to custom URLs in your built application.
 - `mount.url` | `string` | _required_ : The URL to mount to, matching the string in the simple form above.
 - `mount.static` | `boolean` | _optional_ | **Default**: `false` : If true, don't build files in this directory. Copy and serve them directly from disk to the browser.
 - `mount.resolve` | `boolean` | _optional_ | **Default**: `true`: If false, don't resolve JS & CSS imports in your JS, CSS, and HTML files. Instead send every import to the browser, as written.
-- - `mount.dot` | `boolean` | _optional_ | **Default**: `false`: If true, include dotfiles (ex: `.htaccess`) in the final build.
+- `mount.dot` | `boolean` | _optional_ | **Default**: `false`: If true, include dotfiles (ex: `.htaccess`) in the final build.
 
 Example:
 


### PR DESCRIPTION
## Changes

Fixes a small indentation mistake from https://github.com/snowpackjs/snowpack/pull/3455

Before
![Screenshot from 2021-07-01 07-58-05](https://user-images.githubusercontent.com/5716720/124073587-70cb4b00-da42-11eb-9833-e8ec12ec023d.png)

After
![Screenshot from 2021-07-01 07-58-20](https://user-images.githubusercontent.com/5716720/124073585-7032b480-da42-11eb-9a6d-4ce4c562ae3a.png)

## Testing

Docs markdown change, therefore no test.

## Docs

Yes, `docs/reference/configuration.md` was updated.