### PR TITLE
Runtime: ensure modules are initialized only once

### DIFF
--- a/.changeset/serious-ligers-give.md
+++ b/.changeset/serious-ligers-give.md
@@ -1,0 +1,5 @@
+---
+'snowpack': patch
+---
+
+Fixes regression with modules executing more than once


### PR DESCRIPTION
## Changes

#3530 changed the runtime's execution so that `getModule` returned a function instead of a promise for a value. This allowed splitting up fetching a dependency from executing it.

This caused a regression where if two modules imported the same dep, that dep would be executed twice, because execution is not cached. This fixes that, making the chain be promise-based.

## Testing

Test added for this scenario.

## Docs

N/A, bug fix only.
