### PR TITLE
Adhere to execution order in SSR

### DIFF
--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -34,7 +34,7 @@ export interface ServerRuntime {
   invalidateModule: (url: string) => void;
 }
 
-export interface ServerRuntimeModule<T> {
+export interface ServerRuntimeModule<T extends any> {
   exports: T;
   css: string[];
 }

--- a/test/snowpack/runtime/runtime.test.js
+++ b/test/snowpack/runtime/runtime.test.js
@@ -179,4 +179,29 @@ describe('runtime', () => {
       await fixture.cleanup();
     }
   });
+
+  it('Executes scripts in the correct order', async () => {
+    const fixture = await testRuntimeFixture({
+      'one.js': dedent`
+        global.NUM = 1;
+        export default {};
+      `,
+      'two.js': dedent`
+        global.NUM++;
+        export default global.NUM;
+      `,
+      'main.js': dedent`
+        import one from './one.js';
+        import two from './two.js';
+        export const val = two;
+      `
+    });
+
+    try {
+      let mod = await fixture.runtime.importModule('/main.js');
+      expect(await mod.exports.val).toEqual(2);
+    } finally {
+      await fixture.cleanup();
+    }
+  })
 });


### PR DESCRIPTION
## Changes

ESM execution order is specced to be top-down. If you have imports like:

```js
import 'one.js';
import 'two.js';
```

one.js should be executed before two.js. This allows you to handle global state change. While these files must be executed in order, they can be loaded in parallel.

Previously snowpack was loading and executing modules in parallel in SSR. This fixes that by making loading and executing distinct, thus preserving execution order (while still getting the perf benefit of async loading).

## Testing

Test added which relies on execution order and global state change.

## Docs

N/A, bug fix.
