### PR TITLE
Use the correct resourceType on linked proxy imports

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -612,6 +612,7 @@ export async function startServer(
       let attemptedFileLoc = fileToUrlMapping.key(reqPath);
       if (!attemptedFileLoc) {
         resourcePath = reqPath.replace(/\.map$/, '').replace(/\.proxy\.js$/, '');
+        resourceType = path.extname(resourcePath);
       }
       attemptedFileLoc = fileToUrlMapping.key(resourcePath);
       if (!attemptedFileLoc) {


### PR DESCRIPTION
For https://github.com/snowpackjs/astro/issues/915

## Changes

This changes the resourceType (which is the file extension) when encountering a proxy file.

This makes importing CSS/PNG/etc. from a workspace project work.

## Testing

No test added, can't really test this scenario of the dev server.

## Docs

Bug fix only
