### PR TITLE
Remove export map

### DIFF
--- a/.changeset/poor-wasps-cough.md
+++ b/.changeset/poor-wasps-cough.md
@@ -1,0 +1,5 @@
+---
+'snowpack': patch
+---
+
+Remove exports field from package.json

--- a/snowpack/package.json
+++ b/snowpack/package.json
@@ -30,16 +30,6 @@
   },
   "types": "./lib/cjs/index.d.ts",
   "main": "./lib/cjs/index.js",
-  "exports": {
-    ".": {
-      "esm": "./lib/cjs/index.js",
-      "node": "./lib/cjs/index.js",
-      "require": "./lib/cjs/index.js",
-      "default": "./lib/esm/index.js"
-    },
-    "./assets": "./assets/*",
-    "./*": "./*"
-  },
   "bin": {
     "sp": "./index.bin.js",
     "snowpack": "./index.bin.js"


### PR DESCRIPTION
## Changes

Snowpack now ships an ESM build that’s still in beta. The export map would force loading the ESM version in some contexts. For now, avoid loading the ESM build until the next major release (but we’ll continue shipping it for testing, and/or for importing when it makes sense to)

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

No testing needed

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

Behind-the-scenes change

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
