### PR TITLE
fix subnav overflow

### DIFF
--- a/www/src/components/Subnav.astro
+++ b/www/src/components/Subnav.astro
@@ -34,6 +34,7 @@ const { title, inputPath, headers } = Astro.props;
     color: inherit;
     background: none;
     -webkit-overflow-scrolling: touch;
+    overflow-y: auto;
   }
 
 


### PR DESCRIPTION
## Changes

Added `overflow-y:auto;` to subnav menu, since it was missing, causing it not to be scrollable.

## Testing

Manually tested on latest Chrome and Firefox.

## Docs

This is about the Docs itself.
