### PR TITLE
Exclude @vue/runtime-core from processing, to fix Vue SSR for nested components

### DIFF
--- a/.changeset/brown-meals-sniff.md
+++ b/.changeset/brown-meals-sniff.md
@@ -1,0 +1,5 @@
+---
+"@snowpack/plugin-vue": patch
+---
+
+Exclude @vue/runtime-core from processing, to fix Vue SSR for nested components

--- a/plugins/plugin-vue/plugin.js
+++ b/plugins/plugin-vue/plugin.js
@@ -62,6 +62,13 @@ module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
       input: ['.vue'],
       output: ['.js', '.css'],
     },
+    config(snowpackConfig) {
+      snowpackConfig.packageOptions = snowpackConfig.packageOptions || {}
+      snowpackConfig.packageOptions.external = snowpackConfig.packageOptions.external || []
+      snowpackConfig.packageOptions.external.push('@vue/runtime-core')
+
+      return snowpackConfig
+    },
     async load({filePath, isSSR}) {
       const {sourcemap, sourceMaps} = snowpackConfig.buildOptions;
 


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

It adds a `@vue/runtime-core` package to `packageOptions.external` of the `@snowpack/plugin-vue` config. 

More description about root causes of the issue are there -> https://github.com/snowpackjs/astro/issues/828

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

I was using a slightly modified version of Astro Vue app - https://github.com/Igloczek/astro-vue-nested-components
Then changed `node_modules/@snowpack/plugin-vue/plugin.js` to contains my changes, and run Astro.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
It's just a bugfix.