### PR TITLE
add option to disable env expanding in plugin-dotenv

### DIFF
--- a/.changeset/breezy-comics-glow.md
+++ b/.changeset/breezy-comics-glow.md
@@ -1,0 +1,5 @@
+---
+'@snowpack/plugin-dotenv': minor
+---
+
+Added an option to disable dotenv-expand functionality

--- a/plugins/plugin-dotenv/README.md
+++ b/plugins/plugin-dotenv/README.md
@@ -30,6 +30,7 @@ SNOWPACK_PUBLIC_ENABLE_FEATURE=true
 
 #### Plugin Options
 
-| Name  | Type     | Description                                                                                        |
-| :---- | :------- | :------------------------------------------------------------------------------------------------- |
-| `dir` | `string` | (optional) Where to find `.env` files. Default is your current working directory (`process.cwd()`) |
+| Name     | Type      | Description                                                                                        |
+| :------- | :-------- | :------------------------------------------------------------------------------------------------- |
+| `dir`    | `string`  | (optional) Where to find `.env` files. Default is your current working directory (`process.cwd()`) |
+| `expand` | `boolean` | (optional) Enable `dotenv-expand` support. Default is `true`                                       |

--- a/plugins/plugin-dotenv/plugin.js
+++ b/plugins/plugin-dotenv/plugin.js
@@ -16,6 +16,7 @@ module.exports = function plugin(snowpackConfig, options) {
   ].filter(Boolean);
 
   const dir = options && options.dir ? options.dir.toString() : '.';
+  const expand = options && options.expand !== undefined ? options.expand : true;
   // Load environment variables from .env* files. Suppress warnings using silent
   // if this file is missing. dotenv will never modify any environment variables
   // that have already been set.  Variable expansion is supported in .env files.
@@ -25,11 +26,11 @@ module.exports = function plugin(snowpackConfig, options) {
     dotenvFile = path.resolve(process.cwd(), dir, dotenvFile);
 
     if (fs.existsSync(dotenvFile)) {
-      require('dotenv-expand')(
-        require('dotenv').config({
-          path: dotenvFile,
-        }),
-      );
+      const dotenv = require('dotenv').config({
+        path: dotenvFile
+      });
+
+      if (expand) require('dotenv-expand')(dotenv);
     }
   });
 

--- a/plugins/plugin-dotenv/test/__snapshots__/plugin.test.js.snap
+++ b/plugins/plugin-dotenv/test/__snapshots__/plugin.test.js.snap
@@ -5,6 +5,7 @@ Object {
   "__DOTENV_DEVELOPMENT": "DEVELOPMENT",
   "__DOTENV_DEVELOPMENT_LOCAL": "DEVELOPMENT_LOCAL",
   "__DOTENV_ENV": "ENV",
+  "__DOTENV_EXPAND": "PRESET",
   "__DOTENV_LOCAL": "LOCAL",
   "__DOTENV_PRESET": "PRESET",
   "__DOTENV_PRODUCTION": "ENV",
@@ -19,6 +20,7 @@ Object {
   "__DOTENV_DEVELOPMENT": "ENV",
   "__DOTENV_DEVELOPMENT_LOCAL": "LOCAL",
   "__DOTENV_ENV": "ENV",
+  "__DOTENV_EXPAND": "PRESET",
   "__DOTENV_LOCAL": "LOCAL",
   "__DOTENV_PRESET": "PRESET",
   "__DOTENV_PRODUCTION": "PRODUCTION",
@@ -33,6 +35,7 @@ Object {
   "__DOTENV_DEVELOPMENT": "ENV",
   "__DOTENV_DEVELOPMENT_LOCAL": "ENV",
   "__DOTENV_ENV": "ENV",
+  "__DOTENV_EXPAND": "PRESET",
   "__DOTENV_LOCAL": "TEST",
   "__DOTENV_PRESET": "PRESET",
   "__DOTENV_PRODUCTION": "ENV",
@@ -47,6 +50,7 @@ Object {
   "__DOTENV_DEVELOPMENT": "ENV",
   "__DOTENV_DEVELOPMENT_LOCAL": "LOCAL",
   "__DOTENV_ENV": "ENV",
+  "__DOTENV_EXPAND": "PRESET",
   "__DOTENV_LOCAL": "LOCAL",
   "__DOTENV_PRESET": "PRESET",
   "__DOTENV_PRODUCTION": "ENV",
@@ -103,6 +107,126 @@ Object {
   "__DOTENV_DEVELOPMENT": "ENV",
   "__DOTENV_DEVELOPMENT_LOCAL": "LOCAL",
   "__DOTENV_ENV": "ENV",
+  "__DOTENV_LOCAL": "LOCAL",
+  "__DOTENV_PRESET": "PRESET",
+  "__DOTENV_PRODUCTION": "ENV",
+  "__DOTENV_PRODUCTION_LOCAL": "LOCAL",
+  "__DOTENV_TEST": "ENV",
+  "__DOTENV_TEST_LOCAL": "LOCAL",
+}
+`;
+
+exports[`with expand explicitly off development 1`] = `
+Object {
+  "__DOTENV_DEVELOPMENT": "DEVELOPMENT",
+  "__DOTENV_DEVELOPMENT_LOCAL": "DEVELOPMENT_LOCAL",
+  "__DOTENV_ENV": "ENV",
+  "__DOTENV_EXPAND": "\${__DOTENV_PRESET}",
+  "__DOTENV_LOCAL": "LOCAL",
+  "__DOTENV_PRESET": "PRESET",
+  "__DOTENV_PRODUCTION": "ENV",
+  "__DOTENV_PRODUCTION_LOCAL": "LOCAL",
+  "__DOTENV_TEST": "ENV",
+  "__DOTENV_TEST_LOCAL": "LOCAL",
+}
+`;
+
+exports[`with expand explicitly off production 1`] = `
+Object {
+  "__DOTENV_DEVELOPMENT": "ENV",
+  "__DOTENV_DEVELOPMENT_LOCAL": "LOCAL",
+  "__DOTENV_ENV": "ENV",
+  "__DOTENV_EXPAND": "\${__DOTENV_PRESET}",
+  "__DOTENV_LOCAL": "LOCAL",
+  "__DOTENV_PRESET": "PRESET",
+  "__DOTENV_PRODUCTION": "PRODUCTION",
+  "__DOTENV_PRODUCTION_LOCAL": "PRODUCTION_LOCAL",
+  "__DOTENV_TEST": "ENV",
+  "__DOTENV_TEST_LOCAL": "LOCAL",
+}
+`;
+
+exports[`with expand explicitly off test 1`] = `
+Object {
+  "__DOTENV_DEVELOPMENT": "ENV",
+  "__DOTENV_DEVELOPMENT_LOCAL": "ENV",
+  "__DOTENV_ENV": "ENV",
+  "__DOTENV_EXPAND": "\${__DOTENV_PRESET}",
+  "__DOTENV_LOCAL": "TEST",
+  "__DOTENV_PRESET": "PRESET",
+  "__DOTENV_PRODUCTION": "ENV",
+  "__DOTENV_PRODUCTION_LOCAL": "ENV",
+  "__DOTENV_TEST": "TEST",
+  "__DOTENV_TEST_LOCAL": "TEST_LOCAL",
+}
+`;
+
+exports[`with expand explicitly off undefined 1`] = `
+Object {
+  "__DOTENV_DEVELOPMENT": "ENV",
+  "__DOTENV_DEVELOPMENT_LOCAL": "LOCAL",
+  "__DOTENV_ENV": "ENV",
+  "__DOTENV_EXPAND": "\${__DOTENV_PRESET}",
+  "__DOTENV_LOCAL": "LOCAL",
+  "__DOTENV_PRESET": "PRESET",
+  "__DOTENV_PRODUCTION": "ENV",
+  "__DOTENV_PRODUCTION_LOCAL": "LOCAL",
+  "__DOTENV_TEST": "ENV",
+  "__DOTENV_TEST_LOCAL": "LOCAL",
+}
+`;
+
+exports[`with expand explicitly on development 1`] = `
+Object {
+  "__DOTENV_DEVELOPMENT": "DEVELOPMENT",
+  "__DOTENV_DEVELOPMENT_LOCAL": "DEVELOPMENT_LOCAL",
+  "__DOTENV_ENV": "ENV",
+  "__DOTENV_EXPAND": "PRESET",
+  "__DOTENV_LOCAL": "LOCAL",
+  "__DOTENV_PRESET": "PRESET",
+  "__DOTENV_PRODUCTION": "ENV",
+  "__DOTENV_PRODUCTION_LOCAL": "LOCAL",
+  "__DOTENV_TEST": "ENV",
+  "__DOTENV_TEST_LOCAL": "LOCAL",
+}
+`;
+
+exports[`with expand explicitly on production 1`] = `
+Object {
+  "__DOTENV_DEVELOPMENT": "ENV",
+  "__DOTENV_DEVELOPMENT_LOCAL": "LOCAL",
+  "__DOTENV_ENV": "ENV",
+  "__DOTENV_EXPAND": "PRESET",
+  "__DOTENV_LOCAL": "LOCAL",
+  "__DOTENV_PRESET": "PRESET",
+  "__DOTENV_PRODUCTION": "PRODUCTION",
+  "__DOTENV_PRODUCTION_LOCAL": "PRODUCTION_LOCAL",
+  "__DOTENV_TEST": "ENV",
+  "__DOTENV_TEST_LOCAL": "LOCAL",
+}
+`;
+
+exports[`with expand explicitly on test 1`] = `
+Object {
+  "__DOTENV_DEVELOPMENT": "ENV",
+  "__DOTENV_DEVELOPMENT_LOCAL": "ENV",
+  "__DOTENV_ENV": "ENV",
+  "__DOTENV_EXPAND": "PRESET",
+  "__DOTENV_LOCAL": "TEST",
+  "__DOTENV_PRESET": "PRESET",
+  "__DOTENV_PRODUCTION": "ENV",
+  "__DOTENV_PRODUCTION_LOCAL": "ENV",
+  "__DOTENV_TEST": "TEST",
+  "__DOTENV_TEST_LOCAL": "TEST_LOCAL",
+}
+`;
+
+exports[`with expand explicitly on undefined 1`] = `
+Object {
+  "__DOTENV_DEVELOPMENT": "ENV",
+  "__DOTENV_DEVELOPMENT_LOCAL": "LOCAL",
+  "__DOTENV_ENV": "ENV",
+  "__DOTENV_EXPAND": "PRESET",
   "__DOTENV_LOCAL": "LOCAL",
   "__DOTENV_PRESET": "PRESET",
   "__DOTENV_PRODUCTION": "ENV",

--- a/plugins/plugin-dotenv/test/env/.env
+++ b/plugins/plugin-dotenv/test/env/.env
@@ -17,3 +17,5 @@ __DOTENV_PRODUCTION=ENV
 # new environment variable
 __DOTENV_ENV=ENV
 
+# expanded variable
+__DOTENV_EXPAND=${__DOTENV_PRESET}

--- a/plugins/plugin-dotenv/test/plugin.test.js
+++ b/plugins/plugin-dotenv/test/plugin.test.js
@@ -33,3 +33,19 @@ describe('with dir NODE_ENV=', () => {
     });
   });
 });
+
+describe('with expand explicitly off', () => {
+  NODE_ENV_LIST.forEach((nodeEnv) => {
+    test(`${nodeEnv}`, () => {
+      expect(execPlugin(nodeEnv, {expand: false})).toMatchSnapshot();
+    });
+  });
+});
+
+describe('with expand explicitly on', () => {
+  NODE_ENV_LIST.forEach((nodeEnv) => {
+    test(`${nodeEnv}`, () => {
+      expect(execPlugin(nodeEnv, {expand: true})).toMatchSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
## Changes

Changed the `dotenv-expand` functionality to be configurable via an `expand` option (defaults to true). Sometimes you don't want env expansion if you want to run something like envsubst on your built files.

## Testing

Added a new expandable variable and snapshot tests for when the option is on/off.

## Docs

Yes, added `expand` option to config table.
