### PR TITLE
Remove default language option from app-template-svelte-typescript

### DIFF
--- a/.changeset/long-spiders-jump.md
+++ b/.changeset/long-spiders-jump.md
@@ -1,0 +1,5 @@
+---
+'@snowpack/app-template-svelte-typescript': patch
+---
+
+Remove default language option as its use is discouraged

--- a/create-snowpack-app/app-template-svelte-typescript/svelte.config.js
+++ b/create-snowpack-app/app-template-svelte-typescript/svelte.config.js
@@ -1,9 +1,5 @@
 const autoPreprocess = require('svelte-preprocess');
 
 module.exports = {
-  preprocess: autoPreprocess({
-    defaults: {
-      script: 'typescript',
-    },
-  }),
+  preprocess: autoPreprocess(),
 };


### PR DESCRIPTION
## Changes

Remove the default language option from app-template-svelte-typescript. It's discouraged to use because tooling is not able to deal with it in all cases: https://github.com/sveltejs/svelte-preprocess/blob/main/docs/preprocessing.md#auto-preprocessing-options

## Testing

Manual test done; there are no tests for the starters

## Docs

Does not apply
