### PR TITLE
Set `build --watch` package paths to be relative to `/_snowpack/pkg/`

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -509,7 +509,7 @@ export async function startServer(
       }
       const resourcePath = reqPath.replace(/\.map$/, '').replace(/\.proxy\.js$/, '');
       const webModuleUrl = resourcePath.substr(PACKAGE_PATH_PREFIX.length);
-      let loadedModule = await pkgSource.load(webModuleUrl, {isSSR});
+      let loadedModule = await pkgSource.load(webModuleUrl, {isSSR, isWatch});
       if (!loadedModule) {
         throw new NotFoundError(reqPath);
       }

--- a/snowpack/src/rewrite-imports.ts
+++ b/snowpack/src/rewrite-imports.ts
@@ -65,7 +65,8 @@ export async function transformEsmImports(
       }
       // Rewrite the path to be relative when using --watch.
       if (isWatch) {
-        rewrittenImport = rewrittenImport.replace(`${metaUrlPath}/pkg/`, './')
+        const pkgRegex = new RegExp(`^${metaUrlPath}/pkg/`);
+        rewrittenImport = rewrittenImport.replace(pkgRegex, './');
       }
       collectedRewrites.push({rewrite: rewrittenImport, start: imp.s, end: imp.e});
     }),

--- a/snowpack/src/rewrite-imports.ts
+++ b/snowpack/src/rewrite-imports.ts
@@ -44,6 +44,7 @@ export async function transformEsmImports(
   _code: string,
   replaceImport: (specifier: string) => string | Promise<string>,
   isWatch?: boolean,
+  metaUrlPath?: string,
 ) {
   const imports = await scanCodeImportsExports(_code);
   const collectedRewrites: RewriteInstruction[] = [];
@@ -64,7 +65,7 @@ export async function transformEsmImports(
       }
       // Rewrite the path to be relative when using --watch.
       if (isWatch) {
-        rewrittenImport = rewrittenImport.replace('/_snowpack/pkg/', './')
+        rewrittenImport = rewrittenImport.replace(`${metaUrlPath}/pkg/`, './')
       }
       collectedRewrites.push({rewrite: rewrittenImport, start: imp.s, end: imp.e});
     }),
@@ -129,11 +130,11 @@ async function transformCssImports(
 }
 
 export async function transformFileImports(
-  {type, contents, isWatch}: {type: string; contents: string; isWatch?: boolean},
+  {type, contents, isWatch, metaUrlPath}: {type: string; contents: string; isWatch?: boolean; metaUrlPath?: string},
   replaceImport: (specifier: string) => string | Promise<string>,
 ) {
   if (type === '.js') {
-    return transformEsmImports(contents, replaceImport, isWatch);
+    return transformEsmImports(contents, replaceImport, isWatch, metaUrlPath);
   }
   if (type === '.html') {
     return transformHtmlImports(contents, replaceImport);

--- a/snowpack/src/sources/local.ts
+++ b/snowpack/src/sources/local.ts
@@ -269,7 +269,7 @@ export class PackageSourceLocal implements PackageSource {
     }
   }
 
-  async load(id: string, {isSSR}: {isSSR?: boolean} = {}) {
+  async load(id: string, {isSSR, isWatch}: {isSSR?: boolean; isWatch?: boolean} = {}) {
     const {config, allPackageImports} = this;
     const packageImport = allPackageImports[id];
     if (!packageImport) {
@@ -325,7 +325,7 @@ export class PackageSourceLocal implements PackageSource {
       // Otherwise, resolve this specifier as an external package.
       return await this.resolvePackageImport(spec, {source: entrypoint});
     };
-    packageCode = await transformFileImports({type, contents: packageCode}, async (spec) => {
+    packageCode = await transformFileImports({type, contents: packageCode, isWatch}, async (spec) => {
       let resolvedImportUrl = await resolveImport(spec);
       const importExtName = path.posix.extname(resolvedImportUrl);
       const isProxyImport = importExtName && importExtName !== '.js' && importExtName !== '.mjs';

--- a/snowpack/src/sources/local.ts
+++ b/snowpack/src/sources/local.ts
@@ -325,7 +325,7 @@ export class PackageSourceLocal implements PackageSource {
       // Otherwise, resolve this specifier as an external package.
       return await this.resolvePackageImport(spec, {source: entrypoint});
     };
-    packageCode = await transformFileImports({type, contents: packageCode, isWatch}, async (spec) => {
+    packageCode = await transformFileImports({type, contents: packageCode, isWatch, metaUrlPath: config.buildOptions.metaUrlPath}, async (spec) => {
       let resolvedImportUrl = await resolveImport(spec);
       const importExtName = path.posix.extname(resolvedImportUrl);
       const isProxyImport = importExtName && importExtName !== '.js' && importExtName !== '.mjs';

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -391,7 +391,7 @@ export interface PackageSource {
    */
   load(
     spec: string,
-    options: {isSSR: boolean},
+    options: {isSSR: boolean; isWatch: boolean},
   ): Promise<undefined | {contents: Buffer | string; imports: InstallTarget[]}>;
   /** Resolve a package import to URL (ex: "react" -> "/pkg/react") */
   resolvePackageImport(


### PR DESCRIPTION
## Changes

Identified by: #3487, #2931, #3065, and #3066

When running `build --watch` the package paths within `/_snowpack/pkg/` are all incorrectly derived from the dev server. In the dev server that path is correct, but when written to file the packages are often located within  a `/build/_snowpack/pkg/` directory.

Previously, package dependencies imported from an incorrect directory of `/_snowpack/pkg/`.

![image](https://user-images.githubusercontent.com/28543038/126359880-05220ca7-9860-45a6-bb73-6435cb90ab45.png)

Now they will import relative to the pkg directory.

![image](https://user-images.githubusercontent.com/28543038/126362062-404c0249-f8da-4f9a-ae20-9eb20b12d15f.png)

I would assume there is a better way to fix this rather than passing around an `isWatch` config, but this solves the problem for now.

## Testing

I'm not quite sure how to run a test for `build --watch` due to it continuing to watch for changes so never exiting the test. I made a test locally and then manually stopped it just to make sure the code worked, but it's not something that can be committed without messing up the CI. Happy to make one with some direction.

## Docs

bug fix only
