### PR TITLE
Fix typo in error message

### DIFF
--- a/esinstall/src/entrypoints.ts
+++ b/esinstall/src/entrypoints.ts
@@ -213,7 +213,7 @@ export function resolveEntrypoint(
       if (npmName && npmName.startsWith('@')) npmName += '/' + parts.shift();
       throw new Error(
         `Module "${dep}" not found.
-    If you‘re trying to CSS file from your project, try "./${dep}".
+    If you‘re trying to import a CSS file from your project, try "./${dep}".
     If you‘re trying to import an NPM package, try running \`npm install ${npmName}\` and re-running Snowpack.`,
       );
     }


### PR DESCRIPTION
## Changes

Fixes a minor typo in an error message. The correction follows the same template for NPM packages.

### Before
`If you‘re trying to CSS file from your project, try "./${dep}"`
### After
`If you‘re trying to import a CSS file from your project, try "./${dep}".`
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing
No testing since this is only a typo fix in an error message.
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs
No need for updating docs since this is only a typo fix in an error message.
<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
