### PR TITLE
Fix HMR for circular dependencies

### DIFF
--- a/snowpack/src/dev/hmr.ts
+++ b/snowpack/src/dev/hmr.ts
@@ -41,6 +41,10 @@ export function startHmrEngine(
     } else {
       // We've reached the top, trigger a full page refresh
       hmrEngine.broadcastMessage({type: 'reload'});
+      visited.add('RELOAD_BROADCASTED');
+    }
+    if (!isBubbled && !visited.has('RELOAD_BROADCASTED')) {
+      hmrEngine.broadcastMessage({type: 'reload'});
     }
   }
 


### PR DESCRIPTION
## Changes

Circular dependencies cause hmr to no longer refresh the page. This fixes that. I outlined the problem and my proposed solution in #3607.

I had a few questions on my code changes that I'll include here as well since they seem relevant:
- Should reload always be triggered? Even if update has been triggered?
- What does "bubble" mean in this context? To me it seems to mean traverse the dependents, but I normally see it used in reference to events. Maybe it means the file change event?
- The visited.add('RELOAD_BROADCASTED'); seems a little hacky, we could add a parameter to the updateOrBubble function and change it to return a variable named isReloadBroadcasted or something. However, that seems to add a lot of complexity to the code that is already a little complex due to the recursion.

## Testing

I didn't see any existing tests for hmr, and am not familiar enough with how hmr works to feel comfortable creating tests for that. I can create some if necessary.

`yarn test:dev` failed before and after my changes complaining about the number of assertions, but `yarn test` passed before and after. 

## Docs

bug fix only
