### PR TITLE
Fix build:watch command for Snowpack

### DIFF
--- a/snowpack/package.json
+++ b/snowpack/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "build": "tsc --noUnusedLocals false --noUnusedParameters false && tsc -p tsconfig.cjs.json",
-    "build:watch": "tsc --watch --noUnusedLocals false --noUnusedParameters false",
+    "build:watch": "tsc --watch -p tsconfig.cjs.json",
     "lint": "tsc --noEmit"
   },
   "engines": {


### PR DESCRIPTION
## Changes

Dev-only change; fixes the `yarn build:watch` command for Snowpack so the correct TS build is used

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
