### PR TITLE
Support for dynamic import scanning

### DIFF
--- a/.changeset/great-doors-begin.md
+++ b/.changeset/great-doors-begin.md
@@ -1,5 +1,0 @@
----
-'esinstall': patch
----
-
-Lock slash package version more aggressively

--- a/.changeset/late-lamps-try.md
+++ b/.changeset/late-lamps-try.md
@@ -1,5 +1,0 @@
----
-'snowpack': patch
----
-
-Remove type attribute from HMR script in dev server

--- a/.changeset/poor-wasps-cough.md
+++ b/.changeset/poor-wasps-cough.md
@@ -1,5 +1,0 @@
----
-'snowpack': patch
----
-
-Remove exports field from package.json

--- a/esinstall/CHANGELOG.md
+++ b/esinstall/CHANGELOG.md
@@ -1,5 +1,11 @@
 # esinstall
 
+## 1.1.7
+
+### Patch Changes
+
+- 9b1472f6: Lock slash package version more aggressively
+
 ## 1.1.6
 
 ### Patch Changes

--- a/esinstall/package.json
+++ b/esinstall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esinstall",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Convert packages to ESM.",
   "license": "MIT",
   "keywords": [

--- a/snowpack/CHANGELOG.md
+++ b/snowpack/CHANGELOG.md
@@ -1,5 +1,14 @@
 # snowpack
 
+## 3.8.1
+
+### Patch Changes
+
+- a1f56ef7: Remove type attribute from HMR script in dev server
+- 95d4309a: Remove exports field from package.json
+- Updated dependencies [9b1472f6]
+  - esinstall@1.1.7
+
 ## 3.8.0
 
 ### Minor Changes

--- a/snowpack/package.json
+++ b/snowpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snowpack",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "The ESM-powered frontend build tool. Fast, lightweight, unbundled.",
   "author": "Fred K. Schott <fkschott@gmail.com>",
   "license": "MIT",
@@ -53,7 +53,7 @@
     "detect-port": "^1.3.0",
     "es-module-lexer": "^0.3.24",
     "esbuild": "~0.9.0",
-    "esinstall": "^1.0.0",
+    "esinstall": "^1.1.7",
     "estree-walker": "^2.0.2",
     "etag": "^1.8.1",
     "execa": "^5.1.1",

--- a/snowpack/src/scan-imports.ts
+++ b/snowpack/src/scan-imports.ts
@@ -83,7 +83,7 @@ export function matchDynamicImportValue(importStatement: string) {
   return matched?.[2] || matched?.[3] || null;
 }
 
-function getWebModuleSpecifierFromCode(code: string, imp: ImportSpecifier) {
+export function getWebModuleSpecifierFromCode(code: string, imp: ImportSpecifier): string | null {
   // import.meta: we can ignore
   if (imp.d === -2) {
     return null;

--- a/snowpack/src/sources/local.ts
+++ b/snowpack/src/sources/local.ts
@@ -16,7 +16,7 @@ import slash from 'slash';
 import {getBuiltFileUrls} from '../build/file-urls';
 import {logger} from '../logger';
 import {scanCodeImportsExports, transformFileImports} from '../rewrite-imports';
-import {getInstallTargets} from '../scan-imports';
+import {getInstallTargets, getWebModuleSpecifierFromCode} from '../scan-imports';
 import {ImportMap, PackageOptionsLocal, PackageSource, SnowpackConfig} from '../types';
 import {
   createInstallTarget,
@@ -627,7 +627,14 @@ export class PackageSourceLocal implements PackageSource {
         const packageImports = new Set<string>();
         const code = loadedFile.toString('utf8');
         for (const imp of await scanCodeImportsExports(code)) {
-          const spec = code.substring(imp.s, imp.e).replace(/(\/|\\)+$/, ''); // remove trailing slash from end of specifier (easier for Node to resolve)
+          let spec = getWebModuleSpecifierFromCode(code, imp);
+          if(spec === null) {
+            continue;
+          }
+
+          // remove trailing slash from end of specifier (easier for Node to resolve)
+          spec = spec.replace(/(\/|\\)+$/, '');
+
           if (isRemoteUrl(spec)) {
             continue;
           }

--- a/test/build/config-loading-esm-package/package.json
+++ b/test/build/config-loading-esm-package/package.json
@@ -7,6 +7,6 @@
     "testbuild": "snowpack build"
   },
   "dependencies": {
-    "snowpack": "^3.8.0"
+    "snowpack": "^3.8.1"
   }
 }

--- a/test/build/config-loading-mjs/package.json
+++ b/test/build/config-loading-mjs/package.json
@@ -6,6 +6,6 @@
     "testbuild": "snowpack build"
   },
   "dependencies": {
-    "snowpack": "^3.8.0"
+    "snowpack": "^3.8.1"
   }
 }

--- a/test/build/entrypoint-ids/package.json
+++ b/test/build/entrypoint-ids/package.json
@@ -16,6 +16,6 @@
     "ansi-styles": "*"
   },
   "devDependencies": {
-    "snowpack": "^3.8.0"
+    "snowpack": "^3.8.1"
   }
 }

--- a/test/build/import-assets/package.json
+++ b/test/build/import-assets/package.json
@@ -8,6 +8,6 @@
     "testbuild": "snowpack build"
   },
   "devDependencies": {
-    "snowpack": "^3.8.0"
+    "snowpack": "^3.8.1"
   }
 }

--- a/test/build/package-bootstrap/package.json
+++ b/test/build/package-bootstrap/package.json
@@ -15,6 +15,6 @@
     "bootstrap": "^4.5.2"
   },
   "devDependencies": {
-    "snowpack": "^3.8.0"
+    "snowpack": "^3.8.1"
   }
 }

--- a/test/build/package-workspace/package.json
+++ b/test/build/package-workspace/package.json
@@ -7,7 +7,7 @@
     "testbuild": "snowpack build"
   },
   "devDependencies": {
-    "snowpack": "^3.8.0"
+    "snowpack": "^3.8.1"
   },
   "dependencies": {
     "test-workspace-component": "^1.0.0"

--- a/test/build/plugin-build-script/package.json
+++ b/test/build/plugin-build-script/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@babel/cli": "^7.10.5",
     "@snowpack/plugin-build-script": "^2.0.0",
-    "snowpack": "^3.8.0"
+    "snowpack": "^3.8.1"
   },
   "dependencies": {
     "@babel/preset-typescript": "^7.13.0"

--- a/test/build/plugin-hook-optimize/package.json
+++ b/test/build/plugin-hook-optimize/package.json
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@snowpack/plugin-optimize": "^0.2.0",
-    "snowpack": "^3.8.0"
+    "snowpack": "^3.8.1"
   }
 }

--- a/test/build/plugin-run-script/package.json
+++ b/test/build/plugin-run-script/package.json
@@ -9,6 +9,6 @@
   "devDependencies": {
     "@snowpack/plugin-run-script": "^2.0.0",
     "sass": "^1.26.10",
-    "snowpack": "^3.8.0"
+    "snowpack": "^3.8.1"
   }
 }

--- a/test/build/prepare-external-package/package.json
+++ b/test/build/prepare-external-package/package.json
@@ -19,7 +19,7 @@
     }
   },
   "devDependencies": {
-    "snowpack": "^3.8.0"
+    "snowpack": "^3.8.1"
   },
   "dependencies": {
     "array-flatten": "^3.0.0"

--- a/test/esinstall/alias/package.json
+++ b/test/esinstall/alias/package.json
@@ -9,6 +9,6 @@
     "vue-currency-input": "^1.21.0"
   },
   "devDependencies": {
-    "snowpack": "^3.8.0"
+    "snowpack": "^3.8.1"
   }
 }

--- a/test/esinstall/config-package-svelte/package.json
+++ b/test/esinstall/config-package-svelte/package.json
@@ -7,6 +7,6 @@
     "simple-svelte-autocomplete": "1.2.4"
   },
   "devDependencies": {
-    "snowpack": "^3.8.0"
+    "snowpack": "^3.8.1"
   }
 }

--- a/test/esinstall/dep-list-simple/package.json
+++ b/test/esinstall/dep-list-simple/package.json
@@ -4,6 +4,6 @@
   "name": "@snowpack/test-dep-list-simple",
   "dependencies": {
     "async": "3.1.0",
-    "snowpack": "^3.8.0"
+    "snowpack": "^3.8.1"
   }
 }

--- a/test/esinstall/error-missing-dep/package.json
+++ b/test/esinstall/error-missing-dep/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.1",
   "name": "@snowpack/test-error-missing-dep",
   "devDependencies": {
-    "snowpack": "^3.8.0"
+    "snowpack": "^3.8.1"
   }
 }

--- a/test/esinstall/exclude-external-packages/package.json
+++ b/test/esinstall/exclude-external-packages/package.json
@@ -7,6 +7,6 @@
     "react-dom": "17.0.1"
   },
   "devDependencies": {
-    "snowpack": "^3.8.0"
+    "snowpack": "^3.8.1"
   }
 }

--- a/test/esinstall/exports-only-no-main/package.json
+++ b/test/esinstall/exports-only-no-main/package.json
@@ -10,6 +10,6 @@
     "exports-only-no-main": "file:./pkg"
   },
   "devDependencies": {
-    "snowpack": "^3.8.0"
+    "snowpack": "^3.8.1"
   }
 }

--- a/test/esinstall/exports-only/package.json
+++ b/test/esinstall/exports-only/package.json
@@ -10,6 +10,6 @@
     "exports-only": "file:./pkg"
   },
   "devDependencies": {
-    "snowpack": "^3.8.0"
+    "snowpack": "^3.8.1"
   }
 }

--- a/test/esinstall/import-nothing/package.json
+++ b/test/esinstall/import-nothing/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.1",
   "name": "@snowpack/test-import-nothing",
   "devDependencies": {
-    "snowpack": "^3.8.0"
+    "snowpack": "^3.8.1"
   }
 }

--- a/test/esinstall/named-exports/package.json
+++ b/test/esinstall/named-exports/package.json
@@ -13,6 +13,6 @@
     "umd-named-exports": "file:./packages/umd-named-exports"
   },
   "devDependencies": {
-    "snowpack": "^3.8.0"
+    "snowpack": "^3.8.1"
   }
 }

--- a/test/esinstall/package-node-fetch/package.json
+++ b/test/esinstall/package-node-fetch/package.json
@@ -17,6 +17,6 @@
     "dep-node-fetch-mock-pkg": "file:./packages/dep-node-fetch-mock-pkg"
   },
   "devDependencies": {
-    "snowpack": "^3.8.0"
+    "snowpack": "^3.8.1"
   }
 }

--- a/test/esinstall/package-react/package.json
+++ b/test/esinstall/package-react/package.json
@@ -8,6 +8,6 @@
     "react-dom": "16.13.1"
   },
   "devDependencies": {
-    "snowpack": "^3.8.0"
+    "snowpack": "^3.8.1"
   }
 }

--- a/test/esinstall/rollup/package.json
+++ b/test/esinstall/rollup/package.json
@@ -11,6 +11,6 @@
     "svelte-routing": "^1.4.0"
   },
   "devDependencies": {
-    "snowpack": "^3.8.0"
+    "snowpack": "^3.8.1"
   }
 }

--- a/test/snowpack/runtime/runtime.test.js
+++ b/test/snowpack/runtime/runtime.test.js
@@ -238,4 +238,46 @@ describe('runtime', () => {
       await fixture.cleanup();
     }
   });
+
+  it('Installs dynamic imports', async () => {
+    const fixture = await testRuntimeFixture({
+      'packages/@owner/dyn/package.json': dedent`
+        {
+          "version": "1.0.0",
+          "name": "@owner/dyn",
+          "module": "main.js"
+        }
+      `,
+      'packages/@owner/dyn/sub/path.js': dedent`
+        export default 2;
+      `,
+      'package.json': dedent`
+        {
+          "version": "1.0.1",
+          "name": "@snowpack/test-runtime-import-dynamic-pkg",
+          "dependencies": {
+            "@owner/dyn": "file:./packages/@owner/dyn"
+          }
+        }
+      `,
+      'main.js': dedent`
+        const promise = import('@owner/dyn/sub/path.js');
+
+        export default async function() {
+          let mod = await promise;
+          return mod.default;
+        }
+      `
+    });
+
+    try {
+      let mod = await fixture.runtime.importModule('/main.js');
+      let promise = mod.exports.default();
+      let value = await promise;
+      console.log(value);
+      expect(value).toEqual(2);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
 });


### PR DESCRIPTION
## Changes

This fixes dynamic import scanning (for packages). If you do:

```js
if(condition) {
  const mod = await import('pkg/path.js');
}
```

We'll now correctly install such packages.

## Testing

Test added

## Docs

Bug fix only
