### PR TITLE
Safer /api/ string replace regex

### DIFF
--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -48,7 +48,7 @@ export default {
       src: '/api/.*',
       dest: (req, res) => {
         // remove /api prefix (optional)
-        req.url = req.url.replace(/^\/api/, '');
+        req.url = req.url.replace(/^\/api\//, '/');
 
         return proxy.web(req, res, {
           hostname: 'localhost',


### PR DESCRIPTION
## Changes

Edits the example proxy api route to show a better regex. 
- The current docs have an invalid regex, though the docfile had a corrected one
- That corrected one would still replace /apigldjg routes though
- The new regex only replaces /api/ at the beginning of the string with /

## Testing

The regex was tested on the console?

## Docs

This is only a change to the docs for a better example.
