### PR TITLE
Update blank templates

### DIFF
--- a/create-snowpack-app/app-template-blank-typescript/public/index.html
+++ b/create-snowpack-app/app-template-blank-typescript/public/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="Web site created using create-snowpack-app" />
     <link rel="stylesheet" type="text/css" href="/dist/index.css" />
+    <script type="module" src="/dist/index.js" defer></script>
     <title>Snowpack App</title>
   </head>
   <body>
@@ -17,7 +18,6 @@
       </a>
     </p>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <script type="module" src="/dist/index.js"></script>
     <!--
       This HTML file is a template.
 

--- a/create-snowpack-app/app-template-blank-typescript/public/index.html
+++ b/create-snowpack-app/app-template-blank-typescript/public/index.html
@@ -20,7 +20,6 @@
     <script type="module" src="/dist/index.js"></script>
     <!--
       This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
 
       You can add webfonts, meta tags, or analytics to this file.
       The build step will place the bundled scripts into the <body> tag.

--- a/create-snowpack-app/app-template-blank/public/index.html
+++ b/create-snowpack-app/app-template-blank/public/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="Web site created using create-snowpack-app" />
     <link rel="stylesheet" type="text/css" href="/dist/index.css" />
+    <script type="module" src="/dist/index.js" defer></script>
     <title>Snowpack App</title>
   </head>
   <body>
@@ -17,7 +18,6 @@
       </a>
     </p>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <script type="module" src="/dist/index.js"></script>
     <!--
       This HTML file is a template.
 

--- a/create-snowpack-app/app-template-blank/public/index.html
+++ b/create-snowpack-app/app-template-blank/public/index.html
@@ -10,7 +10,6 @@
   </head>
   <body>
     <img id="img" src="/logo.svg" />
-    <img id="img" src="/logo.svg" />
     <p>Page has been open for <code id="counter">0</code> seconds.</p>
     <p>
       <a href="https://developer.mozilla.org/en-US/docs/Learn">

--- a/create-snowpack-app/app-template-blank/public/index.html
+++ b/create-snowpack-app/app-template-blank/public/index.html
@@ -20,7 +20,6 @@
     <script type="module" src="/dist/index.js"></script>
     <!--
       This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
 
       You can add webfonts, meta tags, or analytics to this file.
       The build step will place the bundled scripts into the <body> tag.

--- a/test/create-snowpack-app/__snapshots__/create-snowpack-app.test.js.snap
+++ b/test/create-snowpack-app/__snapshots__/create-snowpack-app.test.js.snap
@@ -648,10 +648,10 @@ exports[`create-snowpack-app app-template-blank > build: index.html 1`] = `
     <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\" />
     <meta name=\\"description\\" content=\\"Web site created using create-snowpack-app\\" />
     <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"/dist/index.css\\" />
+    <script type=\\"module\\" src=\\"/dist/index.js\\" defer></script>
     <title>Snowpack App</title>
   </head>
   <body>
-    <img id=\\"img\\" src=\\"/logo.svg\\" />
     <img id=\\"img\\" src=\\"/logo.svg\\" />
     <p>Page has been open for <code id=\\"counter\\">0</code> seconds.</p>
     <p>
@@ -660,10 +660,8 @@ exports[`create-snowpack-app app-template-blank > build: index.html 1`] = `
       </a>
     </p>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <script type=\\"module\\" src=\\"/dist/index.js\\"></script>
     <!--
       This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
       You can add webfonts, meta tags, or analytics to this file.
       The build step will place the bundled scripts into the <body> tag.
       To begin the development, run \`npm start\` or \`yarn start\`.
@@ -731,6 +729,7 @@ exports[`create-snowpack-app app-template-blank-typescript > build: index.html 1
     <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\" />
     <meta name=\\"description\\" content=\\"Web site created using create-snowpack-app\\" />
     <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"/dist/index.css\\" />
+    <script type=\\"module\\" src=\\"/dist/index.js\\" defer></script>
     <title>Snowpack App</title>
   </head>
   <body>
@@ -742,10 +741,8 @@ exports[`create-snowpack-app app-template-blank-typescript > build: index.html 1
       </a>
     </p>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <script type=\\"module\\" src=\\"/dist/index.js\\"></script>
     <!--
       This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
       You can add webfonts, meta tags, or analytics to this file.
       The build step will place the bundled scripts into the <body> tag.
       To begin the development, run \`npm start\` or \`yarn start\`.


### PR DESCRIPTION
## Changes

A fix and some other changes:

- Duplicate `<img>` has been deleted from `blank-typescript` template
- Comment line about an empty page has been deleted
- `<script>` elements have been moved to head and `defer` attributes have been added.

## Testing
Updated snapshots.

## Docs

N/A, no user action required.
