### PR TITLE
Correct small screen overflow on Firefox

### DIFF
--- a/www/src/pages/index.astro
+++ b/www/src/pages/index.astro
@@ -43,7 +43,7 @@ let description = 'Snowpack is a lightning-fast frontend build tool, designed fo
       text-align: center;
 
       img {
-        max-width: 32rem;
+        max-width: min(32rem, 100%);
       }
     }
 


### PR DESCRIPTION
## Changes
Limit max width on home page header image

Before:
![image](https://user-images.githubusercontent.com/5839548/130159841-ddc3d55e-cb98-4bad-8a78-56b37d27343a.png)

After:
![image](https://user-images.githubusercontent.com/5839548/130159896-f63c6486-29a1-4047-aea5-31c502da9391.png)


## Testing

This was tested in firefox using the CSS editor. Browser support for this feature was checked at CanIUse
https://caniuse.com/?search=min

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
Bug fix only
