### PR TITLE
throw a error when a CJS export is used in a ESM file

### DIFF
--- a/snowpack/assets/require-or-import.js
+++ b/snowpack/assets/require-or-import.js
@@ -9,53 +9,40 @@ const r = require('resolve');
  * @param {string} filepath
  */
 module.exports = async function requireOrImport(filepath, {from = process.cwd()} = {}) {
-  return new Promise((resolve, reject) => {
-    if (filepath.startsWith('node:')) {
-      return NATIVE_IMPORT(filepath).then(
-        (mdl) => resolve(mdl),
-        (err) => reject(err),
-      );
-    }
+  if (filepath.startsWith('node:')) {
+    return NATIVE_IMPORT(filepath);
+  }
 
-    // Resolve path based on `from`
-    const resolvedPath = r.sync(filepath, {
-      basedir: from,
-    });
-    try {
-      const mdl = NATIVE_REQUIRE(resolvedPath);
-
-      // Add a `default` property on a CommonJS export so that it can be accessed from import statements.
-      // This is set to enumerable: false to make it hidden(ish) to code.
-      if (mdl && !('default' in mdl)) {
-        Object.defineProperty(mdl, 'default', {
-          configurable: true,
-          enumerable: false,
-          writable: true,
-          value: mdl,
-        });
-      }
-
-      resolve(mdl);
-    } catch (e) {
-      if (e instanceof SyntaxError && /export|import/.test(e.message)) {
-        console.error(
-          `Failed to load "${filepath}"!\nESM format is not natively supported in "node@${process.version}".\nPlease use CommonJS or upgrade to an LTS version of node above "node@12.17.0".`,
-        );
-      } else if (e.code === 'ERR_REQUIRE_ESM') {
-        const url = pathToFileURL(resolvedPath);
-        return NATIVE_IMPORT(url).then(
-          (mdl) => resolve(mdl.default ? mdl.default : mdl),
-          (err) => reject(err),
-        );
-      }
-      try {
-        return NATIVE_IMPORT(pathToFileURL(resolvedPath)).then(
-          (mdl) => resolve(mdl.default ? mdl.default : mdl),
-          (err) => reject(err),
-        );
-      } catch (e) {
-        reject(e);
-      }
-    }
+  // Resolve path based on `from`
+  const resolvedPath = r.sync(filepath, {
+    basedir: from,
   });
+  try {
+    const mdl = NATIVE_REQUIRE(resolvedPath);
+
+    // Add a `default` property on a CommonJS export so that it can be accessed from import statements.
+    // This is set to enumerable: false to make it hidden(ish) to code.
+    if (mdl && !('default' in mdl)) {
+      Object.defineProperty(mdl, 'default', {
+        configurable: true,
+        enumerable: false,
+        writable: true,
+        value: mdl,
+      });
+    }
+
+    return mdl;
+  } catch (e) 
+    if (e instanceof SyntaxError && /export|import/.test(e.message)) {
+      console.error(`Failed to load "${filepath}"!\nESM format is not natively supported in "node@${process.version}".\nPlease use CommonJS or upgrade to an LTS version of node above "node@12.17.0".`);
+    } else {
+      try {
+        return await import(pathToFileURL(resolvedPath)).then(mdl => mdl.default || mdl);
+      } catch (e) {
+        console.error(`Failed to load "${filepath}"!\nThis file is treated as an ES module because it has a '.mjs' file extension or nearest parent package.json contains "type": "module". Please rename this file to end in .cjs, change the code to use ESM export, or remove "type": "module" from package.json.`);
+      }
+    }
+
+    process.exit(1);
+  }
 };


### PR DESCRIPTION
## Changes

Fixes: https://github.com/snowpackjs/snowpack/issues/3441

This returns a useful error to the user instead of an error that may be more complicated to understand.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

bug fix only