### PR TITLE
fix(snowpack): add missing dependency `magic-string`

### DIFF
--- a/.changeset/late-pots-taste.md
+++ b/.changeset/late-pots-taste.md
@@ -1,0 +1,5 @@
+---
+'snowpack': patch
+---
+
+Fixes a ghost dependency on 'magic-string'

--- a/snowpack/package.json
+++ b/snowpack/package.json
@@ -67,6 +67,7 @@
     "isbinaryfile": "^4.0.6",
     "jsonschema": "~1.2.5",
     "kleur": "^4.1.1",
+    "magic-string": "^0.25.7",
     "meriyah": "^3.1.6",
     "mime-types": "^2.1.26",
     "mkdirp": "^1.0.3",


### PR DESCRIPTION
## Changes

`snowpack` is using `magic-string` but doesn't declare it as a dependency so this PR adds it
https://github.com/snowpackjs/snowpack/blob/91da2b6af73bc7c639e3e94a6cf7010cd0e1e14a/snowpack/src/ssr-loader/transform.ts#L2

Ref https://github.com/snowpackjs/snowpack/issues/3591#issuecomment-901504691
Ref https://github.com/yarnpkg/berry/pull/3329

## Testing

By running snowpack in a strict dependency environment (Yarn PnP)

## Docs

Bugfix only