### PR TITLE
Lock slash to 3.x

### DIFF
--- a/.changeset/great-doors-begin.md
+++ b/.changeset/great-doors-begin.md
@@ -1,0 +1,5 @@
+---
+'esinstall': patch
+---
+
+Lock slash package version more aggressively

--- a/esinstall/package.json
+++ b/esinstall/package.json
@@ -56,7 +56,7 @@
     "rimraf": "^3.0.0",
     "rollup": "~2.37.1",
     "rollup-plugin-polyfill-node": "^0.6.2",
-    "slash": "^3.0.0",
+    "slash": "~3.0.0",
     "validate-npm-package-name": "^3.0.0",
     "vm2": "^3.9.2"
   }

--- a/snowpack/package.json
+++ b/snowpack/package.json
@@ -92,6 +92,7 @@
     "rimraf": "^3.0.0",
     "rollup": "~2.37.1",
     "signal-exit": "^3.0.3",
+    "slash": "~3.0.0",
     "skypack": "^0.3.0",
     "source-map": "^0.7.3",
     "strip-ansi": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14576,7 +14576,7 @@ slash@^2.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
   integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
-slash@^3.0.0:
+slash@^3.0.0, slash@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==


### PR DESCRIPTION
## Changes

Slash v4 switches to ESM. Which is great! But we‘re not ready yet. This locks the version more aggressively

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
