### PR TITLE
Support dynamic import scanning

### DIFF
--- a/.changeset/curly-dancers-double.md
+++ b/.changeset/curly-dancers-double.md
@@ -1,0 +1,5 @@
+---
+'snowpack': patch
+---
+
+Fixes scanning of dynamic imports on packages

--- a/snowpack/src/scan-imports.ts
+++ b/snowpack/src/scan-imports.ts
@@ -83,7 +83,7 @@ export function matchDynamicImportValue(importStatement: string) {
   return matched?.[2] || matched?.[3] || null;
 }
 
-function getWebModuleSpecifierFromCode(code: string, imp: ImportSpecifier) {
+export function getWebModuleSpecifierFromCode(code: string, imp: ImportSpecifier): string | null {
   // import.meta: we can ignore
   if (imp.d === -2) {
     return null;

--- a/snowpack/src/sources/local.ts
+++ b/snowpack/src/sources/local.ts
@@ -16,7 +16,7 @@ import slash from 'slash';
 import {getBuiltFileUrls} from '../build/file-urls';
 import {logger} from '../logger';
 import {scanCodeImportsExports, transformFileImports} from '../rewrite-imports';
-import {getInstallTargets} from '../scan-imports';
+import {getInstallTargets, getWebModuleSpecifierFromCode} from '../scan-imports';
 import {ImportMap, PackageOptionsLocal, PackageSource, SnowpackConfig} from '../types';
 import {
   createInstallTarget,
@@ -627,7 +627,14 @@ export class PackageSourceLocal implements PackageSource {
         const packageImports = new Set<string>();
         const code = loadedFile.toString('utf8');
         for (const imp of await scanCodeImportsExports(code)) {
-          const spec = code.substring(imp.s, imp.e).replace(/(\/|\\)+$/, ''); // remove trailing slash from end of specifier (easier for Node to resolve)
+          let spec = getWebModuleSpecifierFromCode(code, imp);
+          if(spec === null) {
+            continue;
+          }
+
+          // remove trailing slash from end of specifier (easier for Node to resolve)
+          spec = spec.replace(/(\/|\\)+$/, '');
+
           if (isRemoteUrl(spec)) {
             continue;
           }

--- a/test/snowpack/runtime/runtime.test.js
+++ b/test/snowpack/runtime/runtime.test.js
@@ -238,4 +238,46 @@ describe('runtime', () => {
       await fixture.cleanup();
     }
   });
+
+  it('Installs dynamic imports', async () => {
+    const fixture = await testRuntimeFixture({
+      'packages/@owner/dyn/package.json': dedent`
+        {
+          "version": "1.0.0",
+          "name": "@owner/dyn",
+          "module": "main.js"
+        }
+      `,
+      'packages/@owner/dyn/sub/path.js': dedent`
+        export default 2;
+      `,
+      'package.json': dedent`
+        {
+          "version": "1.0.1",
+          "name": "@snowpack/test-runtime-import-dynamic-pkg",
+          "dependencies": {
+            "@owner/dyn": "file:./packages/@owner/dyn"
+          }
+        }
+      `,
+      'main.js': dedent`
+        const promise = import('@owner/dyn/sub/path.js');
+
+        export default async function() {
+          let mod = await promise;
+          return mod.default;
+        }
+      `
+    });
+
+    try {
+      let mod = await fixture.runtime.importModule('/main.js');
+      let promise = mod.exports.default();
+      let value = await promise;
+      console.log(value);
+      expect(value).toEqual(2);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
 });


### PR DESCRIPTION
## Changes

This fixes dynamic import scanning (for packages). If you do:

if(condition) {
  const mod = await import('pkg/path.js');
}
We'll now correctly install such packages.

## Testing

Test added

## Docs

Bug fix only
