### PR TITLE
Fix css modules

### DIFF
--- a/snowpack/src/build/build-pipeline.ts
+++ b/snowpack/src/build/build-pipeline.ts
@@ -90,30 +90,6 @@ async function runPipelineLoadStep(
     }
   }
 
-  // handle CSS Modules, after plugins run
-  if (needsCSSModules(srcPath)) {
-    let contents: string = result['.css']
-      ? (result['.css'].code as string)
-      : ((await readFile(srcPath)) as string);
-    if (contents) {
-      // for CSS Modules URLs, we only need the destination URL (POSIX-style)
-      let url = srcPath;
-      for (const dir in config.mount) {
-        if (srcPath.startsWith(dir)) {
-          url = srcPath
-            .replace(dir, config.mount[dir].url)
-            .replace(/\\/g, '/')
-            .replace(/\/+/g, '/')
-            .replace(/\.(scss|sass)$/i, '.css');
-          break;
-        }
-      }
-      const {css, json} = await cssModules({contents, url});
-      result['.css'] = {...(result['.css'] || {}), code: css};
-      result['.json'] = {code: JSON.stringify(json)};
-    }
-  }
-
   // if no result was generated, return file as-is
   if (!Object.keys(result).length) {
     return {
@@ -218,6 +194,30 @@ async function runPipelineTransformStep(
       // Attach metadata detailing where the error occurred.
       err.__snowpackBuildDetails = {name: step.name, step: 'transform'};
       throw err;
+    }
+  }
+
+  // handle CSS Modules, after plugins run
+  if (needsCSSModules(srcPath)) {
+    let contents: string = output['.css']
+      ? (output['.css'].code as string)
+      : ((await readFile(srcPath)) as string);
+    if (contents) {
+      // for CSS Modules URLs, we only need the destination URL (POSIX-style)
+      let url = srcPath;
+      for (const dir in config.mount) {
+        if (srcPath.startsWith(dir)) {
+          url = srcPath
+            .replace(dir, config.mount[dir].url)
+            .replace(/\\/g, '/')
+            .replace(/\/+/g, '/')
+            .replace(/\.(scss|sass)$/i, '.css');
+          break;
+        }
+      }
+      const {css, json} = await cssModules({contents, url});
+      output['.css'] = {...(output['.css'] || {}), code: css};
+      output['.json'] = {code: JSON.stringify(json)};
     }
   }
 

--- a/snowpack/src/build/optimize.ts
+++ b/snowpack/src/build/optimize.ts
@@ -401,6 +401,7 @@ async function runEsbuildOnBuildDirectory(
   ) {
     publicPath = config.buildOptions.baseUrl;
   }
+  const supportedExtensions = ['*.js', '*.mjs', '*.css', '*.json', '*'];
   const {outputFiles, warnings, metafile} = await esbuild.build({
     entryPoints: bundleEntrypoints,
     outdir: FAKE_BUILD_DIRECTORY,
@@ -417,7 +418,7 @@ async function runEsbuildOnBuildDirectory(
     minify: config.optimize!.minify,
     target: config.optimize!.target,
     external: Array.from(new Set(allFiles.map((f) => '*' + path.extname(f))))
-      .filter((ext) => ext !== '*.js' && ext !== '*.mjs' && ext !== '*.css' && ext !== '*')
+      .filter((ext) => !supportedExtensions.includes(ext))
       .concat(config.packageOptions?.external ?? []),
     charset: 'utf8',
   });


### PR DESCRIPTION
## Changes

Fix for https://github.com/snowpackjs/snowpack/issues/2998

In this PR I did a couple of changes to fix development and production environments when CSS modules are used.

1. First change was related to fix the generated JSON based on CSS module.  
    I moved JSON generation after transform plugins are applied, because the `.sass`, `.less` or `.css` (with postcss) should be transformed to CSS, and after that resulted CSS is ready to be transformed to JSON. 
   
2. Second change is related to `fileBuilder`. When `.js`, `.jsx`, `.ts` or `.tsx` file is transformed through `fileBuilder` for the case when it contains a `.module.css` file, the `.module.css` import should be changed to 2 new imports, one for CSS and second for JSON.
    Ex.  We have  ```import styles from './test.module.css'```
    1. ```import './test.module.css' ```
    2. ```import styles from './test.module.css.json'```
   Why we need this?
   Both files should be part of final bundle.  `test.module.css'` - will be part of final `index.css`, and `test.module.css.json` will be part of final `index.js`

3. Third change is to allow esbuild to add JSON files into the final bundle. 
    As I said the generated JSON based on `*.module.css` should be part of the bundle.

## Example 

` test.module.css`  - I am using postcss with a couple of additional plugins 
```
.block {
  display: block;
  box-sizing: border-box;
}

@each $side in top, right, bottom, left {
  .margin-$(side) {
    margin: 1rem;
  }
}
```

### Before change

`test.module.css.json` generated JSON  which is not included in the final bundle
```
{"block":"_block_re84t_1","margin-$(side)":"_margin-$(side)_re84t_7"}
```

content in JS bundle 
```
// build/dist/lib/controls/test/test.module.css
var _default = {};
```

*NOTE*: content in CSS bundle - everything is OK 

### After change

`test.module.css.json` is included in the final bundle and it looks
```
// build/dist/lib/controls/test/test.module.css.json
var block = "_block_1jm6y_1";
var margin_top = "_margin-top_1jm6y_6";
var margin_right = "_margin-right_1jm6y_10";
var margin_bottom = "_margin-bottom_1jm6y_14";
var margin_left = "_margin-left_1jm6y_18";
var block_module_css_default = {block, "margin-top": margin_top, "margin-right": margin_right, "margin-bottom": margin_bottom, "margin-left": margin_left};
```

content from CSS bundle 
```
/* build/dist/lib/controls/test/test.module.css */
._block_1jm6y_1 {
  display: block;
  box-sizing: border-box;
}
._margin-top_1jm6y_6 {
  margin: 1rem;
}
._margin-right_1jm6y_10 {
  margin: 1rem;
}
._margin-bottom_1jm6y_14 {
  margin: 1rem;
}
._margin-left_1jm6y_18 {
  margin: 1rem;
}
```


## Testing
- Tested locally 

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
