### PR TITLE
Attempt 2 to set build --watch package paths to be relative

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -509,7 +509,7 @@ export async function startServer(
       }
       const resourcePath = reqPath.replace(/\.map$/, '').replace(/\.proxy\.js$/, '');
       const webModuleUrl = resourcePath.substr(PACKAGE_PATH_PREFIX.length);
-      let loadedModule = await pkgSource.load(webModuleUrl, {isSSR});
+      let loadedModule = await pkgSource.load(webModuleUrl, {isSSR, isWatch});
       if (!loadedModule) {
         throw new NotFoundError(reqPath);
       }

--- a/snowpack/src/sources/local.ts
+++ b/snowpack/src/sources/local.ts
@@ -273,7 +273,7 @@ export class PackageSourceLocal implements PackageSource {
     }
   }
 
-  async load(id: string, {isSSR}: {isSSR?: boolean} = {}) {
+  async load(id: string, {isSSR, isWatch}: {isSSR?: boolean; isWatch?: boolean} = {}) {
     const {config, allPackageImports} = this;
     const packageImport = allPackageImports[id];
     if (!packageImport) {
@@ -329,7 +329,7 @@ export class PackageSourceLocal implements PackageSource {
       // Otherwise, resolve this specifier as an external package.
       return await this.resolvePackageImport(spec, {source: entrypoint});
     };
-    packageCode = await transformFileImports({type, contents: packageCode}, async (spec) => {
+    packageCode = await transformFileImports({type, contents: packageCode, isWatch, metaUrlPath: config.buildOptions.metaUrlPath}, async (spec) => {
       let resolvedImportUrl = await resolveImport(spec);
       const importExtName = path.posix.extname(resolvedImportUrl);
       const isProxyImport = importExtName && importExtName !== '.js' && importExtName !== '.mjs';

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -391,7 +391,7 @@ export interface PackageSource {
    */
   load(
     spec: string,
-    options: {isSSR: boolean},
+    options: {isSSR: boolean; isWatch: boolean},
   ): Promise<undefined | {contents: Buffer | string; imports: InstallTarget[]}>;
   /** Resolve a package import to URL (ex: "react" -> "/pkg/react") */
   resolvePackageImport(


### PR DESCRIPTION
## Changes

This is the original code from https://github.com/snowpackjs/snowpack/pull/3597. It was merged but then rolled back in https://github.com/snowpackjs/snowpack/pull/3652 without explanation about what went wrong, specific errors, or things that could be fixed. So I have created this to try to move this forward once again and further resolve any problems.

Currently `build --watch` is unusable which makes snowpack a non-starter for server side language sites built with php, ruby, cms systems, etc. This PR removes that incorrect absolute paths and replaces them with ones relative to the pkg directory.

Identified by: #3692, #3629, #3487, #2931, #3065, and #3066


