### PR TITLE
support multiple onFileChange event handlers

### DIFF
--- a/.changeset/long-actors-march.md
+++ b/.changeset/long-actors-march.md
@@ -1,0 +1,5 @@
+---
+'snowpack': patch
+---
+
+Fix issue where multiple onFileChange handlers overwrote each other


### PR DESCRIPTION
## Changes

- Currently, `onFileChange` is stored as a single callback.
- This means that every call to `onFileChange` overwrite the existing callback.
- bug: because Snowpack uses an `onFileChange()` handler internally for SSR, SSR support degrades when a custom `onFileChange()` handler is added.
- This adds support for multiple onFileChange handlers, fixing the bug.

## Testing

- No tests for this API. +1 for adding them but this PR is so small I'd like to avoid that work here.

## Docs

- Bug fix, no docs needed.