### PR TITLE
Remove superfluous script language attribute

### DIFF
--- a/snowpack/src/build/build-import-proxy.ts
+++ b/snowpack/src/build/build-import-proxy.ts
@@ -115,7 +115,7 @@ Add the missing doctype, or set buildOptions.htmlFragments=true if HTML fragment
   if (hmr && isFullPage) {
     let hmrScript = ``;
     if (hmrPort) {
-      hmrScript += `<script type="text/javascript">window.HMR_WEBSOCKET_PORT=${hmrPort}</script>\n`;
+      hmrScript += `<script>window.HMR_WEBSOCKET_PORT=${hmrPort}</script>\n`;
     }
     hmrScript += `<script type="module" integrity="${SRI_CLIENT_HMR_SNOWPACK}" src="${getMetaUrlPath(
       'hmr-client.js',

--- a/test-dev/__snapshots__/dev.test.ts.snap
+++ b/test-dev/__snapshots__/dev.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`snowpack dev smoke: about 1`] = `
 "<!DOCTYPE html>
 <html>
-  <head><script type=\\"text/javascript\\">window.HMR_WEBSOCKET_PORT=8080</script>
+  <head><script>window.HMR_WEBSOCKET_PORT=8080</script>
 <script type=\\"module\\" integrity=\\"sha384-y8il70JD9siKrwwsMhcx99P7XKCWpwH7DWMCPklzJJeQBV6Y4OY9RpL+HlYJlW2r\\" src=\\"/_snowpack/hmr-client.js\\"></script><script type=\\"module\\" integrity=\\"sha384-LH/mFhEGRB4jHedP0nqOoIUwc4VX8eWJxEL+qTGWtroqiLJ2vxX169J0oSBMHL5o\\" src=\\"/_snowpack/hmr-error-overlay.js\\"></script></head>
   <body>
     <p>this is a template in some language that builds to .html</p>
@@ -21,7 +21,7 @@ exports[`snowpack dev smoke: html 1`] = `
     <meta name=\\"description\\" content=\\"Web site created using create-snowpack-app\\" />
     <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"/index.css\\" />
     <title>Snowpack App</title>
-  <script type=\\"text/javascript\\">window.HMR_WEBSOCKET_PORT=8080</script>
+  <script>window.HMR_WEBSOCKET_PORT=8080</script>
 <script type=\\"module\\" integrity=\\"sha384-y8il70JD9siKrwwsMhcx99P7XKCWpwH7DWMCPklzJJeQBV6Y4OY9RpL+HlYJlW2r\\" src=\\"/_snowpack/hmr-client.js\\"></script><script type=\\"module\\" integrity=\\"sha384-LH/mFhEGRB4jHedP0nqOoIUwc4VX8eWJxEL+qTGWtroqiLJ2vxX169J0oSBMHL5o\\" src=\\"/_snowpack/hmr-error-overlay.js\\"></script></head>
   <body>
     <img id=\\"img\\" src=\\"/logo.svg\\" />


### PR DESCRIPTION
## Changes

Removes superfluous script language attribute. Rely on the default. This also fixes the respective W3C validator warning.

## Testing

The change was not tested locally. Tests weren‘t added. Test code was updated.

## Docs

Internal source code quality improvement only.
