### PR TITLE
Fix circular import dependency GLOBAL_CACHE_DIR (snowpackjs#3554)

### DIFF
--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -23,17 +23,16 @@ import {
 import {
   addLeadingSlash,
   addTrailingSlash,
-  GLOBAL_CACHE_DIR,
   NATIVE_REQUIRE,
   REQUIRE_OR_IMPORT,
   removeTrailingSlash,
   isPathImport,
 } from './util';
+import {GLOBAL_CACHE_DIR} from './sources/util';
 import type {Awaited} from './util';
 
 const CONFIG_NAME = 'snowpack';
 const ALWAYS_EXCLUDE = ['**/_*.{sass,scss}', '**.d.ts'];
-
 const DEFAULT_PROJECT_CACHE_DIR =
   projectCacheDir({name: 'snowpack'}) ||
   // If `projectCacheDir()` is null, no node_modules directory exists.

--- a/snowpack/src/sources/local.ts
+++ b/snowpack/src/sources/local.ts
@@ -22,13 +22,13 @@ import {
   createInstallTarget,
   findMatchingAliasEntry,
   getExtension,
-  GLOBAL_CACHE_DIR,
   isJavaScript,
   isPathImport,
   isRemoteUrl,
   parsePackageImportSpecifier,
   readFile,
 } from '../util';
+import {GLOBAL_CACHE_DIR} from './util';
 import {installPackages} from './local-install';
 
 const CURRENT_META_FILE_CONTENTS = `.snowpack cache - Do not edit this directory!

--- a/snowpack/src/sources/util.ts
+++ b/snowpack/src/sources/util.ts
@@ -3,6 +3,9 @@ import {PackageSourceLocal} from './local';
 import {PackageSourceRemote} from './remote';
 import path from 'path';
 import rimraf from 'rimraf';
+import globalCacheDir from 'cachedir';
+
+export const GLOBAL_CACHE_DIR = globalCacheDir('snowpack');
 
 export async function clearCache() {
   return Promise.all([

--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -1,4 +1,3 @@
-import globalCacheDir from 'cachedir';
 import etag from 'etag';
 import execa from 'execa';
 import findUp from 'find-up';
@@ -14,6 +13,7 @@ import type {ImportMap, LockfileManifest, SnowpackConfig} from './types';
 import type {InstallTarget} from 'esinstall';
 import {SkypackSDK} from 'skypack';
 import {REMOTE_PACKAGE_ORIGIN} from './config';
+import {GLOBAL_CACHE_DIR} from './sources/util';
 
 // (!) Beware circular dependencies! No relative imports!
 // Because this file is imported from so many different parts of Snowpack,
@@ -21,7 +21,6 @@ import {REMOTE_PACKAGE_ORIGIN} from './config';
 // circular dependencies (sometimes only visible in the final bundled build.)
 export const IS_DOTFILE_REGEX = /\/\.[^\/]+$/; // note: always assume forward-slashes, even on Windows
 
-export const GLOBAL_CACHE_DIR = globalCacheDir('snowpack');
 export const LOCKFILE_NAME = 'snowpack.deps.json';
 
 // We need to use eval here to prevent Rollup from detecting this use of `require()`


### PR DESCRIPTION
## Problem

snowpack seems to get broken when there is no package.json can be found, and I realized it's the same problem with [#3544 ](https://github.com/snowpackjs/snowpack/issues/3554)

so I debug this and find out there is a circular import dependency for GLOBAL_CACHE_DIR (between `snowpack/src/config.ts` and `snowpack/src/utils.ts`). it caused GLOBAL_CACHE_DIR to be imported before it's initialed.

## Changes
move the constant variable GLOBAL_CACHE_DIR to `snowpack/src/source/utils.ts` just like Fred k. Schott used to.
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing
use any snowpack command below your `~` directory can make it.
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs
bux fix only
