### PR TITLE
fix(app-scripts-react): React 17 auto import JSX not work

### DIFF
--- a/create-snowpack-app/app-scripts-react/jest/babelTransform.js
+++ b/create-snowpack-app/app-scripts-react/jest/babelTransform.js
@@ -11,6 +11,8 @@ const babelJest = require('babel-jest');
 const importMetaBabelPlugin = require('./importMetaBabelPlugin');
 
 module.exports = babelJest.createTransformer({
-  presets: ['babel-preset-react-app', '@babel/preset-react', '@babel/preset-typescript'],
+  presets: ['babel-preset-react-app', ['@babel/preset-react', {
+    runtime: "automatic"
+  }], '@babel/preset-typescript'],
   plugins: [[importMetaBabelPlugin]],
 });


### PR DESCRIPTION
## Changes

Add `runtime: 'automatic'` to babel plugin options
Ref: https://stackoverflow.com/questions/67736828/react-17-jsx-import-with-jest-snapshot-tests

## Testing

<!-- How was this change tested? -->
1. Create new app with react 17
2. Create new Component
2. don't add `import React from 'react'`
3. Write test for Component on 2.
3. Run jest test
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
bug fix only.
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
