### PR TITLE
Fix SSR Runtime bug with default exports

### DIFF
--- a/.changeset/wise-bulldogs-sin.md
+++ b/.changeset/wise-bulldogs-sin.md
@@ -1,0 +1,5 @@
+---
+'snowpack': patch
+---
+
+Fix a small SSR bug with default exports

--- a/snowpack/src/ssr-loader/transform.ts
+++ b/snowpack/src/ssr-loader/transform.ts
@@ -88,7 +88,7 @@ export function transform(data) {
     }
 
     if (node.type === 'ExportDefaultDeclaration') {
-      code.overwrite(node.start, node.declaration.start, `${exports}.default = `);
+      code.overwrite(node.start, node.declaration.start - 1, `${exports}.default = `);
     }
 
     if (node.type === 'ExportNamedDeclaration') {


### PR DESCRIPTION
## Changes

There was a small typo in the SSR Runtime `transform` step that would cause problems in very rare instances. Previously, we could generate a mismatched `)` due to the way we were overwriting `ExportDefaultDeclaration`. This fixes that!

## Testing

Looks like SSR Runtime is largely untested, so I'm not sure how to test this tbh...

## Docs

Bug fix only
