### PR TITLE
Adds missing `tar` to the dependencies

### DIFF
--- a/.changeset/spicy-apes-listen.md
+++ b/.changeset/spicy-apes-listen.md
@@ -1,0 +1,5 @@
+---
+'skypack': patch
+---
+
+Fixes a ghost dependency on 'tar'

--- a/skypack/package.json
+++ b/skypack/package.json
@@ -52,6 +52,7 @@
     "p-queue": "^6.2.1",
     "rimraf": "^3.0.0",
     "rollup": "~2.37.1",
+    "tar": "^6.1.0",
     "validate-npm-package-name": "^3.0.0"
   }
 }


### PR DESCRIPTION
## Changes

Our [tests](https://github.com/yarnpkg/berry/runs/3018792207?check_suite_focus=true#step:5:77) started pointing out that you forgot to add `tar` into the Skypack dependencies (it's now used [here](https://github.com/snowpackjs/snowpack/blob/main/skypack/src/index.ts#L4)). I added it with `^6.1.0` as range, which I think is the highest version already in your lockfile.

## Testing

n/a

## Docs

n/a