### PR TITLE
Remove mime override of transpiled HTML files

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -622,6 +622,7 @@ export async function startServer(
         throw new NotFoundError(reqPath, [attemptedFileLoc]);
       }
       let foundType = path.extname(reqPath);
+      if (!foundType && attemptedFileLoc.endsWith('.html')) foundType = '.html';
       if (IS_DOTFILE_REGEX.test(reqPath)) foundType = '';
       foundFile = {
         loc: attemptedFileLoc,
@@ -668,6 +669,7 @@ export async function startServer(
       // but we hope to add "virtual file" support soon via plugins. This would
       // be the interface for those response types.
       let foundType = path.extname(reqPath);
+      if (!foundType && attemptedFileLoc.endsWith('.html')) foundType = '.html';
       if (IS_DOTFILE_REGEX.test(reqPath)) foundType = '';
       foundFile = {
         loc: attemptedFileLoc,

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -622,7 +622,6 @@ export async function startServer(
         throw new NotFoundError(reqPath, [attemptedFileLoc]);
       }
       let foundType = path.extname(reqPath);
-      if (attemptedFileLoc.endsWith('.html')) foundType = '.html';
       if (IS_DOTFILE_REGEX.test(reqPath)) foundType = '';
       foundFile = {
         loc: attemptedFileLoc,
@@ -669,7 +668,6 @@ export async function startServer(
       // but we hope to add "virtual file" support soon via plugins. This would
       // be the interface for those response types.
       let foundType = path.extname(reqPath);
-      if (attemptedFileLoc.endsWith('.html')) foundType = '.html';
       if (IS_DOTFILE_REGEX.test(reqPath)) foundType = '';
       foundFile = {
         loc: attemptedFileLoc,


### PR DESCRIPTION
## Changes

This removes the mime override that occurs on HTML files transformed into JS with a Snowpack plugin, resolving https://github.com/snowpackjs/astro/issues/944

The cause and solution were both identified by @matthewp. Thank you!

> As far as I can tell, that part doesn't seem intentional so we can probably remove it
> — [@matthewp](https://discord.com/channels/830184174198718474/845451724738265138/870662973067264020)

And so, here it is. Or, er, isn’t!

## Testing

1. Create an astro project (`npx create-astro`).
2. Add the snowpack plugin as described in https://github.com/snowpackjs/astro/issues/944 (and link to it within `snowpack.config.json`).
3. Create a file (like `components/Hello.module.html`).
4. Start Astro and visit `http://localhost:3000/_astro/src/components/Hello.module.html.js`.
5. Before the fix, the mime type remains `text/html`. After the fix, the mime type becomes `application/javascript`.

## Docs

No public documentation is affected by this change.