### PR TITLE
Fix typo in how-snowpack-works.md

### DIFF
--- a/docs/concepts/how-snowpack-works.md
+++ b/docs/concepts/how-snowpack-works.md
@@ -6,7 +6,7 @@ description: Snowpack serves your application unbundled during development. Each
 
 ### Summary
 
-**Snowpack is a modern, lightweight build tool for faster web development.** Traditional JavaScript build tools like webpack and Parcel need to rebuild & rebundle entire chunks of your application every time you save a single file. This rebundling step introduces lag between hitting save on your changes and seeing them reflected in the browser.
+**Snowpack is a modern, lightweight build tool for faster web development.** Traditional JavaScript build tools like Webpack and Parcel need to rebuild & rebundle entire chunks of your application every time you save a single file. This rebundling step introduces lag between hitting save on your changes and seeing them reflected in the browser.
 
 Snowpack serves your application **unbundled during development.** Each file needs to be built only once and then is cached forever. When a file changes, Snowpack rebuilds that single file. There's no time wasted re-bundling every change, just instant updates in the browser (made even faster via [Hot-Module Replacement (HMR)](/concepts/hot-module-replacement)). You can read more about this approach in our [Snowpack 2.0 Release Post.](/posts/2020-05-26-snowpack-2-0-release/)
 


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->

The word "Webpack" should be capitalized on line 9

<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- How was this change tested? -->

Not tested, as it's just a small one letter typo in the docs.

<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->

Yes, the public documentation was updated to reflect the changes after fixing the typo. 

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
