### PR TITLE
Revert "Set `build --watch` package paths to be relative to `/_snowpa…

### DIFF
--- a/.changeset/empty-coats-cough.md
+++ b/.changeset/empty-coats-cough.md
@@ -1,0 +1,5 @@
+---
+'snowpack': patch
+---
+
+Fixes a regression caused by #3597

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -509,7 +509,7 @@ export async function startServer(
       }
       const resourcePath = reqPath.replace(/\.map$/, '').replace(/\.proxy\.js$/, '');
       const webModuleUrl = resourcePath.substr(PACKAGE_PATH_PREFIX.length);
-      let loadedModule = await pkgSource.load(webModuleUrl, {isSSR, isWatch});
+      let loadedModule = await pkgSource.load(webModuleUrl, {isSSR});
       if (!loadedModule) {
         throw new NotFoundError(reqPath);
       }

--- a/snowpack/src/rewrite-imports.ts
+++ b/snowpack/src/rewrite-imports.ts
@@ -43,8 +43,6 @@ export async function scanCodeImportsExports(code: string): Promise<any[]> {
 export async function transformEsmImports(
   _code: string,
   replaceImport: (specifier: string) => string | Promise<string>,
-  isWatch?: boolean,
-  metaUrlPath?: string,
 ) {
   const imports = await scanCodeImportsExports(_code);
   const collectedRewrites: RewriteInstruction[] = [];
@@ -62,11 +60,6 @@ export async function transformEsmImports(
         rewrittenImport = webpackMagicCommentMatches
           ? `${webpackMagicCommentMatches.join(' ')} ${JSON.stringify(rewrittenImport)}`
           : JSON.stringify(rewrittenImport);
-      }
-      // Rewrite the path to be relative when using --watch.
-      if (isWatch) {
-        const pkgRegex = new RegExp(`^${metaUrlPath}/pkg/`);
-        rewrittenImport = rewrittenImport.replace(pkgRegex, './');
       }
       collectedRewrites.push({rewrite: rewrittenImport, start: imp.s, end: imp.e});
     }),
@@ -131,16 +124,11 @@ async function transformCssImports(
 }
 
 export async function transformFileImports(
-  {
-    type,
-    contents,
-    isWatch,
-    metaUrlPath,
-  }: {type: string; contents: string; isWatch?: boolean; metaUrlPath?: string},
+  {type, contents}: {type: string; contents: string},
   replaceImport: (specifier: string) => string | Promise<string>,
 ) {
   if (type === '.js') {
-    return transformEsmImports(contents, replaceImport, isWatch, metaUrlPath);
+    return transformEsmImports(contents, replaceImport);
   }
   if (type === '.html') {
     return transformHtmlImports(contents, replaceImport);

--- a/snowpack/src/sources/local.ts
+++ b/snowpack/src/sources/local.ts
@@ -269,7 +269,7 @@ export class PackageSourceLocal implements PackageSource {
     }
   }
 
-  async load(id: string, {isSSR, isWatch}: {isSSR?: boolean; isWatch?: boolean} = {}) {
+  async load(id: string, {isSSR}: {isSSR?: boolean} = {}) {
     const {config, allPackageImports} = this;
     const packageImport = allPackageImports[id];
     if (!packageImport) {
@@ -326,7 +326,7 @@ export class PackageSourceLocal implements PackageSource {
       return await this.resolvePackageImport(spec, {source: entrypoint});
     };
     packageCode = await transformFileImports(
-      {type, contents: packageCode, isWatch, metaUrlPath: config.buildOptions.metaUrlPath},
+      {type, contents: packageCode},
       async (spec) => {
         let resolvedImportUrl = await resolveImport(spec);
         const importExtName = path.posix.extname(resolvedImportUrl);

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -391,7 +391,7 @@ export interface PackageSource {
    */
   load(
     spec: string,
-    options: {isSSR: boolean; isWatch: boolean},
+    options: {isSSR: boolean},
   ): Promise<undefined | {contents: Buffer | string; imports: InstallTarget[]}>;
   /** Resolve a package import to URL (ex: "react" -> "/pkg/react") */
   resolvePackageImport(


### PR DESCRIPTION
…ck/pkg/` (#3597)"

This reverts commit 5b44adf3a02d7fc58e26e81c203a448a095a7caf.

This change, and specifically this part: https://github.com/snowpackjs/snowpack/compare/revert-watch2?expand=1#diff-72af5cfd522413829d8d2ff64402719a6d21f89f196be3c7897921d2f6eae341L68-L69

Was breaking Astro.