### PR TITLE
Fix typo in web-test-runner.md

### DIFF
--- a/docs/guides/web-test-runner.md
+++ b/docs/guides/web-test-runner.md
@@ -21,7 +21,7 @@ The base testing dependencies (don't hit Enter just yet!):
 npm i -D @web/test-runner @snowpack/web-test-runner-plugin chai
 ```
 
-If using React, Vue, Svelte, or Preact, add the corresponding [Testing Library](https://testing-library.com/) (in this case `@testing-libary/react`).
+If using React, Vue, Svelte, or Preact, add the corresponding [Testing Library](https://testing-library.com/) (in this case `@testing-library/react`).
 
 If using TypeScript, add `@types/mocha` and `@types/chai`.
 

--- a/docs/guides/web-test-runner.md
+++ b/docs/guides/web-test-runner.md
@@ -57,7 +57,7 @@ If needed, swap `.jsx` with the file type(s) containing your tests.
 To specify multiple test file types, enclose with curly brackets and separate with commas. For example, to match `.jsx`, `.js`, and `.ts` files, the script would be:
 
 ```
-"test": "web-test-runner \"src/**/*.test.{jsx,js,ts}\"",
+"test": "web-test-runner \\\"src/**/*.test.{jsx,js,ts}\\\"",
 ```
 
 > 💡 Tip: `wtr` can be used as a shorthand for `web-test-runner`.

--- a/docs/guides/web-test-runner.md
+++ b/docs/guides/web-test-runner.md
@@ -47,7 +47,7 @@ Add a `test` script to your project `package.json`:
 "scripts": {
   "start": "snowpack dev",
   "build": "snowpack build",
-+  "test": "web-test-runner \"src/**/*.test.jsx\"",
++  "test": "web-test-runner \\\"src/**/*.test.jsx\\\"",
   ...
 },
 ```


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

This fixes a typo in the guide for `@web/test-runner` in the Guides section of the documentation.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

No tests were added since this is simply a docs change.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

Public documentation was updated to fix a typo.